### PR TITLE
Allow to include and exclude namespaces.

### DIFF
--- a/charts/kubescape-prometheus-integrator/README.md
+++ b/charts/kubescape-prometheus-integrator/README.md
@@ -101,6 +101,8 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | kubescape.serviceMonitor.enabled | bool | `true` | enable/disable service monitor for prometheus (operator) integration |
 | kubescape.volumes | object | `[]` | Additional volumes for Kubescape |
 | kubescape.volumeMounts | object | `[]` | Additional volumeMounts for Kubescape |
+| kubescape.includeNamespaces | object | `[]` | List of namespaces to include, rest of the namespaces will be ignored. |
+| kubescape.excludeNamespaces | object | `[]` | List of namespaces to exclude |
 | kubescapeHostScanner.volumes | object | `[]` | Additional volumes for the host scanner |
 | kubescapeHostScanner.volumeMounts | object | `[]` | Additional volumeMounts for the host scanner |
 | awsIamRoleArn | string | `nil` | AWS IAM arn role |

--- a/charts/kubescape-prometheus-integrator/templates/kubescape/kubescape-deployment.yaml
+++ b/charts/kubescape-prometheus-integrator/templates/kubescape/kubescape-deployment.yaml
@@ -76,6 +76,14 @@ spec:
           value: "{{ .Values.kubescape.submit }}"
         - name: KS_SKIP_UPDATE_CHECK
           value: "{{ .Values.kubescape.skipUpdateCheck }}"
+        {{- with .Values.kubescape.excludeNamespaces }}
+        - name: KS_EXCLUDE_NAMESPACES
+          value: {{ join "," . }}
+        {{- end }}
+        {{- with .Values.kubescape.includeNamespaces }}
+        - name: KS_INCLUDE_NAMESPACES
+          value: {{ join "," . }}
+        {{- end }}
         - name: KS_SAAS_ENV
         {{ if eq .Values.environment "dev" }}
           value: "dev"

--- a/charts/kubescape-prometheus-integrator/values.yaml
+++ b/charts/kubescape-prometheus-integrator/values.yaml
@@ -69,6 +69,12 @@ kubescape:
   # -- submit results to the Kubescape cloud: https://cloud.armosec.io/
   submit: false
 
+  # -- list of namespaces to include
+  includeNamespaces: []
+
+  # -- List of namespaces to exclude
+  excludeNamespaces: []
+
   replicaCount: 1
 
   service:


### PR DESCRIPTION
## Overview
Allow to include and exclude namespaces.

## How to Test
```sh
helm template -n kubescape  kubescape-prometheus-integrator ./charts/kubescape-prometheus-integrator --set "includeNamespaces[0]=ns1" --set "includeNamespaces[1]=ns2" --set "excludeNamespaces[0]=ns3"  --set "excludeNamespaces[1]=ns4" 
```