### PR TITLE
fix: update host-scaner container image

### DIFF
--- a/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
@@ -44,7 +44,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: host-sensor
-        image: quay.io/kubescape/host-scanner:v1.0.59
+        image: quay.io/kubescape/host-scanner:v1.0.61
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true


### PR DESCRIPTION
## Overview
`/kubeletcommandline` has been replaced by `/kubeletinfo` endpoint.

## Related issues/PRs:
Related issue:
* https://github.com/kubescape/host-scanner/pull/46

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
