### PR TITLE
fix: check supported version

### DIFF
--- a/charts/kubescape-cloud-operator/assets/kubescape-cronjob-full.yaml
+++ b/charts/kubescape-cloud-operator/assets/kubescape-cronjob-full.yaml
@@ -1,3 +1,6 @@
+{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
+  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- end }}
 apiVersion: batch/v1
     kind: CronJob
     metadata:

--- a/charts/kubescape-cloud-operator/assets/kubevuln-cronjob-full.yaml
+++ b/charts/kubescape-cloud-operator/assets/kubevuln-cronjob-full.yaml
@@ -1,3 +1,6 @@
+{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
+  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- end }}
 apiVersion: batch/v1
     kind: CronJob
     metadata:

--- a/charts/kubescape-cloud-operator/assets/registry-scan-cronjob-full.yaml
+++ b/charts/kubescape-cloud-operator/assets/registry-scan-cronjob-full.yaml
@@ -1,3 +1,6 @@
+{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
+  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- end }}
 apiVersion: batch/v1
     kind: CronJob
     metadata:

--- a/charts/kubescape-cloud-operator/templates/kubescape-scheduler/cronjob.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-scheduler/cronjob.yaml
@@ -1,3 +1,6 @@
+{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
+  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- end }}
 {{- if and .Values.kubescapeScheduler.enabled .Values.kubescape.enabled }}
 {{- $kubescape_daily_scan_cron_tab := (include "kubescape_daily_scan_cron_tab" .) -}}
 apiVersion: batch/v1

--- a/charts/kubescape-cloud-operator/templates/kubevuln-scheduler/cronjob.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubevuln-scheduler/cronjob.yaml
@@ -1,3 +1,6 @@
+{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
+  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- end }}
 {{- if .Values.kubevulnScheduler.enabled }}
 {{- $kubevuln_daily_scan_cron_tab := (include "kubevuln_daily_scan_cron_tab" .) -}}
 apiVersion: batch/v1


### PR DESCRIPTION
## Overview

Since `batchv/v1/CronJob` were GA in K8s in version `>= 1.21` any versions prior to that throw an error while trying to install the charts as we use `CronJob` as well. A more clearer error is being thrown now if the resource is not supported.

## Additional Information

Helm installations provide a lot of templating functionalities internally such as checking if a given resources definition exists in the cluster already or not, combining this with the ability to conditionally fail the install helps in this case.

## How to Test

Try to install the chart on a K8s version which doesn't support `batch/v1/CronJob` i.e. `< 1.21`

## Related issues/PRs:

Resolved #112 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
 