### PR TITLE
Add tolerations to kubescape deployment template

### DIFF
--- a/charts/kubescape-cloud-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape/deployment.yaml
@@ -139,4 +139,8 @@ spec:
       affinity:
         {{- toYaml . | nindent 8}}
       {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
## Overview
Add tolerations to kubescape deployment


## Additional Information

Current helm template for kubescape deployment does not provide a way to add tolerations

## How to Test

Install chart locally and test if tolerations field have been applied to kubescape deployment

## Related issues/PRs:

Resolved https://github.com/kubescape/helm-charts/issues/58

## Checklist before requesting a review

- [ x] My code follows the style guidelines of this project
- [ x] I have commented on my code, particularly in hard-to-understand areas
- [ x] I have performed a self-review of my code
- [ x] If it is a core feature, I have added thorough tests.
- [ x] New and existing unit tests pass locally with my changes
 