### PR TITLE
chore: bump Kubescape Storage AA version

### DIFF
--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -472,7 +472,7 @@ kubescapeStorage:
       image:
         pullPolicy: "IfNotPresent"
         repository: "vklokun/kube-sample-apiserver"
-        tag: "0.1.39"
+        tag: "0.1.40"
 
 
   # Values for the storage that backs the Aggregated APIServer


### PR DESCRIPTION
## Overview
Bump the Kubescape Storage AA version to increase etcd message limits even further

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes