### PR TITLE
feat: Use read-only filesystem in all components

### DIFF
--- a/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
@@ -46,6 +46,7 @@ spec:
       - name: host-sensor
         image: quay.io/kubescape/host-scanner:v1.0.54
         securityContext:
+          allowPrivilegeEscalation: true
           privileged: true
           readOnlyRootFilesystem: true
           procMount: Unmasked

--- a/charts/kubescape-cloud-operator/templates/kollector/statefulset.yaml
+++ b/charts/kubescape-cloud-operator/templates/kollector/statefulset.yaml
@@ -47,6 +47,7 @@ spec:
           imagePullPolicy: {{ .Values.kollector.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 100
           ports:
@@ -91,6 +92,8 @@ spec:
           - -v=4
           - 2>&1
           volumeMounts:
+            - name: tmp-dir
+              mountPath: /tmp
             - name: {{ .Values.global.cloudConfig }}
               mountPath: /etc/config
               readOnly: true
@@ -101,6 +104,8 @@ spec:
 {{ toYaml .Values.kollector.volumeMounts | indent 12 }}
 {{- end }}
       volumes:
+        - name: tmp-dir
+          emptyDir: {}
         - name: {{ .Values.global.cloudConfig }}
           configMap:
             name: {{ .Values.global.cloudConfig }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-scheduler/cronjob.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-scheduler/cronjob.yaml
@@ -31,6 +31,11 @@ spec:
             imagePullPolicy: {{ .Values.kubescapeScheduler.image.pullPolicy }}
             resources:
 {{ toYaml .Values.kubescapeScheduler.resources | indent 14 }}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 100
             args: 
               - -method=post
               - -scheme=http

--- a/charts/kubescape-cloud-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape/deployment.yaml
@@ -50,6 +50,7 @@ spec:
         imagePullPolicy: "{{ .Values.kubescape.image.pullPolicy }}"
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 100
         ports:
@@ -138,6 +139,10 @@ spec:
         - name: host-scanner-definition
           mountPath: /home/ks/.kubescape/host-scanner.yaml
           subPath: host-scanner-yaml
+        - name: results
+          mountPath: /home/ks/results
+        - name: failed
+          mountPath: /home/ks/failed
 {{- if .Values.volumeMounts }}
 {{ toYaml .Values.volumeMounts | indent 8 }}
 {{- end }}
@@ -153,6 +158,10 @@ spec:
       - name: host-scanner-definition
         configMap:
           name: host-scanner-definition
+      - name: results
+        emptyDir: {}
+      - name: failed
+        emptyDir: {}
 {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | indent 6 }}
 {{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubevuln-scheduler/cronjob.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubevuln-scheduler/cronjob.yaml
@@ -31,6 +31,11 @@ spec:
             imagePullPolicy: {{ .Values.kubevulnScheduler.image.pullPolicy }}
             resources:
 {{ toYaml .Values.kubevulnScheduler.resources | indent 14 }}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 100
             args: 
               - -method=post
               - -scheme=http

--- a/charts/kubescape-cloud-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubevuln/deployment.yaml
@@ -49,6 +49,7 @@ spec:
           imagePullPolicy: {{ .Values.kubevuln.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 100
           ports:
@@ -92,6 +93,10 @@ spec:
             - -v=4
             - 2>&1
           volumeMounts:
+            - name: tmp-dir
+              mountPath: /tmp
+            - name: grype-db-cache
+              mountPath: /home/ks/anchore-resources/db
             - name: {{ .Values.global.cloudConfig }}
               mountPath: /etc/config
               readOnly: true
@@ -102,6 +107,10 @@ spec:
 {{ toYaml .Values.kubevuln.volumeMounts | indent 12 }}
 {{- end }}
       volumes:
+        - name: tmp-dir
+          emptyDir: {}
+        - name: grype-db-cache
+          emptyDir: {}
         - name: {{ .Values.global.cloudConfig }}
           configMap:
             name: {{ .Values.global.cloudConfig }}

--- a/charts/kubescape-cloud-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/operator/deployment.yaml
@@ -47,6 +47,7 @@ spec:
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 100
           ports:
@@ -94,6 +95,8 @@ spec:
             - -v=4
             - 2>&1
           volumeMounts:
+            - name: tmp-dir
+              mountPath: /tmp
             - name: {{ .Values.global.cloudConfig }}
               mountPath: /etc/config
               readOnly: true
@@ -104,6 +107,8 @@ spec:
 {{ toYaml .Values.operator.volumeMounts | indent 12 }}
 {{- end }}
       volumes:
+        - name: tmp-dir
+          emptyDir: {}
         - name: {{ .Values.global.cloudConfig }}
           configMap:
             name: {{ .Values.global.cloudConfig }}


### PR DESCRIPTION
## Describe your changes

Using read-only containers and only allow certain directories to be writable is a common security hardening practice in the container ecosystem.

This PR is blocked by the linked issues/PRs here:
- [x] https://github.com/kubescape/kubevuln/pull/23
- [x] https://github.com/kubescape/kubescape/pull/935
 fix bug where failed reports are written directly to `$HOME`
 ![Screenshot of wrong folder name](https://user-images.githubusercontent.com/7290987/203357526-73452908-d8a8-4b02-bcec-36a3d8d03443.png)
- [x] https://github.com/kubescape/kubescape/pull/976

Open issue(s):
- kubescape caveats:
  - decide whether kubescape should ship `/home/ks/.kubescape/*.json`. These files are also downloaded during runtime. In the current setup these files are overwritten at runtime
    ![Screenshot "dive quay.io/kubescape/kubescape:v2.0.175"](https://user-images.githubusercontent.com/7290987/203356722-72b16ca0-d638-426e-bd20-3c4aa8d1f35c.png)



## Screenshots - If Any (Optional)

## Issue ticket number and link

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
