### PR TITLE
added way to integrate with non-operator prometheus helm chart

### DIFF
--- a/charts/kubescape-prometheus-integrator/README.md
+++ b/charts/kubescape-prometheus-integrator/README.md
@@ -4,7 +4,9 @@
 
 ## [Docs](https://hub.armosec.io/docs/prometheus-exporter)
 
-## Installing Kubescape-Prometheus integration Helm chart:
+Most of the end users either use [`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) prometheus operator else [`prometheus helm chart`](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus) to install prometheus for monitoring. Based on your choice of prometheus, you can follow either of the below method to enable kubescape monitoring with Prometheus.  
+
+## Kubescape integration with Kube-Prometheus-stack (Prometheus operator):
 
 1. Install the `kube-prometheus-stack` Helm Chart
 ```
@@ -20,6 +22,25 @@ helm install -n prometheus kube-prometheus-stack prometheus-community/kube-prome
 helm repo add kubescape https://kubescape.github.io/helm-charts/
 helm repo update
 helm upgrade --install kubescape-prometheus kubescape/kubescape-prometheus-integrator -n kubescape-prometheus --create-namespace
+``` 
+---
+
+## Kubescape integration with Prometheus community helm chart:
+
+1. Install the `prometheus-community` Helm Chart
+```
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+kubectl create namespace prometheus
+helm install -n prometheus prometheus prometheus-community/prometheus
+```
+
+2. Install the `kubescape-prometheus-integrator` Helm Chart with podAnnotations enabled
+
+```
+helm repo add kubescape https://kubescape.github.io/helm-charts/
+helm repo update
+helm upgrade --install kubescape-prometheus kubescape/kubescape-prometheus-integrator -n kubescape-prometheus --set kubescape.prometheusAnnotation.enabled=True --create-namespace 
 ``` 
 ---
 
@@ -99,8 +120,7 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | kubescape.image.repository | string | `"quay.io/kubescape/kubescape"` | [source code](https://github.com/kubescape/kubescape/tree/master/httphandler) (public repo) |
 | kubescape.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) |
 | kubescape.serviceMonitor.enabled | bool | `true` | enable/disable service monitor for prometheus (operator) integration |
-| kubescape.serviceMonitor.interval | string | `20m` | Scrape interval |
-| kubescape.serviceMonitor.scrapeTimeout | string | `100s` | Adjust to avoid timeout |
+| kubescape.prometheusAnnotation.enabled | bool | `false` | add/remove pod annotation for prometheus (non-operator) integration |
 | kubescape.volumes | object | `[]` | Additional volumes for Kubescape |
 | kubescape.volumeMounts | object | `[]` | Additional volumeMounts for Kubescape |
 | kubescapeHostScanner.volumes | object | `[]` | Additional volumes for the host scanner |

--- a/charts/kubescape-prometheus-integrator/README.md
+++ b/charts/kubescape-prometheus-integrator/README.md
@@ -120,6 +120,8 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | kubescape.image.repository | string | `"quay.io/kubescape/kubescape"` | [source code](https://github.com/kubescape/kubescape/tree/master/httphandler) (public repo) |
 | kubescape.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) |
 | kubescape.serviceMonitor.enabled | bool | `true` | enable/disable service monitor for prometheus (operator) integration |
+| kubescape.serviceMonitor.interval | string | `20m` | Scrape interval |
+| kubescape.serviceMonitor.scrapeTimeout | string | `100s` | Adjust to avoid timeout |
 | kubescape.prometheusAnnotation.enabled | bool | `false` | add/remove pod annotation for prometheus (non-operator) integration |
 | kubescape.volumes | object | `[]` | Additional volumes for Kubescape |
 | kubescape.volumeMounts | object | `[]` | Additional volumeMounts for Kubescape |

--- a/charts/kubescape-prometheus-integrator/templates/kubescape/kubescape-deployment.yaml
+++ b/charts/kubescape-prometheus-integrator/templates/kubescape/kubescape-deployment.yaml
@@ -32,6 +32,12 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         tier: {{ .Values.global.namespaceTier}}
         app: {{ .Values.kubescape.name }}
+      {{- if .Values.kubescape.prometheusAnnotation.enabled }}
+      annotations:
+        prometheus.io/path: /v1/metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/kubescape-prometheus-integrator/values.yaml
+++ b/charts/kubescape-prometheus-integrator/values.yaml
@@ -46,7 +46,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v2.0.181
+    tag: v2.1.3
     pullPolicy: IfNotPresent
 
   resources:
@@ -80,6 +80,12 @@ kubescape:
     
     # -- enable/disable service monitor for prometheus (operator) integration
     enabled: true
+
+    # -- scrape interval
+    interval: 20m
+
+    # -- adjust to avoid timeout
+    scrapeTimeout: 100s
 
     # If needed the service monitor can be deployed to a different namespace than the one kubescape is in
     #namespace: my-namespace

--- a/charts/kubescape-prometheus-integrator/values.yaml
+++ b/charts/kubescape-prometheus-integrator/values.yaml
@@ -46,7 +46,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v2.1.3
+    tag: v2.0.181
     pullPolicy: IfNotPresent
 
   resources:
@@ -81,15 +81,12 @@ kubescape:
     # -- enable/disable service monitor for prometheus (operator) integration
     enabled: true
 
-    # -- scrape interval
-    interval: 20m
-
-    # -- adjust to avoid timeout
-    scrapeTimeout: 100s
-
     # If needed the service monitor can be deployed to a different namespace than the one kubescape is in
     #namespace: my-namespace
-
+  
+  # Enable prometheus pod annotations,to allow your opensource prometheus (not operator) to scrape metrics
+  prometheusAnnotation:
+    enabled: false
   # -- Additional volumes to be mounted on Kubescape
   volumes: []
 


### PR DESCRIPTION
[Creating this new PR as weill delete the old one: https://github.com/kubescape/helm-charts/pull/57 raised for the same]
## Overview
As of now, current documentation only shows how to integrate kubescape with prometheus operator aka kube-prometheus-stack. Sometimes people do not use operator but the actual prometheus community helm chart and customise it as per their need. So allow monitoring of kubescape with such custom/non-operator/community helm chart, we need to make use of  [scraping-pod-metrics-via-annotations](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus#scraping-pod-metrics-via-annotations) method. So have amended the kubescape helm chart to allow setting up prometheus pod annotation. 

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->


## How to Test
To test the same, once can clone the  PR -branch locally and go to path: `charts/kubescape-prometheus-integrator` and run below command to allow prometheus annotations added. Please check the whole instructions from the updated README file of this PR. After this you would be able to see kubescape in target section of prometheus (installed via community helm chart)

```
helm upgrade --install kubescape-prometheus . -n kubescape-prometheus --set kubescape.prometheusAnnotation.enabled=True --create-namespace
```


## Examples/Screenshots
You would be able to see below prometheus annotations added for kubescape pod deployed via helm chart
```
➜ kubectl describe po kubescape-5d9f6487bd-jm29c |grep -i -A 4 Annotations
Annotations:  prometheus.io/path: /v1/metrics
              prometheus.io/port: 8080
              prometheus.io/scrape: true
Status:       Running

```


<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 