### PR TITLE
fix: move host-scanner namespace

### DIFF
--- a/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
@@ -7,13 +7,13 @@ metadata:
     k8s-app: kubescape-host-scanner
     kubernetes.io/metadata.name: kubescape-host-scanner
     tier: kubescape-host-scanner-control-plane
-  name: kubescape-host-scanner
+  name: kubescape
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: host-scanner
-  namespace: kubescape-host-scanner
+  namespace: kubescape
   labels:
     app: host-scanner
     k8s-app: kubescape-host-scanner

--- a/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
@@ -44,7 +44,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: host-sensor
-        image: quay.io/kubescape/host-scanner:v1.0.54
+        image: quay.io/kubescape/host-scanner:v1.0.59
         securityContext:
           privileged: true
           readOnlyRootFilesystem: true
@@ -82,12 +82,17 @@ spec:
 {{- if .Values.kubescapeHostScanner.volumeMounts }}
 {{ toYaml .Values.kubescapeHostScanner.volumeMounts | indent 8 }}
 {{- end }}
-        readinessProbe:
+        startupProbe:
           httpGet:
-            path: /kernelVersion
+            path: /readyz
             port: 7888
-            initialDelaySeconds: 1
-            periodSeconds: 1
+          failureThreshold: 30
+          periodSeconds: 1
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 7888
+          periodSeconds: 10
       terminationGracePeriodSeconds: 120
       dnsPolicy: ClusterFirstWithHostNet
       automountServiceAccountToken: false


### PR DESCRIPTION
## Overview
In this PR we are moving the previous dedicated **host-scanner**'s namespace (`kubescape-host-scanner`), to the current in use for **kubescape** operator (`kubescape`).

## Additional Information

This is useful to avoid communication issues between namespaces when a policy engine is installed on the cluster.

## How to Test

Build kubescape by your own from this branch and run it against a cluster with the following command: `./kubescape scan --enable-host-scan`.
Check if host-scanner is deployed in kubescape namespace.

## Related Issues/PRs:
This is related to this other PR in **kubescape**:
https://github.com/kubescape/kubescape/pull/1217

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

 