### PR TITLE
Added (optional) hostmetrics receiver to otel collector config

### DIFF
--- a/charts/kubescape-cloud-operator/README.md
+++ b/charts/kubescape-cloud-operator/README.md
@@ -86,6 +86,12 @@ otelCollector:
 If you don't have an otel distribution, we suggest you try either [Uptrace](https://github.com/uptrace/uptrace/tree/master/example/docker) or [SigNoz](https://signoz.io/docs/install/docker/)
 as they are free, opensource and can be quickly deployed using docker-compose.
 
+#### Host metrics collection
+
+The OpenTelemetry collector is configured with the [`hostmetrics`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md) receiver to collect CPU and memory utilization metrics.
+
+Note that the hostmetrics receiver is disabled by default. If you wish to enable it, simply install the operator with `--set otelCollector.hostmetrics.enabled=true`
+
 #### Example: exporting to uptrace running inside docker-compose
 
 ```mermaid

--- a/charts/kubescape-cloud-operator/assets/otel-collector-config.yaml
+++ b/charts/kubescape-cloud-operator/assets/otel-collector-config.yaml
@@ -1,12 +1,26 @@
+{{ template "cluster_name" . }}
 # receivers configure how data gets into the Collector.
 receivers:
   otlp:
     protocols:
       grpc:
       http:
+  hostmetrics:
+    collection_interval: {{ .Values.otelCollector.hostmetrics.scrapeInterval }}
+    scrapers:
+      cpu:
+      memory:
 
 # processors specify what happens with the received data.
 processors:
+  attributes/ksCloud:
+    actions:
+      - key: account_id
+        value: "{{ .Values.account }}"
+        action: upsert
+      - key: cluster_name
+        value: "{{ regexReplaceAll "\\W+" .Values.clusterName "-" }}"
+        action: upsert
   batch:
     send_batch_size: 10000
     timeout: 10s
@@ -48,6 +62,16 @@ service:
         - otlp
       {{- end }}
         - otlp/ksCloud
+    {{- if .Values.otelCollector.hostmetrics.enabled }}
+    metrics/2:
+      receivers: [hostmetrics]
+      processors: [attributes/ksCloud, batch]
+      exporters: 
+      {{- if ne .Values.otelCollector.endpoint.host "" }}
+        - otlp
+      {{- end }}
+        - otlp/ksCloud
+    {{- end }}
     metrics:
       receivers: [otlp]
       processors: [batch]

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -433,6 +433,11 @@ otelCollector:
     headers:
       uptrace-dsn: ""
 
+  # -- enable/disable hostmetrics collection  
+  hostmetrics:
+    enabled: false
+    scrapeInterval: 30s
+
   image:
     repository: otel/opentelemetry-collector
     tag: 0.70.0


### PR DESCRIPTION
Provide the ability to collect CPU and memory utilization metrics by the OpenTelemetry collector.
By default this option is disabled.