### PR TITLE
Fixing Version Checks for CronJobs

### DIFF
--- a/charts/kubescape-cloud-operator/assets/kubescape-cronjob-full.yaml
+++ b/charts/kubescape-cloud-operator/assets/kubescape-cronjob-full.yaml
@@ -1,6 +1,3 @@
-{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
-  {{- fail "`batch/v1/CronJob not supported`" }}
-{{- end }}
 apiVersion: batch/v1
     kind: CronJob
     metadata:

--- a/charts/kubescape-cloud-operator/assets/kubevuln-cronjob-full.yaml
+++ b/charts/kubescape-cloud-operator/assets/kubevuln-cronjob-full.yaml
@@ -1,6 +1,3 @@
-{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
-  {{- fail "`batch/v1/CronJob not supported`" }}
-{{- end }}
 apiVersion: batch/v1
     kind: CronJob
     metadata:

--- a/charts/kubescape-cloud-operator/assets/registry-scan-cronjob-full.yaml
+++ b/charts/kubescape-cloud-operator/assets/registry-scan-cronjob-full.yaml
@@ -1,6 +1,3 @@
-{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
-  {{- fail "`batch/v1/CronJob not supported`" }}
-{{- end }}
 apiVersion: batch/v1
     kind: CronJob
     metadata:

--- a/charts/kubescape-cloud-operator/templates/configs/ks-recurring-cronjob-configmap.yaml
+++ b/charts/kubescape-cloud-operator/templates/configs/ks-recurring-cronjob-configmap.yaml
@@ -1,3 +1,6 @@
+{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
+  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- end }}
 kind: ConfigMap 
 apiVersion: v1 
 metadata:

--- a/charts/kubescape-cloud-operator/templates/configs/kv-recurring-cronjob-configmap.yaml
+++ b/charts/kubescape-cloud-operator/templates/configs/kv-recurring-cronjob-configmap.yaml
@@ -1,3 +1,6 @@
+{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
+  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- end }}
 kind: ConfigMap 
 apiVersion: v1 
 metadata:

--- a/charts/kubescape-cloud-operator/templates/configs/registry-scan-recurring-cronjob-configmap.yaml
+++ b/charts/kubescape-cloud-operator/templates/configs/registry-scan-recurring-cronjob-configmap.yaml
@@ -1,3 +1,6 @@
+{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
+  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses an issue with version checks for CronJobs in the kubescape-cloud-operator. The version checks have been moved from the CronJob files to the ConfigMap files to ensure proper functionality.

___
## PR Main Files Walkthrough:
-`kubescape-cronjob-full.yaml`: Removed the version check for CronJob.
-`kubevuln-cronjob-full.yaml`: Removed the version check for CronJob.
-`registry-scan-cronjob-full.yaml`: Removed the version check for CronJob.
-`ks-recurring-cronjob-configmap.yaml`: Added the version check for CronJob.
-`kv-recurring-cronjob-configmap.yaml`: Added the version check for CronJob.
-`registry-scan-recurring-cronjob-configmap.yaml`: Added the version check for CronJob.
