### PR TITLE
fix(host-scanner): remove hostNetwork and hostPort parameters

### DIFF
--- a/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
@@ -61,7 +61,6 @@ spec:
         {{- end }}
         ports:
           - name: scanner # Do not change port name
-            hostPort: 7888
             containerPort: 7888
             protocol: TCP
         resources:
@@ -100,6 +99,5 @@ spec:
 {{- if .Values.kubescapeHostScanner.volumes }}
 {{ toYaml .Values.kubescapeHostScanner.volumes | indent 6 }}
 {{- end }}
-      hostNetwork: true
       hostPID: true
       hostIPC: true


### PR DESCRIPTION
## Overview
This fix removes the hostNetwork and hostPort parameters from the host-scanner deployment, since we don't need them anymore.