### PR TITLE
fix: Use read-only filesystem also on kubevuln component

### DIFF
--- a/charts/kubescape-cloud-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubevuln/deployment.yaml
@@ -50,6 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.kubevuln.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 100
           ports:
@@ -102,11 +103,8 @@ spec:
             - name: {{ .Values.global.cloudConfig }}
               mountPath: /etc/config
               readOnly: true
-            {{- if .Values.persistence.enabled }}
             - name: "grype-db"
               mountPath: "/home/ks/.cache/grype"
-              readOnly: false
-            {{- end }}
 {{- if .Values.volumeMounts }}
 {{ toYaml .Values.volumeMounts | indent 12 }}
 {{- end }}
@@ -134,11 +132,13 @@ spec:
             items:
             - key: "clusterData"
               path: "clusterData.json"
-        {{- if .Values.persistence.enabled }}
         - name: "grype-db"
+          {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: "{{ .Values.kubevuln.name }}"
-        {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
 {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | indent 8 }}
 {{- end }}


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

This is a follow-up of my PR https://github.com/kubescape/helm-charts/pull/26. Since the PR was open for a long period, kubevuln also got new features which conflicted with the implementation of the read-only FS.


## Additional Information

It seems that there is another case (with another directory) which isn't covered today:
https://github.com/kubescape/kubevuln/blob/29d1e5536bac8ba4b52191261460c4cd5d2e16a3/adapters/v1/grype.go#L45-L64

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 