### PR TITLE
[kubescape-prometheus-integrator]Default logger settings

### DIFF
--- a/charts/kubescape-prometheus-integrator/values.yaml
+++ b/charts/kubescape-prometheus-integrator/values.yaml
@@ -7,6 +7,10 @@ createKubescapeServiceAccount: true # TODO: move to kubescape
 # -- set the image pull secrets for private registry support 
 imagePullSecrets: ""
 
+logger:
+  level: info
+  name: zap
+
 # cloud support
 cloudProviderMetadata:
 


### PR DESCRIPTION
## Overview

The logger configuration has been added to the integrator in the following Pull Request: https://github.com/kubescape/helm-charts/pull/185, but it has not been reflected in values.yaml.
If there are no default settings, developers will encounter value reference errors when updating the chart.

This is a similar fix as in Pull Request https://github.com/kubescape/helm-charts/pull/81.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 