### PR TITLE
Added urls to Kubescape config and increased memory limits of Kubescape

### DIFF
--- a/labs/kubescape-relevancy/Chart.yaml
+++ b/labs/kubescape-relevancy/Chart.yaml
@@ -10,14 +10,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 2.0.16
+version: 2.0.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 2.0.16
+appVersion: 2.0.17
 
 maintainers:
 - name: Ben Hirschberg

--- a/labs/kubescape-relevancy/templates/kubescape/configmap.yaml
+++ b/labs/kubescape-relevancy/templates/kubescape/configmap.yaml
@@ -13,6 +13,10 @@ data:
   config.json: |
     {
       "accountID": "{{ .Values.account }}",
+      "cloudReportURL": "{{ .Values.kubescape.urls.report }}",
+      "cloudAPIURL": "{{ .Values.kubescape.urls.api }}",
+      "cloudUIURL": "{{ .Values.kubescape.urls.ui }}",
+      "cloudAuthURL": "{{ .Values.kubescape.urls.auth }}",
       "clusterName": "{{ regexReplaceAll "\\W+" .Values.clusterName "-" }}",
       "clientID": "{{ .Values.clientID }}",
       "secretKey": "{{ .Values.secretKey }}"

--- a/labs/kubescape-relevancy/values.yaml
+++ b/labs/kubescape-relevancy/values.yaml
@@ -165,7 +165,14 @@ kubescape:
        memory: 400Mi
     limits:
        cpu: 600m
-       memory: 800Mi
+       memory: 1Gi
+
+  # -- override the default URLs when using private cloud
+  urls:
+    report: ""
+    api: ""
+    ui: ""
+    auth: ""
 
   # -- set the number of concurrent goroutines to process OPA rules
   ruleProcessingConcurrency: 1


### PR DESCRIPTION
Applied the following changes from `master` branch to the `relevancy` branch:
- https://github.com/kubescape/helm-charts/pull/181
- https://github.com/kubescape/helm-charts/pull/172