### PR TITLE
Control Kubescape rule processing concurrency by env var

### DIFF
--- a/charts/kubescape-cloud-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape/deployment.yaml
@@ -77,6 +77,8 @@ spec:
           value: "{{ .Values.logger.name }}"
         - name: KS_DOWNLOAD_ARTIFACTS  # When set to true the artifacts will be downloaded every scan execution
           value: "{{ .Values.kubescape.downloadArtifacts }}" 
+        - name: RULE_PROCESSING_GOMAXPROCS
+          value: "{{ .Values.kubescape.ruleProcessingConcurrency }}"
         - name: KS_DEFAULT_CONFIGMAP_NAME
           value: "{{ .Values.kubescape.name }}-config"
         - name: KS_DEFAULT_CONFIGMAP_NAMESPACE

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -164,6 +164,9 @@ kubescape:
   # -- skip check for a newer version 
   skipUpdateCheck: false
 
+  # -- set the number of concurrent goroutines to process OPA rules
+  ruleProcessingConcurrency: 1
+
   # -- submit results to the Kubescape cloud: https://cloud.armosec.io/
   submit: true
 

--- a/charts/kubescape-prometheus-integrator/templates/kubescape/kubescape-deployment.yaml
+++ b/charts/kubescape-prometheus-integrator/templates/kubescape/kubescape-deployment.yaml
@@ -82,6 +82,8 @@ spec:
           value: "{{ .Values.kubescape.submit }}"
         - name: KS_SKIP_UPDATE_CHECK
           value: "{{ .Values.kubescape.skipUpdateCheck }}"
+        - name: RULE_PROCESSING_GOMAXPROCS
+          value: "{{ .Values.kubescape.ruleProcessingConcurrency }}"
         {{- with .Values.kubescape.excludeNamespaces }}
         - name: KS_EXCLUDE_NAMESPACES
           value: {{ join "," . }}

--- a/charts/kubescape-prometheus-integrator/values.yaml
+++ b/charts/kubescape-prometheus-integrator/values.yaml
@@ -72,6 +72,9 @@ kubescape:
   # -- skip check for a newer version 
   skipUpdateCheck: true
 
+  # -- set the number of concurrent goroutines to process OPA rules
+  ruleProcessingConcurrency: 1
+  
   # -- submit results to the Kubescape cloud: https://cloud.armosec.io/
   submit: false
 

--- a/labs/kubescape-relevancy/README.md
+++ b/labs/kubescape-relevancy/README.md
@@ -157,6 +157,7 @@ docker-compose logs uptrace
 | kubescape.enabled | bool | `true` | enable/disable kubescape scanning |
 | kubescape.image.repository | string | `"quay.io/kubescape/kubescape"` | [source code](https://github.com/kubescape/kubescape/tree/master/httphandler) (public repo) |
 | kubescape.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) |
+| kubescape.ruleProcessingConcurrency | integer | 1 | Number of concurrent goroutines to process OPA rules |
 | kubescape.serviceMonitor.enabled | bool | `false` | enable/disable service monitor for prometheus (operator) integration |
 | kubescape.skipUpdateCheck | bool | `false` | skip check for a newer version |
 | kubescape.submit | bool | `true` | submit results to Kubescape SaaS: https://cloud.armosec.io/ |

--- a/labs/kubescape-relevancy/templates/kubescape/deployment.yaml
+++ b/labs/kubescape-relevancy/templates/kubescape/deployment.yaml
@@ -77,6 +77,8 @@ spec:
           value: "{{ .Values.logger.name }}"
         - name: KS_DOWNLOAD_ARTIFACTS  # When set to true the artifacts will be downloaded every scan execution
           value: "{{ .Values.kubescape.downloadArtifacts }}" 
+        - name: RULE_PROCESSING_GOMAXPROCS
+          value: "{{ .Values.kubescape.ruleProcessingConcurrency }}"
         - name: KS_DEFAULT_CONFIGMAP_NAME
           value: "{{ .Values.kubescape.name }}-config"
         - name: KS_DEFAULT_CONFIGMAP_NAMESPACE

--- a/labs/kubescape-relevancy/values.yaml
+++ b/labs/kubescape-relevancy/values.yaml
@@ -160,6 +160,9 @@ kubescape:
   # -- skip check for a newer version 
   skipUpdateCheck: false
 
+  # -- set the number of concurrent goroutines to process OPA rules
+  ruleProcessingConcurrency: 1
+
   # -- submit results to the Kubescape cloud: https://cloud.armosec.io/
   submit: true
 


### PR DESCRIPTION
## Overview

As part of this PR, added a new env var to Kubescape which was introduced in https://github.com/kubescape/kubescape/pull/1230. It allows setting the concurrency level in which OPA rules are processed. 
By default, Kubescape will not evaluate the OPA rules concurrently (value=1) as it can be a resource-intensive operation that can lead to OOM situations when scanning large clusters. 


## Additional Information

N/A 

## Related issues/PRs:

* https://github.com/kubescape/kubescape/pull/1230

## Checklist before requesting a review

- [X] My code follows the style guidelines of this project
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
- [X] New and existing unit tests pass locally with my changes
