### PR TITLE
chore(apiserver): bump version to support Strategic Merge Patch

### DIFF
--- a/labs/kubescape-relevancy/Chart.yaml
+++ b/labs/kubescape-relevancy/Chart.yaml
@@ -10,14 +10,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 2.0.7
+version: 2.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 2.0.7
+appVersion: 2.0.8
 
 maintainers:
 - name: Ben Hirschberg

--- a/labs/kubescape-relevancy/values.yaml
+++ b/labs/kubescape-relevancy/values.yaml
@@ -522,7 +522,7 @@ kubescapeStorage:
       image:
         pullPolicy: "IfNotPresent"
         repository: "vklokun/kube-sample-apiserver"
-        tag: "0.1.40"
+        tag: "0.1.41"
 
 
   # Values for the storage that backs the Aggregated APIServer


### PR DESCRIPTION
## Overview

This PR bumps the Aggregated APIServer version to support the Strategic Merge Patch. Enables changes delivered by kubescape/storage#12.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 