### PR TITLE
add interval and scrapeTimeout to values.yaml

### DIFF
--- a/charts/kubescape-prometheus-integrator/README.md
+++ b/charts/kubescape-prometheus-integrator/README.md
@@ -99,6 +99,8 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | kubescape.image.repository | string | `"quay.io/kubescape/kubescape"` | [source code](https://github.com/kubescape/kubescape/tree/master/httphandler) (public repo) |
 | kubescape.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) |
 | kubescape.serviceMonitor.enabled | bool | `true` | enable/disable service monitor for prometheus (operator) integration |
+| kubescape.serviceMonitor.interval | string | `20m` | Scrape interval |
+| kubescape.serviceMonitor.scrapeTimeout | string | `100s` | Adjust to avoid timeout |
 | kubescape.volumes | object | `[]` | Additional volumes for Kubescape |
 | kubescape.volumeMounts | object | `[]` | Additional volumeMounts for Kubescape |
 | kubescapeHostScanner.volumes | object | `[]` | Additional volumes for the host scanner |

--- a/charts/kubescape-prometheus-integrator/templates/ks-servicemonitor.yaml
+++ b/charts/kubescape-prometheus-integrator/templates/ks-servicemonitor.yaml
@@ -17,6 +17,6 @@ spec:
   endpoints:
     - port: http
       path: /v1/metrics
-      interval: 20m
-      scrapeTimeout: 100s
+      interval: {{ .Values.kubescape.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.kubescape.serviceMonitor.scrapeTimeout }}
 {{ end }}

--- a/charts/kubescape-prometheus-integrator/values.yaml
+++ b/charts/kubescape-prometheus-integrator/values.yaml
@@ -81,6 +81,12 @@ kubescape:
     # -- enable/disable service monitor for prometheus (operator) integration
     enabled: true
 
+    # -- scrape interval
+    interval: 20m
+
+    # -- adjust to avoid timeout
+    scrapeTimeout: 100s
+
     # If needed the service monitor can be deployed to a different namespace than the one kubescape is in
     #namespace: my-namespace
 


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

I feel that using Prometheus integration makes modifying some Service Monitor properties more convenient.
Specifically, I'd like to make changes so that the interval and scrapeTimeout can be set:
1. Change `interval` to allow scans to be performed at any desired timing.
1. Modify the `scrapeTimeout` value to ensure that scans do not fail even if they exceed `100s` by executing scans with the minimum CPU limit."
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 