### PR TITLE
chore: bump Kubescape Storage APIServer version

### DIFF
--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -472,7 +472,7 @@ kubescapeStorage:
       image:
         pullPolicy: "IfNotPresent"
         repository: "vklokun/kube-sample-apiserver"
-        tag: "0.1.38"
+        tag: "0.1.39"
 
 
   # Values for the storage that backs the Aggregated APIServer


### PR DESCRIPTION
## Overview

The newest version contains the increased etcd message size limit. (https://github.com/kubescape/storage/pull/9)