### PR TITLE
Addin secrets to operator cluster role

### DIFF
--- a/charts/kubescape-cloud-operator/templates/operator/clusterrole.yaml
+++ b/charts/kubescape-cloud-operator/templates/operator/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.operator.name }}
 rules:
   - apiGroups: [""]
-    resources: ["pods", "nodes", "namespaces", "configmaps"]
+    resources: ["pods", "nodes", "namespaces", "configmaps", "secrets"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["batch"]
     resources: ["jobs", "cronjobs"]


### PR DESCRIPTION
## Overview
The Operator failed  to retrieve the credentials for images in private repos:
```
{"level":"error","ts":"2023-07-26T21:21:31Z","msg":"unable to get secret","secret name":"reg-cred","error":"secrets \"reg-cred\" is forbidden: User \"system:serviceaccount:kubescape:operator\" cannot get resource \"secrets\" in API group \"\" in the namespace \"event-4\""}
```

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 