### PR TITLE
Minor fixes to cloud operator readme (#12)

### DIFF
--- a/charts/kubescape-cloud-operator/README.md
+++ b/charts/kubescape-cloud-operator/README.md
@@ -26,12 +26,15 @@ Otherwise, get the account ID from the [kubescape SaaS](https://hub.armosec.io/d
 
 Run the install command:
 ```
-helm upgrade --install kubescape kubescape/kubescape-cloud-operator -n kubescape --create-namespace --set account=<my_account_ID> --set cluster-name=`kubectl config current-context` 
+helm upgrade --install kubescape kubescape/kubescape-cloud-operator -n kubescape --create-namespace --set account=<my_account_ID> --set clusterName=`kubectl config current-context` 
 ```
 
 > Add `--set clientID=<generated client id> --set secretKey=<generated secret key>` if you have [generated an auth key](https://hub.armosec.io/docs/authentication)
 
 > Add `--set kubescape.serviceMonitor.enabled=true` for installing the Prometheus service monitor, [read more about Prometheus integration](https://hub.armosec.io/docs/prometheus-exporter)
+
+### Removing old version of Kubescape helm chart
+To avoid collisions, if are running an older versions (>=`1.7.18`), you should run the following command: `helm uninstall armo -n armo-system`
 
 ### Adjusting Resource Usage for Your Cluster
 

--- a/charts/kubescape-prometheus-integrator/README.md
+++ b/charts/kubescape-prometheus-integrator/README.md
@@ -1,10 +1,10 @@
-# Kubescape Operator
+# Kubescape-Prometheus Integration
 
 ![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.0](https://img.shields.io/badge/AppVersion-v0.0.0-informational?style=flat-square)
 
 ## [Docs](https://hub.armosec.io/docs/prometheus-exporter)
 
-## Installing Kubescape Operator in a Kubernetes cluster using Helm:
+## Installing Kubescape-Prometheus integration Helm chart:
 
 1. Install the `kube-prometheus-stack` Helm Chart
 ```


### PR DESCRIPTION
* feat: reduce requests for ephemeral storage

* Update chart version

* Change cloudapi-configmap.yanl extension for fix the typo

Fix the following lint error

```
[ERROR] templates/cloudapi-configmap.yanl: file extension '.yanl' not
valid. Valid extensions are .yaml, .yml, .tpl, or .txt
```

* Update kubescape image tag

* Added prometheus chart (#11)

* Adding kubescape-prometheus

* removed unused volume

* fixed readme table

* update chart version

* update docs link

* update chart release

* update readme

* [cloud-operator] fix upgrade command in readme

* [cloud-operator] add instructions to remove depracated version

Co-authored-by: Vlad Klokun <vklokun@protonmail.ch>
Co-authored-by: David Wertenteil <dwertent@armosec.io>
Co-authored-by: mgi166 <hiromu.mogi@gmail.com>

## Describe your changes

## Screenshots - If Any (Optional)

## Issue ticket number and link

## Checklist before requesting a review
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
