### PR TITLE
Update Kubescape version, revert gateway & kollector limits

### DIFF
--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -336,10 +336,10 @@ kollector:
 
   resources:
     requests:
-       cpu: 0.1
+       cpu: 10m
        memory: 40Mi
     limits:
-       cpu: 0.5
+       cpu: 500m
        memory: 500Mi
 
 
@@ -389,11 +389,11 @@ gateway:
   replicaCount: 1
   resources:
     requests:
-       cpu: 0.0001
+       cpu: 10m
        memory: 10Mi
     limits:
-       cpu: 0.001
-       memory: 20Mi
+       cpu: 100m
+       memory: 50Mi
 
   env: {}
   labels: {}

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -144,7 +144,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v2.3.1
+    tag: v2.3.3
     pullPolicy: Always
 
   resources:

--- a/charts/kubescape-prometheus-integrator/values.yaml
+++ b/charts/kubescape-prometheus-integrator/values.yaml
@@ -52,7 +52,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v2.2.5
+    tag: v2.3.3
     pullPolicy: IfNotPresent
 
   resources:


### PR DESCRIPTION
## Overview

- Bump KS version to v2.3.3
- Revert resource limits of gateway & kollector (https://github.com/kubescape/helm-charts/pull/140)