### PR TITLE
chore: bump Kubevuln version to 0.0.45

### DIFF
--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -251,7 +251,7 @@ kubevuln:
   image:
     # -- source code: https://github.com/kubescape/kubevuln
     repository: quay.io/kubescape/kubevuln
-    tag: v0.0.44
+    tag: v0.0.45
     pullPolicy: Always
 
   replicaCount: 1


### PR DESCRIPTION
## Describe your changes

This PR bumps the Kubevuln version to 0.0.45. This version contains a fix for the ephemeral storage usage.

## Screenshots - If Any (Optional)

## Issue ticket number and link

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
