### PR TITLE
bump host-scanner version

### DIFF
--- a/charts/kubescape-cloud-operator/Chart.yaml
+++ b/charts/kubescape-cloud-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.13.3
+version: 1.13.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.13.3
+appVersion: 1.13.4
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
@@ -44,7 +44,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: host-sensor
-        image: quay.io/kubescape/host-scanner:v1.0.61
+        image: quay.io/kubescape/host-scanner:v1.0.63
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true

--- a/charts/kubescape-prometheus-integrator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-prometheus-integrator/assets/host-scanner-definition.yaml
@@ -40,7 +40,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: host-sensor
-        image: quay.io/kubescape/host-scanner:v1.0.59
+        image: quay.io/kubescape/host-scanner:v1.0.63
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true


### PR DESCRIPTION
this version of the host-scanner removes readiness and liveness endpoints from telemetry to decrease the number of events sent to our backend