### PR TITLE
feat: add support for the Kubescape Storage

### DIFF
--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/_helpersKubescapeStorage.tpl
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/_helpersKubescapeStorage.tpl
@@ -98,3 +98,36 @@ Name of the Kubescape Storage APIServer Service
 {{- define "kubescapeStorage.apiServer.service.name" -}}
   {{- .Values.kubescapeStorage.k8sApiserver.name | printf "%s-api" }}
 {{- end }}
+
+{{/*
+Kubescape Storage: value of the backing storage's container port serving the payload
+*/}}
+{{- define "kubescapeStorage.backingStorage.containerPort" -}}
+2379
+{{- end }}
+
+{{/*
+Kubescape Storage: value of the backing storage deployment port
+*/}}
+{{- define "kubescapeStorage.backingStorage.deployment.port" -}}
+- name: "etcd-port"
+  protocol: "TCP"
+  containerPort: {{ include "kubescapeStorage.backingStorage.containerPort" . }}
+{{- end }}
+
+{{/*
+Kubescape Storage: value of the backing storage service port
+*/}}
+{{- define "kubescapeStorage.backingStorage.service.port" -}}
+- name: "etcd-port"
+  protocol: "TCP"
+  targetPort: {{ include "kubescapeStorage.backingStorage.containerPort" . }}
+  port: {{ include "kubescapeStorage.backingStorage.containerPort" . }}
+{{- end }}
+
+{{/*
+Kubescape Storage: value of the backing storage service name
+*/}}
+{{- define "kubescapeStorage.backingStorage.service.name" -}}
+{{- printf "%s-backing-storage-svc" .Values.kubescapeStorage.k8sApiserver.name -}}
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/_helpersKubescapeStorage.tpl
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/_helpersKubescapeStorage.tpl
@@ -91,3 +91,10 @@ Create the name of the Kubescape Storage APIServer to use
 {{- define "kubescapeStorage.apiServer.deploymentName" -}}
   {{- .Values.kubescapeStorage.k8sApiserver.name | printf "%s-apiserver" }}
 {{- end }}
+
+{{/*
+Name of the Kubescape Storage APIServer Service
+*/}}
+{{- define "kubescapeStorage.apiServer.service.name" -}}
+  {{- .Values.kubescapeStorage.k8sApiserver.name | printf "%s-api" }}
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/_helpersKubescapeStorage.tpl
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/_helpersKubescapeStorage.tpl
@@ -1,0 +1,93 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubescape-storage.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubescape-storage.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubescape-storage.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubescape-storage.labels" -}}
+helm.sh/chart: {{ include "kubescape-storage.chart" . }}
+{{ include "kubescape-storage.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubescape-storage.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubescape-storage.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the Kubescape Storage ServiceAccount to use
+*/}}
+{{- define "kubescapeStorage.serviceAccountName" -}}
+  {{- .Values.kubescapeStorage.k8sApiserver.name | printf "%s-sa" }}
+{{- end }}
+
+{{/*
+Create the name of the Kubescape Storage ClusterRole to use
+*/}}
+{{- define "kubescapeStorage.clusterRoleName" -}}
+  {{- .Values.kubescapeStorage.k8sApiserver.name | printf "%s-clusterrole" }}
+{{- end }}
+
+{{/*
+Create the name of the Kubescape Storage ClusterRoleBinding to use
+*/}}
+{{- define "kubescapeStorage.clusterRoleBindingName" -}}
+  {{- .Values.kubescapeStorage.k8sApiserver.name | printf "%s-clusterrolebinding" }}
+{{- end }}
+
+{{/*
+Create the name of the Kubescape Storage Auth Reader RoleBinding to use
+*/}}
+{{- define "kubescapeStorage.authReaderRoleBindingName" -}}
+  {{- .Values.kubescapeStorage.k8sApiserver.name | printf "%s-auth-reader" }}
+{{- end }}
+
+{{/*
+Create the name of the Kubescape Storage Auth Reader ClusterRoleBinding to use
+*/}}
+{{- define "kubescapeStorage.authDelegatorClusterRoleBindingName" -}}
+  {{- .Values.kubescapeStorage.k8sApiserver.name | printf "%s:system:auth-delegator" }}
+{{- end }}
+
+{{/*
+Create the name of the Kubescape Storage APIServer to use
+*/}}
+{{- define "kubescapeStorage.apiServer.deploymentName" -}}
+  {{- .Values.kubescapeStorage.k8sApiserver.name | printf "%s-apiserver" }}
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/apiservice.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/apiservice.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.kubescapeStorage.enabled }}
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: {{ .Values.kubescapeStorage.k8sApiserver.apiservice.name | quote}}
+spec:
+  {{- /* Ensure the namespace is set on the APIServer object and then use it. */ -}}
+  {{- /* Mutates the original key! */ -}}
+  {{- $_ := set (required "Service spec is required" .Values.kubescapeStorage.k8sApiserver.apiservice.spec.service ) "namespace" .Values.ksNamespace }}
+  {{- .Values.kubescapeStorage.k8sApiserver.apiservice.spec | toYaml | nindent 2 }}
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/apiservice.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/apiservice.yaml
@@ -2,10 +2,15 @@
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: {{ .Values.kubescapeStorage.k8sApiserver.apiservice.name | quote}}
+  name: "v1beta1.spdx.softwarecomposition.kubescape.io"
 spec:
-  {{- /* Ensure the namespace is set on the APIServer object and then use it. */ -}}
-  {{- /* Mutates the original key! */ -}}
-  {{- $_ := set (required "Service spec is required" .Values.kubescapeStorage.k8sApiserver.apiservice.spec.service ) "namespace" .Values.ksNamespace }}
-  {{- .Values.kubescapeStorage.k8sApiserver.apiservice.spec | toYaml | nindent 2 }}
+  insecureSkipTLSVerify: true
+  group: "spdx.softwarecomposition.kubescape.io"
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  version: "v1beta1"
+
+  service:
+    name: {{ include "kubescapeStorage.apiServer.service.name" . | quote }}
+    namespace: {{ .Values.ksNamespace | quote }}
 {{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/auth-delegator.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/auth-delegator.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.kubescapeStorage.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubescapeStorage.authDelegatorClusterRoleBindingName" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubescapeStorage.serviceAccountName" . | quote }}
+  namespace: {{ .Values.ksNamespace | quote }}
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/auth-reader.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/auth-reader.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.kubescapeStorage.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kubescapeStorage.authReaderRoleBindingName" . | quote }}
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  # This is a default role name provided by K8s and should not be templated or changed
+  name: "extension-apiserver-authentication-reader"
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubescapeStorage.serviceAccountName" . | quote }}
+  namespace: {{ .Values.ksNamespace | quote }}
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/backingStorage-deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/backingStorage-deployment.yaml
@@ -21,7 +21,10 @@ spec:
         image: {{ printf "%s:%s" .Values.kubescapeStorage.backingStorage.deployment.image.repository .Values.kubescapeStorage.backingStorage.deployment.image.tag | quote }}
         imagePullPolicy: {{ .Values.kubescapeStorage.backingStorage.deployment.image.pullPolicy | quote }}
         args:
-          {{- .Values.kubescapeStorage.backingStorage.deployment.args | toYaml | nindent 10 }}
+          - "etcd"
+          - "--listen-client-urls=http://0.0.0.0:2379"
+          - "--advertise-client-urls=http://0.0.0.0:2379"
+          - "--max-request-bytes=25165824"
         ports:
           {{ .Values.kubescapeStorage.backingStorage.deployment.ports | toYaml | nindent 10 }}
 {{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/backingStorage-deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/backingStorage-deployment.yaml
@@ -17,8 +17,9 @@ spec:
         {{ .Values.kubescapeStorage.backingStorage.deployment.labels | toYaml | nindent 8 }}
     spec:
       containers:
-      - name: etcd
-        image: gcr.io/etcd-development/etcd:v3.5.7
+      - name: "etcd"
+        image: {{ printf "%s:%s" .Values.kubescapeStorage.backingStorage.deployment.image.repository .Values.kubescapeStorage.backingStorage.deployment.image.tag | quote }}
+        imagePullPolicy: {{ .Values.kubescapeStorage.backingStorage.deployment.image.pullPolicy | quote }}
         args:
           {{- .Values.kubescapeStorage.backingStorage.deployment.args | toYaml | nindent 10 }}
         ports:

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/backingStorage-deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/backingStorage-deployment.yaml
@@ -26,5 +26,5 @@ spec:
           - "--advertise-client-urls=http://0.0.0.0:2379"
           - "--max-request-bytes=25165824"
         ports:
-          {{ .Values.kubescapeStorage.backingStorage.deployment.ports | toYaml | nindent 10 }}
+          {{- include "kubescapeStorage.backingStorage.deployment.port" . | nindent 10 }}
 {{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/backingStorage-deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/backingStorage-deployment.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.kubescapeStorage.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubescape-aa-storage-etcd
+  namespace: {{ .Values.ksNamespace | quote }}
+  labels:
+    {{ .Values.kubescapeStorage.backingStorage.deployment.labels | toYaml | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{ .Values.kubescapeStorage.backingStorage.deployment.labels | toYaml | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{ .Values.kubescapeStorage.backingStorage.deployment.labels | toYaml | nindent 8 }}
+    spec:
+      containers:
+      - name: etcd
+        image: gcr.io/etcd-development/etcd:v3.5.7
+        args:
+          {{- .Values.kubescapeStorage.backingStorage.deployment.args | toYaml | nindent 10 }}
+        ports:
+          {{ .Values.kubescapeStorage.backingStorage.deployment.ports | toYaml | nindent 10 }}
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/backingStorage-service.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/backingStorage-service.yaml
@@ -2,17 +2,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.kubescapeStorage.backingStorage.service.name | quote }}
+  name: {{ include "kubescapeStorage.backingStorage.service.name" . | quote }}
   namespace: {{ .Values.ksNamespace | quote }}
   labels:
     {{ .Values.kubescapeStorage.backingStorage.deployment.labels | toYaml | nindent 4 }}
 spec:
-  type: {{ .Values.kubescapeStorage.backingStorage.service.type | quote }}
+  type: "ClusterIP"
   selector:
     {{ .Values.kubescapeStorage.backingStorage.deployment.labels | toYaml | nindent 4 }}
   ports:
-  - name: "etcd-port"
-    protocol: "TCP"
-    port: {{ .Values.kubescapeStorage.backingStorage.service.port }}
-    targetPort: {{ (index .Values.kubescapeStorage.backingStorage.deployment.ports 0).name }}
+    {{- include "kubescapeStorage.backingStorage.service.port" . | nindent 4 }}
 {{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/backingStorage-service.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/backingStorage-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.kubescapeStorage.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.kubescapeStorage.backingStorage.service.name | quote }}
+  namespace: {{ .Values.ksNamespace | quote }}
+  labels:
+    {{ .Values.kubescapeStorage.backingStorage.deployment.labels | toYaml | nindent 4 }}
+spec:
+  type: {{ .Values.kubescapeStorage.backingStorage.service.type | quote }}
+  selector:
+    {{ .Values.kubescapeStorage.backingStorage.deployment.labels | toYaml | nindent 4 }}
+  ports:
+  - name: "etcd-port"
+    protocol: "TCP"
+    port: {{ .Values.kubescapeStorage.backingStorage.service.port }}
+    targetPort: {{ (index .Values.kubescapeStorage.backingStorage.deployment.ports 0).name }}
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/k8sApiserver-deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/k8sApiserver-deployment.yaml
@@ -21,5 +21,5 @@ spec:
       - name: apiserver
         image: {{ printf "%s:%s" .Values.kubescapeStorage.k8sApiserver.deployment.image.repository .Values.kubescapeStorage.k8sApiserver.deployment.image.tag  | quote }}
         imagePullPolicy: {{ .Values.kubescapeStorage.k8sApiserver.deployment.image.pullPolicy | quote }}
-        args: [ "--etcd-servers=http://{{ .Values.kubescapeStorage.backingStorage.service.name }}:2379" ]
+        args: [ "--etcd-servers=http://{{ include "kubescapeStorage.backingStorage.service.name" . }}:{{ include "kubescapeStorage.backingStorage.containerPort" . }}" ]
 {{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/k8sApiserver-deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/k8sApiserver-deployment.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.kubescapeStorage.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kubescapeStorage.apiServer.deploymentName" . | quote }}
+  namespace: {{ .Values.ksNamespace }}
+  labels:
+    {{ .Values.kubescapeStorage.k8sApiserver.deployment.labels | toYaml  | nindent 4}}
+spec:
+  replicas: {{ .Values.kubescapeStorage.k8sApiserver.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      {{ .Values.kubescapeStorage.k8sApiserver.deployment.labels | toYaml | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{ .Values.kubescapeStorage.k8sApiserver.deployment.labels | toYaml | nindent 8}}
+    spec:
+      serviceAccountName: {{ include "kubescapeStorage.serviceAccountName" . | quote }}
+      containers:
+      - name: apiserver
+        image: {{ printf "%s:%s" .Values.kubescapeStorage.k8sApiserver.deployment.image.repository .Values.kubescapeStorage.k8sApiserver.deployment.image.tag  | quote }}
+        imagePullPolicy: {{ .Values.kubescapeStorage.k8sApiserver.deployment.image.pullPolicy | quote }}
+        args: [ "--etcd-servers=http://{{ .Values.kubescapeStorage.backingStorage.service.name }}:2379" ]
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/k8sApiservice-service.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/k8sApiservice-service.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.kubescapeStorage.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.kubescapeStorage.k8sApiserver.apiservice.spec.service.name | quote }}
+  namespace: {{ .Values.ksNamespace }} 
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    {{ .Values.kubescapeStorage.k8sApiserver.deployment.labels | toYaml | nindent 4}}
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/k8sApiservice-service.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/k8sApiservice-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.kubescapeStorage.k8sApiserver.apiservice.spec.service.name | quote }}
+  name: {{ include "kubescapeStorage.apiServer.service.name" . | quote }}
   namespace: {{ .Values.ksNamespace }} 
 spec:
   ports:

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/rbac-bind.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/rbac-bind.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.kubescapeStorage.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubescapeStorage.clusterRoleBindingName" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kubescapeStorage.clusterRoleName" . | quote }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubescapeStorage.serviceAccountName" . | quote }}
+  namespace: {{ .Values.ksNamespace | quote }}
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/rbac.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/rbac.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.kubescapeStorage.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kubescapeStorage.clusterRoleName" . | quote }}
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["get", "watch", "list"]
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/sa.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/sa.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.kubescapeStorage.enabled }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ include "kubescapeStorage.serviceAccountName" . | quote }}
+  namespace: {{ .Values.ksNamespace | quote }}
+{{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/tests/test-connection.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Values.kubescapeStorage.k8sApiserver.name }}-test-connection"
+  labels:
+    {{- include "kubescape-storage.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ .Values.kubescapeStorage.k8sApiserver.apiservice.spec.service.name }}:80']
+  restartPolicy: Never

--- a/charts/kubescape-cloud-operator/templates/kubescape-storage/tests/test-connection.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-storage/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ .Values.kubescapeStorage.k8sApiserver.apiservice.spec.service.name }}:80']
+      args: ['{{ include "kubescapeStorage.apiServer.service.name" . }}:80']
   restartPolicy: Never

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -487,12 +487,6 @@ kubescapeStorage:
           protocol: "TCP"
           containerPort: 2379
 
-      args:
-        - "etcd"
-        - "--listen-client-urls=http://0.0.0.0:2379"
-        - "--advertise-client-urls=http://0.0.0.0:2379"
-        - "--max-request-bytes=25165824"
-
     service:
       name: "kubescape-aa-storage-etcd"
 

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -453,7 +453,7 @@ kubescapeStorage:
 
   # Values or the Aggregated APIServer
   k8sApiserver:
-    name: "kubescape-aggregated-apiserver"
+    name: "storage-aggregated-apiserver"
 
     # The APIService provided by this AA
     apiservice:

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -445,3 +445,71 @@ otelCollector:
     limits:
        cpu: 1
        memory: 2Gi
+
+# Values for the Kubescape Storage service that Kubescape uses for its internal
+# purposes like storage
+kubescapeStorage:
+  enabled: false
+
+  # Values or the Aggregated APIServer
+  k8sApiserver:
+    name: "kubescape-aggregated-apiserver"
+
+    # The APIService provided by this AA
+    apiservice:
+      name: "v1beta1.spdx.softwarecomposition.kubescape.io"
+
+      spec:
+        insecureSkipTLSVerify: true
+        group: "spdx.softwarecomposition.kubescape.io"
+        groupPriorityMinimum: 1000
+        versionPriority: 15
+        version: "v1beta1"
+
+        service:
+          name: "api"
+
+    deployment:
+      labels:
+        app.kubernetes.io/name: "aggregated-apiserver"
+        app.kubernetes.io/component: "apiserver"
+        app.kubernetes.io/part-of: "kubescape-storage"
+
+      replicaCount: 1
+      image:
+        pullPolicy: "IfNotPresent"
+        repository: "vklokun/kube-sample-apiserver"
+        tag: "0.1.38"
+
+
+  # Values for the storage that backs the Aggregated APIServer
+  backingStorage:
+    deployment: 
+      replicaCount: 1
+
+      labels:
+        app.kubernetes.io/name: "etcd"
+        app.kubernetes.io/component: "database"
+        app.kubernetes.io/part-of: "kubescape-aa-storage"
+
+      image:
+        pullPolicy: "IfNotPresent"
+        repository: "gcr.io/etcd-development/etcd"
+        tag: "v3.5.7"
+
+      ports:
+        - name: "etcd-port"
+          protocol: "TCP"
+          containerPort: 2379
+
+      args:
+        - "etcd"
+        - "--listen-client-urls=http://0.0.0.0:2379"
+        - "--advertise-client-urls=http://0.0.0.0:2379"
+        - "--max-request-bytes=25165824"
+
+    service:
+      name: "kubescape-aa-storage-etcd"
+
+      type: "ClusterIP"
+      port: 2379

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -481,14 +481,3 @@ kubescapeStorage:
         pullPolicy: "IfNotPresent"
         repository: "gcr.io/etcd-development/etcd"
         tag: "v3.5.7"
-
-      ports:
-        - name: "etcd-port"
-          protocol: "TCP"
-          containerPort: 2379
-
-    service:
-      name: "kubescape-aa-storage-etcd"
-
-      type: "ClusterIP"
-      port: 2379

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -455,20 +455,6 @@ kubescapeStorage:
   k8sApiserver:
     name: "storage-aggregated-apiserver"
 
-    # The APIService provided by this AA
-    apiservice:
-      name: "v1beta1.spdx.softwarecomposition.kubescape.io"
-
-      spec:
-        insecureSkipTLSVerify: true
-        group: "spdx.softwarecomposition.kubescape.io"
-        groupPriorityMinimum: 1000
-        versionPriority: 15
-        version: "v1beta1"
-
-        service:
-          name: "api"
-
     deployment:
       labels:
         app.kubernetes.io/name: "aggregated-apiserver"

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -471,7 +471,6 @@ kubescapeStorage:
   # Values for the storage that backs the Aggregated APIServer
   backingStorage:
     deployment: 
-      replicaCount: 1
 
       labels:
         app.kubernetes.io/name: "etcd"


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
This commit adds the Kubscape Storage service into the Helm chart.

Since this is an upcoming feature, it is disabled by default.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

## How to Test

Fetch the new chart definition and run the following command:
```
helm -n kubescape install {FETCHED_CHART_PATH}/kubescape-cloud-operator/ --create-namespace --set kubescape.submit=false --set clusterName="ks-aa-test"
```

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
 