### PR TITLE
Adding Tolerations to Kubescape Cloud Operator

### DIFF
--- a/charts/kubescape-cloud-operator/README.md
+++ b/charts/kubescape-cloud-operator/README.md
@@ -197,8 +197,8 @@ docker-compose logs uptrace
 | operator.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) |
 | operator.volumes | object | `[]` | Additional volumes for the web socket |
 | operator.volumeMounts | object | `[]` | Additional volumeMounts for the web socket |
-| kubescapeHostScanner.volumes | object | `[]` | Additional volumes for the host scanner |
-| kubescapeHostScanner.volumeMounts | object | `[]` | Additional volumeMounts for the host scanner |
+| hostScanner.volumes | object | `[]` | Additional volumes for the host scanner |
+| hostScanner.volumeMounts | object | `[]` | Additional volumeMounts for the host scanner |
 | awsIamRoleArn | string | `nil` | AWS IAM arn role |
 | clientID | string | `""` | client ID, [read more](https://hub.armosec.io/docs/authentication) |
 | addRevisionLabel | bool | `true` | Add revision label to the components. This will insure the components will restart when updating the helm |

--- a/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
@@ -1,14 +1,4 @@
 {{ template "cluster_name" . }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    app: kubescape-host-scanner
-    k8s-app: kubescape-host-scanner
-    kubernetes.io/metadata.name: kubescape-host-scanner
-    tier: kubescape-host-scanner-control-plane
-  name: kubescape
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -33,18 +23,27 @@ spec:
       imagePullSecrets:
       - name: {{ toYaml .Values.imagePullSecrets }}
       {{- end }}
+
       tolerations:
-      # this toleration is to have the DaemonDet runnable on master nodes
-      # remove it if your masters can't run pods
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
+    {{- with .Values.hostScanner.tolerations }}
+        {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .Values.hostScanner.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.hostScanner.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
       - name: host-sensor
-        image: quay.io/kubescape/host-scanner:v1.0.65
+        image: "{{ .Values.hostScanner.image.repository }}:{{ .Values.hostScanner.image.tag }}"
+        imagePullPolicy: {{ .Values.hostScanner.image.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true
@@ -77,11 +76,8 @@ spec:
         volumeMounts:
         - mountPath: /host_fs
           name: host-filesystem
-{{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumeMounts | indent 8 }}
-{{- end }}
-{{- if .Values.kubescapeHostScanner.volumeMounts }}
-{{ toYaml .Values.kubescapeHostScanner.volumeMounts | indent 8 }}
+{{- if .Values.hostScanner.volumeMounts }}
+{{ toYaml .Values.hostScanner.volumeMounts | nindent 8 }}
 {{- end }}
         startupProbe:
           httpGet:
@@ -102,11 +98,8 @@ spec:
           path: /
           type: Directory
         name: host-filesystem
-{{- if .Values.volumeMounts }}
-{{ toYaml .Values.volumes | indent 6 }}
-{{- end }}
-{{- if .Values.kubescapeHostScanner.volumes }}
-{{ toYaml .Values.kubescapeHostScanner.volumes | indent 6 }}
+{{- if .Values.hostScanner.volumes }}
+{{ toYaml .Values.hostScanner.volumes | nindent 6 }}
 {{- end }}
       hostPID: true
       hostIPC: true

--- a/charts/kubescape-cloud-operator/assets/kubescape-cronjob-full.yaml
+++ b/charts/kubescape-cloud-operator/assets/kubescape-cronjob-full.yaml
@@ -16,6 +16,18 @@ apiVersion: batch/v1
               labels:
                 armo.tier: "kubescape-scan"
             spec:
+            {{- with .Values.tolerations }}
+              tolerations:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.kubescapeScheduler.nodeSelector }}
+              nodeSelector:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.kubescapeScheduler.affinity }}
+              affinity:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
               {{- if .Values.imagePullSecrets }}
               imagePullSecrets:
               - name: {{ toYaml .Values.imagePullSecrets }}

--- a/charts/kubescape-cloud-operator/assets/kubevuln-cronjob-full.yaml
+++ b/charts/kubescape-cloud-operator/assets/kubevuln-cronjob-full.yaml
@@ -16,6 +16,18 @@ apiVersion: batch/v1
               labels:
                 armo.tier: "vuln-scan"
             spec:
+            {{- with .Values.tolerations }}
+              tolerations:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.kubevulnScheduler.nodeSelector }}
+              nodeSelector:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.kubevulnScheduler.affinity }}
+              affinity:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
             {{- if .Values.imagePullSecrets }}
               imagePullSecrets:
               - name: {{ toYaml .Values.imagePullSecrets }}

--- a/charts/kubescape-cloud-operator/assets/registry-scan-cronjob-full.yaml
+++ b/charts/kubescape-cloud-operator/assets/registry-scan-cronjob-full.yaml
@@ -16,6 +16,18 @@ apiVersion: batch/v1
               labels:
                 armo.tier: "registry-scan"
             spec:
+            {{- with .Values.tolerations }}
+              tolerations:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.registryScanScheduler.nodeSelector }}
+              nodeSelector:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.registryScanScheduler.affinity }}
+              affinity:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
               {{- if .Values.imagePullSecrets }}
               imagePullSecrets:
               - name: {{ toYaml .Values.imagePullSecrets }}

--- a/charts/kubescape-cloud-operator/templates/grype-offline-db/deployment.yaml
+++ b/charts/kubescape-cloud-operator/templates/grype-offline-db/deployment.yaml
@@ -50,4 +50,16 @@ spec:
             protocol: TCP
           resources:
 {{ toYaml .Values.grypeOfflineDB.resources | indent 12 }}
+    {{- with .Values.grypeOfflineDB.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.grypeOfflineDB.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/charts/kubescape-cloud-operator/templates/kubescape-scheduler/cronjob.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubescape-scheduler/cronjob.yaml
@@ -24,6 +24,18 @@ spec:
             app: {{ .Values.kubescapeScheduler.name }}
             armo.tier: "kubescape-scan"
         spec:
+        {{- with .Values.kubescapeScheduler.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.kubescapeScheduler.affinity }}
+          affinity:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
           {{- if .Values.imagePullSecrets }}
           imagePullSecrets:
           - name: {{ toYaml .Values.imagePullSecrets }}

--- a/charts/kubescape-cloud-operator/templates/kubevuln-scheduler/cronjob.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubevuln-scheduler/cronjob.yaml
@@ -24,10 +24,22 @@ spec:
             app: {{ .Values.kubevulnScheduler.name }}
             armo.tier: "vuln-scan"
         spec:
-          {{- if .Values.imagePullSecrets }}
+        {{- with .Values.kubescapeScheduler.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.kubescapeScheduler.affinity }}
+          affinity:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.imagePullSecrets }}
           imagePullSecrets:
           - name: {{ toYaml .Values.imagePullSecrets }}
-          {{- end }}
+        {{- end }}
           containers:
           - name: {{ .Values.kubevulnScheduler.name }}
             image: "{{ .Values.kubevulnScheduler.image.repository }}:{{ .Values.kubevulnScheduler.image.tag }}"

--- a/charts/kubescape-cloud-operator/templates/node-agent/configmap.yaml
+++ b/charts/kubescape-cloud-operator/templates/node-agent/configmap.yaml
@@ -8,7 +8,8 @@ data:
   config.json: |
     {
         "relevantCVEServiceEnabled": true,
+        "InitialDelay": "{{ .Values.nodeAgent.config.learningPeriod }}"
+        "updateDataPeriod": "{{ .Values.nodeAgent.config.updatePeriod }}"
         "maxSniffingTimePerContainer": "{{ .Values.nodeAgent.config.maxLearningPeriod }}",
-        "updateDataPeriod": "{{ .Values.nodeAgent.config.learningPeriod }}"
     }
 {{- end }}

--- a/charts/kubescape-cloud-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-cloud-operator/templates/node-agent/daemonset.yaml
@@ -32,28 +32,9 @@ spec:
         helm.sh/revision: "{{ .Release.Revision }}"
       {{- end }}
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
       serviceAccountName: {{ .Values.nodeAgent.name }}
       automountServiceAccountToken: true
       hostPID: true
-      nodeSelector:
-        kubernetes.io/os: linux
-        kubernetes.io/arch: amd64
       volumes:
         - name: {{ .Values.global.cloudConfig }}
           configMap:
@@ -148,6 +129,14 @@ spec:
             mountPath: /etc/ssl/certs/proxy.crt
             subPath: proxy.crt
           {{- end }}
+    {{- with .Values.nodeAgent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeAgent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -437,12 +437,29 @@ gateway:
   # Additional volumeMounts to be mounted on the notification-service
   volumeMounts: []
 
-kubescapeHostScanner:
+hostScanner:
+  # enabled: true
+  image:
+    # -- source code: https://github.com/kubescape/host-scanner (public repo)
+    repository: quay.io/kubescape/host-scanner
+    tag: 	v1.0.65
+    pullPolicy: IfNotPresent
+
   # Additional volumes to be mounted on the Kubescape host scanner
   volumes: []
 
   # Additional volumeMounts to be mounted on the Kubescape host scanner
   volumeMounts: []
+
+  tolerations:
+  # this toleration is to have the DaemonDet runnable on master nodes
+  # remove it if your masters can't run pods
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
 
 # registry scan scheduled scan using a CronJob
 registryScanScheduler:
@@ -627,6 +644,23 @@ nodeAgent:
       name: debugfs
     - emptyDir:
       name: data
-node-agent:
-  image:
-    tag: v0.1.87
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/arch
+            operator: In
+            values:
+            - amd64
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/os
+            operator: In
+            values:
+            - linux
+
+  nodeSelector:
+    kubernetes.io/os: linux
+    kubernetes.io/arch: amd64

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -586,12 +586,13 @@ nodeAgent:
   name: node-agent
   image:
     repository: quay.io/kubescape/node-agent
-    tag: v0.1.88
+    tag: v0.1.91
     pullPolicy: IfNotPresent
 
   config: 
     maxLearningPeriod: 3h # duration string
     learningPeriod: 2m # duration string
+    updatePeriod: 10m # duration string
 
   resources:
     requests:

--- a/charts/kubescape-prometheus-integrator/README.md
+++ b/charts/kubescape-prometheus-integrator/README.md
@@ -131,8 +131,8 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | kubescape.volumeMounts | object | `[]` | Additional volumeMounts for Kubescape |
 | kubescape.includeNamespaces | object | `[]` | List of namespaces to include, rest of the namespaces will be ignored. |
 | kubescape.excludeNamespaces | object | `[]` | List of namespaces to exclude |
-| kubescapeHostScanner.volumes | object | `[]` | Additional volumes for the host scanner |
-| kubescapeHostScanner.volumeMounts | object | `[]` | Additional volumeMounts for the host scanner |
+| hostScanner.volumes | object | `[]` | Additional volumes for the host scanner |
+| hostScanner.volumeMounts | object | `[]` | Additional volumeMounts for the host scanner |
 | awsIamRoleArn | string | `nil` | AWS IAM arn role |
 | cloudProviderMetadata.cloudRegion | string | `nil` | cloud region |
 | cloudProviderMetadata.gkeProject | string | `nil` | GKE project |

--- a/charts/kubescape-prometheus-integrator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-prometheus-integrator/assets/host-scanner-definition.yaml
@@ -68,8 +68,8 @@ spec:
 {{- if .Values.volumeMounts }}
 {{ toYaml .Values.volumeMounts | indent 8 }}
 {{- end }}
-{{- if .Values.kubescapeHostScanner.volumeMounts }}
-{{ toYaml .Values.kubescapeHostScanner.volumeMounts | indent 8 }}
+{{- if .Values.hostScanner.volumeMounts }}
+{{ toYaml .Values.hostScanner.volumeMounts | indent 8 }}
 {{- end }}
         startupProbe:
           httpGet:
@@ -93,8 +93,8 @@ spec:
 {{- if .Values.volumeMounts }}
 {{ toYaml .Values.volumes | indent 6 }}
 {{- end }}
-{{- if .Values.kubescapeHostScanner.volumes }}
-{{ toYaml .Values.kubescapeHostScanner.volumes | indent 6 }}
+{{- if .Values.hostScanner.volumes }}
+{{ toYaml .Values.hostScanner.volumes | indent 6 }}
 {{- end }}
       hostPID: true
       hostIPC: true

--- a/charts/kubescape-prometheus-integrator/values.yaml
+++ b/charts/kubescape-prometheus-integrator/values.yaml
@@ -110,7 +110,7 @@ kubescape:
   # -- Additional volumeMounts to be mounted on Kubescape
   volumeMounts: []
 
-kubescapeHostScanner:
+hostScanner:
   # Additional volumes to be mounted on the Kubescape host scanner
   volumes: []
 


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces tolerations to the Kubescape Cloud Operator. Tolerations are applied to Kubernetes pods as a way to ensure that they are not scheduled onto inappropriate nodes. The changes also include renaming 'kubescapeHostScanner' to 'hostScanner' and updating the corresponding volumes and volumeMounts. Additionally, the PR introduces changes to the nodeSelector and affinity settings for various components.

___
## PR Main Files Walkthrough:
-`charts/kubescape-cloud-operator/README.md`: Updated the documentation to reflect the renaming of 'kubescapeHostScanner' to 'hostScanner'.
-`charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml`: Updated the host scanner definition to include tolerations, nodeSelector, and affinity settings.
-`charts/kubescape-cloud-operator/assets/kubescape-cronjob-full.yaml`, `charts/kubescape-cloud-operator/assets/kubevuln-cronjob-full.yaml`, `charts/kubescape-cloud-operator/assets/registry-scan-cronjob-full.yaml`: Added tolerations, nodeSelector, and affinity settings to various cronjobs.
-`charts/kubescape-cloud-operator/templates/grype-offline-db/deployment.yaml`: Added nodeSelector and affinity settings to the grype offline database deployment.
-`charts/kubescape-cloud-operator/templates/node-agent/daemonset.yaml`: Updated the node agent daemonset to include tolerations, nodeSelector, and affinity settings.
-`charts/kubescape-cloud-operator/values.yaml`: Updated the values file to include tolerations, nodeSelector, and affinity settings for various components, and renamed 'kubescapeHostScanner' to 'hostScanner'.
-`charts/kubescape-prometheus-integrator/README.md`: Updated the documentation to reflect the renaming of 'kubescapeHostScanner' to 'hostScanner'.
-`charts/kubescape-prometheus-integrator/assets/host-scanner-definition.yaml`: Updated the host scanner definition to include tolerations, nodeSelector, and affinity settings.
-`charts/kubescape-prometheus-integrator/values.yaml`: Updated the values file to include tolerations, nodeSelector, and affinity settings for various components, and renamed 'kubescapeHostScanner' to 'hostScanner'.
