### PR TITLE
namespace updated to kubescape(default) for kubescape-host-scanner ds

### DIFF
--- a/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
@@ -1,18 +1,9 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    app: kubescape-host-scanner
-    k8s-app: kubescape-host-scanner
-    kubernetes.io/metadata.name: kubescape-host-scanner
-    tier: kubescape-host-scanner-control-plane
-  name: kubescape-host-scanner
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: host-scanner
-  namespace: kubescape-host-scanner
+  namespace: {{ .Values.ksNamespace }}
   labels:
     app: host-scanner
     k8s-app: kubescape-host-scanner


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
Removed the manifest to create namespace from file ```charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml``` and updated the manifest of ```kubescape-host-scanner``` DaemonSet for namespace.

## How to Test

Deploy the ```kubescape-cloud-operator```.
 
## Related issues/PRs:

* Resolved #61 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes