### PR TITLE
"Security" fw scan support

### DIFF
--- a/charts/kubescape-cloud-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape/deployment.yaml
@@ -136,6 +136,8 @@ spec:
         - name : no_proxy
           value: "{{ $no_proxy_envar_list }}"
         {{- end }}
+        - name: KS_SCAN_SECURITY_FRAMEWORK
+          value: "true"
         command:
         - ksserver
         resources:

--- a/charts/kubescape-cloud-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape/deployment.yaml
@@ -136,8 +136,6 @@ spec:
         - name : no_proxy
           value: "{{ $no_proxy_envar_list }}"
         {{- end }}
-        - name: KS_SCAN_SECURITY_FRAMEWORK
-          value: "true"
         command:
         - ksserver
         resources:

--- a/charts/kubescape-cloud-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/operator/deployment.yaml
@@ -99,6 +99,8 @@ spec:
             - name : no_proxy
               value: "{{ $no_proxy_envar_list }}"
             {{- end }}
+            - name: TRIGGER_SECURITY_FRAMEWORK
+              value: "{{ .Values.operator.TriggerSecurityFramework }}"
           args:
             - -alsologtostderr
             - -v=4

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -256,6 +256,8 @@ operator:
   # Additional volumeMounts to be mounted on the websocket
   volumeMounts: []
 
+  TriggerSecurityFramework: true
+
 kubevulnScheduler:
 
   ## Schedule Scan using cron


### PR DESCRIPTION
Adding to operator env var TRIGGER_SECURITY_FRAMEWORK.
If true (default), the operator will trigger scan for "security" fw on top of any framework scan.