### PR TITLE
Configurable servicemonitor properties

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="85a5be72-0cb7-4ba4-aaa0-8454f3a59886" name="変更" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="master" />
+      </map>
+    </option>
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="2LUOaAl0HAgv0JxK9Djntd3nGGz" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "last_opened_file_path": "/Users/masateru.homma/github/HomMarkHunt/helm-charts",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "ruby.rails.projectView.checked": "true"
+  }
+}]]></component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="アプリケーションレベル" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="デフォルトタスク">
+      <changelist id="85a5be72-0cb7-4ba4-aaa0-8454f3a59886" name="変更" comment="" />
+      <created>1675922255742</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1675922255742</updated>
+      <workItem from="1675922257557" duration="4578000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -2,3 +2,58 @@
 
 * [Kubescape cloud operator](charts/kubescape-cloud-operator/README.md)
 * [Kubescape & prometheus integration](charts/kubescape-prometheus-integrator/README.md)
+
+# Helm-charts - CICD Workflow docs
+
+
+## The CICD Pipeline types and steps:
+
+### Automatically Triggered by in-cluster component
+
+The helm chart CICD runs on GitHub Actions, and in most cases will be automatically triggered by one of the in-cluster components:
+* Operator
+* Kubevuln
+* Kollector
+* Gateway
+
+You can find more about the automatic process of in-cluster components [here](https://github.com/kubescape/workflows/blob/main/README.md).
+
+When the CICD will be triggered by one of them, it will run always on the ```dev``` branch and will do the following steps in this order (High-level explanation):
+
+1. Check for valid inputs combination to prevent cases of providing incorrect inputs (most useful for manual triggers, see instructions below).
+2. Update the ```values.yaml``` file according to the arguments that passed.
+3. Create a new commit for the new changes.
+4. Create a new PR from the ```dev``` branch into the ```master``` branch.
+5. Run E2E tests using ```helm_branch=dev``` parameter against the ARMO production backend, the tests will run as parallel jobs.
+6. Create a JUnit report for every test.
+7. Only if all the tests successfully passed, the PR will be automatically merged into the ```master``` branch.
+8. The last step will create a new GitHub release and Helm release for the new chart.
+
+
+### Manually trigger the full CICD process
+If you want to manually trigger the CICD:
+1. Click on the “Actions” tab and click on the ```00-CICD-helm-chart``` workflow on the left side.
+2. Click “Run workflows” on the top of the previous runs list.
+3. A new pop-up will appear with some options:
+    * ```Branch``` - the branch you want to run the workflow from (in most cases will be the “dev” branch)
+    * ```CHANGE_TAG ```- if filled (```true```) the workflows will change the ```values.yaml``` file according to the inputs you provided for ```IMAGE_TAG``` and ```COMPONENT_NAME```
+    * ```COMPONENT_NAME``` - will be the in-cluster component we want to change the tag for.
+    * ```IMAGE_TAG``` - the new docker image tag of the ```COMPONENT_NAME```.
+    * ```HELM_E2E_TEST``` - if filled (```true```), the CICD will run the E2E Tests using ```helm_branch=dev``` parameter
+4. Click on the ```Run workflow``` green button.
+
+
+
+### Manually trigger only the release process
+
+This process will run only the release step from the CICD and will create a new GitHub release and will be published the helm charts
+
+1. Click on the “Actions” tab and click on the ```03-Helm chart release ``` workflow on the left side.
+2. Click “Run workflows” on the top of the previous runs list.
+3. Select the branch you want to create a release from by specifying it using the  ```Branch```. in most cases will be the “master” branch
+4. Click on the ```Run workflow``` green button.
+
+**Note that running only the release process will not run any E2E tests**
+
+### A diagram of the full CICD pipeline:
+![Workflow](https://raw.githubusercontent.com/kubescape/workflows/main/assets/incluster_component_flow.jpeg)

--- a/charts/kubescape-cloud-operator/Chart.yaml
+++ b/charts/kubescape-cloud-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.9.5
+version: 1.9.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.9.5
+appVersion: 1.9.6
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
@@ -24,6 +24,9 @@ spec:
     metadata:
       labels:
         name: host-scanner
+        {{- if .Values.otelCollector.enabled }}
+        otel: enabled
+        {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -45,6 +48,13 @@ spec:
           privileged: true
           readOnlyRootFilesystem: true
           procMount: Unmasked
+        env:
+        {{- if .Values.otelCollector.enabled }}
+        - name: ACCOUNT_ID
+          value: "{{ .Values.account }}"
+        - name: OTEL_COLLECTOR_SVC
+          value: "otel-collector:4317"
+        {{- end }}
         ports:
           - name: scanner # Do not change port name
             hostPort: 7888

--- a/charts/kubescape-cloud-operator/assets/otel-collector-config.yaml
+++ b/charts/kubescape-cloud-operator/assets/otel-collector-config.yaml
@@ -1,0 +1,42 @@
+# receivers configure how data gets into the Collector.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+# processors specify what happens with the received data.
+processors:
+  batch:
+    send_batch_size: 10000
+    timeout: 10s
+
+# exporters configure how to send processed data to one or more backends.
+exporters:
+  otlp:
+    endpoint: "{{ .Values.otelCollector.endpoint.host }}:{{ .Values.otelCollector.endpoint.port }}"
+    tls:
+      insecure: {{ .Values.otelCollector.endpoint.insecure }}
+    {{- if .Values.otelCollector.endpoint.headers }}
+    headers:
+    {{- range $k, $v := .Values.otelCollector.endpoint.headers }}
+      {{ $k }}: {{ $v }}
+    {{- end }}
+    {{- end }}
+
+# service pulls the configured receivers, processors, and exporters together into
+# processing pipelines. Unused receivers/processors/exporters are ignored.
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp]

--- a/charts/kubescape-cloud-operator/templates/configs/otel-collector-configmap.yaml
+++ b/charts/kubescape-cloud-operator/templates/configs/otel-collector-configmap.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap 
+apiVersion: v1 
+metadata:
+  name: otel-collector-config
+  namespace: {{ .Values.ksNamespace }}
+  labels:
+    app: {{ .Values.global.cloudConfig }}
+    tier: {{ .Values.global.namespaceTier }}
+data:
+  otel-collector-config.yaml: |-
+{{ tpl (.Files.Get "assets/otel-collector-config.yaml") . | indent 4}}

--- a/charts/kubescape-cloud-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         tier: {{ .Values.global.namespaceTier}}
         app: {{ .Values.kubescape.name }}
+      {{- if .Values.otelCollector.enabled }}
+        otel: enabled
+      {{- end }}
       {{- if .Values.addRevisionLabel }}
         helm.sh/revision: "{{ .Release.Revision }}"
       {{- end }}
@@ -98,6 +101,12 @@ spec:
         - name: KS_GKE_PROJECT
           value: "{{ .Values.cloudProviderMetadata.gkeProject }}"
         {{- end -}}
+        {{- end }}
+        {{- if .Values.otelCollector.enabled }}
+        - name: ACCOUNT_ID
+          value: "{{ .Values.account }}"
+        - name: OTEL_COLLECTOR_SVC
+          value: "otel-collector:4317"
         {{- end }}
         command:
         - ksserver

--- a/charts/kubescape-cloud-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubevuln/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         tier: {{ .Values.global.namespaceTier}}
         app: {{ .Values.kubevuln.name }}
+      {{- if .Values.otelCollector.enabled }}
+        otel: enabled
+      {{- end }}
       {{- if .Values.addRevisionLabel }}
         helm.sh/revision: "{{ .Release.Revision }}"
       {{- end }}
@@ -73,6 +76,12 @@ spec:
             {{- range .Values.kubevuln.env }}
             - name: {{ .name  }}
               value: "{{ .value }}"
+            {{- end }}
+            {{- if .Values.otelCollector.enabled }}
+            - name: ACCOUNT_ID
+              value: "{{ .Values.account }}"
+            - name: OTEL_COLLECTOR_SVC
+              value: "otel-collector:4317"
             {{- end }}
           args:
             - -alsologtostderr

--- a/charts/kubescape-cloud-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/operator/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         tier: {{ .Values.global.namespaceTier}}
         app: {{ .Values.operator.name }}
+      {{- if .Values.otelCollector.enabled }}
+        otel: enabled
+      {{- end }}
       {{- if .Values.addRevisionLabel }}
         helm.sh/revision: "{{ .Release.Revision }}"
       {{- end }}
@@ -75,6 +78,12 @@ spec:
             {{- range .Values.operator.env }}
             - name: {{ .name  }}
               value: "{{ .value }}"
+            {{- end }}
+            {{- if .Values.otelCollector.enabled }}
+            - name: ACCOUNT_ID
+              value: "{{ .Values.account }}"
+            - name: OTEL_COLLECTOR_SVC
+              value: "otel-collector:4317"
             {{- end }}
           args:
             - -alsologtostderr

--- a/charts/kubescape-cloud-operator/templates/otel-collector/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/otel-collector/deployment.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.otelCollector.enabled  }}
+{{- $cloud_provider := (include "cloud_provider" .) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: {{ .Values.ksNamespace }}
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app: otel-collector
+    tier: {{ .Values.global.namespaceTier }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  replicas: {{ .Values.otelCollector.replicaCount }}
+  revisionHistoryLimit: 2
+  strategy:
+    rollingUpdate:
+      maxSurge: 0%
+      maxUnavailable: 100%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      tier: {{ .Values.global.namespaceTier}}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: otel-collector
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        tier: {{ .Values.global.namespaceTier}}
+        app: otel-collector
+      {{- if .Values.addRevisionLabel }}
+        helm.sh/revision: "{{ .Release.Revision }}"
+      {{- end }}
+    spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ toYaml .Values.imagePullSecrets }}
+      {{- end }}
+      containers:
+      - name: otel-collector
+        image: "{{ .Values.otelCollector.image.repository }}:{{ .Values.otelCollector.image.tag }}"
+        imagePullPolicy: "{{ .Values.otelCollector.image.pullPolicy }}"
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 100
+        ports:
+          - name: otlp
+            containerPort: 4317
+            protocol: TCP
+        env:
+        - name: GOGC
+          value: "80"
+        command:
+        - "/otelcol"
+        - "--config=/conf/otel-collector-config.yaml"
+        resources:
+{{ toYaml .Values.otelCollector.resources | indent 14 }}            
+        volumeMounts:
+        - name: otel-collector-config-volume
+          mountPath: /conf
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.otelCollector.volumeMounts }}
+{{ toYaml .Values.otelCollector.volumeMounts | indent 8 }}
+{{- end }}
+      serviceAccountName: {{ .Values.global.kubescapeServiceAccountName }}
+      automountServiceAccountToken: true
+      volumes:
+      - name: otel-collector-config-volume
+        configMap:
+          name: otel-collector-config
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 6 }}
+{{- end }}
+{{- if .Values.otelCollector.volumes }}
+{{ toYaml .Values.otelCollector.volumes | indent 6 }}
+{{- end }}
+      {{- with .Values.otelCollector.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8}}
+      {{- end }}
+      {{- with .Values.otelCollector.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8}}
+      {{- end }}
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/otel-collector/networkpolicy.yaml
+++ b/charts/kubescape-cloud-operator/templates/otel-collector/networkpolicy.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.global.networkPolicy.enabled .Values.otelCollector.enabled  }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: otel-collector
+  namespace: {{ .Values.ksNamespace }}
+  labels:
+    app: otel-collector
+    tier: {{ .Values.global.namespaceTier }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      tier: {{ .Values.global.namespaceTier}}
+  policyTypes:
+    - Ingress
+  {{- if .Values.global.networkPolicy.createEgressRules }}
+    - Egress
+  egress:
+      # - otel backend
+    - ports:
+      - port: {{ .Values.otelCollector.endpoint.port }}
+        protocol: TCP
+  {{- end }}
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              otel: enabled
+      ports:
+        - port: otlp
+          protocol: TCP
+{{ end }}

--- a/charts/kubescape-cloud-operator/templates/otel-collector/service.yaml
+++ b/charts/kubescape-cloud-operator/templates/otel-collector/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.otelCollector.enabled  }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: {{ .Values.ksNamespace }}
+  labels:
+    app: otel-collector
+spec:
+  type: ClusterIP
+  ports:
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+  selector:
+    app: otel-collector
+{{ end }}

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -120,7 +120,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v2.0.181
+    tag: v2.1.2
     pullPolicy: Always
 
   resources:
@@ -297,7 +297,7 @@ kollector:
   image:
     # -- source code: https://github.com/kubescape/kollector
     repository: quay.io/kubescape/kollector
-    tag: v0.1.1
+    tag: v0.1.2
     pullPolicy: Always
 
   replicaCount: 1
@@ -413,3 +413,29 @@ registryScanScheduler:
 
   # Additional volumeMounts to be mounted on the scan scheduler
   volumeMounts: []
+
+# opentelemetry collector
+otelCollector:
+
+  # -- enable/disable metrics and traces collection
+  enabled: false
+
+  endpoint:
+    host: ""
+    port: 4317
+    insecure: true
+
+  image:
+    repository: otel/opentelemetry-collector
+    tag: 0.70.0
+    pullPolicy: Always
+
+  replicaCount: 1
+
+  resources:
+    requests:
+       cpu: 200m
+       memory: 400Mi
+    limits:
+       cpu: 1
+       memory: 2Gi

--- a/charts/kubescape-prometheus-integrator/Chart.yaml
+++ b/charts/kubescape-prometheus-integrator/Chart.yaml
@@ -5,9 +5,9 @@ description:
  
 type: application
 
-version: 0.0.6
+version: 0.0.7
 
-appVersion: "v0.0.6"
+appVersion: "v0.0.7"
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-prometheus-integrator/README.md
+++ b/charts/kubescape-prometheus-integrator/README.md
@@ -90,24 +90,26 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 
 ### Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| kubescape.affinity | object | `{}` | Assign custom [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) rules to the deployment |
-| kubescape.downloadArtifacts | bool | `false` | download policies every scan, we recommend it should remain true, you should change to 'false' when running in an air-gapped environment or when scanning with high frequency (when running with Prometheus) |
-| kubescape.enableHostScan | bool | `false` | enable [host scanner feature](https://hub.armosec.io/docs/host-sensor) |
-| kubescape.enabled | bool | `true` | enable/disable kubescape scanning |
-| kubescape.image.repository | string | `"quay.io/kubescape/kubescape"` | [source code](https://github.com/kubescape/kubescape/tree/master/httphandler) (public repo) |
-| kubescape.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) |
-| kubescape.serviceMonitor.enabled | bool | `true` | enable/disable service monitor for prometheus (operator) integration |
-| kubescape.volumes | object | `[]` | Additional volumes for Kubescape |
-| kubescape.volumeMounts | object | `[]` | Additional volumeMounts for Kubescape |
-| kubescapeHostScanner.volumes | object | `[]` | Additional volumes for the host scanner |
-| kubescapeHostScanner.volumeMounts | object | `[]` | Additional volumeMounts for the host scanner |
-| awsIamRoleArn | string | `nil` | AWS IAM arn role |
-| cloudRegion | string | `nil` | cloud region |
-| cloudProviderEngine | string | `nil` | cloud provider engine |
-| gkeProject | string | `nil` | GKE project |
-| gkeServiceAccount | string | `nil` | GKE service account |
-| volumes | object | `[]` | Additional volumes for all containers |
-| volumeMounts | object | `[]` | Additional volumeMounts for all containers |
+| Key                               | Type | Default | Description                                                                                                                                                                                                  |
+|-----------------------------------|------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| kubescape.affinity                | object | `{}` | Assign custom [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) rules to the deployment                                                                                   |
+| kubescape.downloadArtifacts       | bool | `false` | download policies every scan, we recommend it should remain true, you should change to 'false' when running in an air-gapped environment or when scanning with high frequency (when running with Prometheus) |
+| kubescape.enableHostScan          | bool | `false` | enable [host scanner feature](https://hub.armosec.io/docs/host-sensor)                                                                                                                                       |
+| kubescape.enabled                 | bool | `true` | enable/disable kubescape scanning                                                                                                                                                                            |
+| kubescape.image.repository        | string | `"quay.io/kubescape/kubescape"` | [source code](https://github.com/kubescape/kubescape/tree/master/httphandler) (public repo)                                                                                                                  |
+| kubescape.nodeSelector            | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)                                                                                                                    |
+| kubescape.serviceMonitor.enabled  | bool | `true` | enable/disable service monitor for prometheus (operator) integration                                                                                                                                         |
+| kubescape.serviceMonitor.interval | string | `20m` | Scrape interval                                                                                                                                                                                              |
+| kubescape.serviceMonitor.scrapeTimeout         | string | `100s` | Adjust avoid timeoutscrapeTimeout                                                                                                                                                                            |
+| kubescape.volumes                 | object | `[]` | Additional volumes for Kubescape                                                                                                                                                                             |
+| kubescape.volumeMounts            | object | `[]` | Additional volumeMounts for Kubescape                                                                                                                                                                        |
+| kubescapeHostScanner.volumes      | object | `[]` | Additional volumes for the host scanner                                                                                                                                                                      |
+| kubescapeHostScanner.volumeMounts | object | `[]` | Additional volumeMounts for the host scanner                                                                                                                                                                 |
+| awsIamRoleArn                     | string | `nil` | AWS IAM arn role                                                                                                                                                                                             |
+| cloudRegion                       | string | `nil` | cloud region                                                                                                                                                                                                 |
+| cloudProviderEngine               | string | `nil` | cloud provider engine                                                                                                                                                                                        |
+| gkeProject                        | string | `nil` | GKE project                                                                                                                                                                                                  |
+| gkeServiceAccount                 | string | `nil` | GKE service account                                                                                                                                                                                          |
+| volumes                           | object | `[]` | Additional volumes for all containers                                                                                                                                                                        |
+| volumeMounts                      | object | `[]` | Additional volumeMounts for all containers                                                                                                                                                                   |
  

--- a/charts/kubescape-prometheus-integrator/templates/ks-servicemonitor.yaml
+++ b/charts/kubescape-prometheus-integrator/templates/ks-servicemonitor.yaml
@@ -17,6 +17,6 @@ spec:
   endpoints:
     - port: http
       path: /v1/metrics
-      interval: 20m
-      scrapeTimeout: 100s
+      interval: {{ .Values.kubescape.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.kubescape.serviceMonitor.scrapeTimeout }}
 {{ end }}

--- a/charts/kubescape-prometheus-integrator/values.yaml
+++ b/charts/kubescape-prometheus-integrator/values.yaml
@@ -46,7 +46,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v2.0.181
+    tag: v2.1.2
     pullPolicy: IfNotPresent
 
   resources:

--- a/charts/kubescape-prometheus-integrator/values.yaml
+++ b/charts/kubescape-prometheus-integrator/values.yaml
@@ -81,6 +81,12 @@ kubescape:
     # -- enable/disable service monitor for prometheus (operator) integration
     enabled: true
 
+    # -- scrape interval
+    interval: 20m
+
+    # -- adjust avoid timeout
+    scrapeTimeout: 100s
+
     # If needed the service monitor can be deployed to a different namespace than the one kubescape is in
     #namespace: my-namespace
 


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

I feel that using Prometheus integration makes modifying some Service Monitor properties more convenient.
Specifically, I'd like to make changes so that the interval and scrapeTimeout can be set:
1. Change `interval` to allow scans to be performed at any desired timing.
1. Modify the `scrapeTimeout` value to ensure that scans do not fail even if they exceed `100s` by executing scans with the minimum CPU limit."
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 