### PR TITLE
Kubescape 2.3.8 Hotfix

### DIFF
--- a/charts/kubescape-cloud-operator/Chart.yaml
+++ b/charts/kubescape-cloud-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.14.3
+version: 1.14.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.14.3
+appVersion: 1.14.4
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-cloud-operator/values.yaml
+++ b/charts/kubescape-cloud-operator/values.yaml
@@ -161,7 +161,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v2.3.8
+    tag: v2.3.8-hotfix
     pullPolicy: IfNotPresent
 
   resources:


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR updates the version of the Kubescape Cloud Operator to include a hotfix. The chart version and the app version have been incremented from 1.14.3 to 1.14.4. Additionally, the tag of the Kubescape image in the values.yaml file has been updated to v2.3.8-hotfix.

___
## PR Main Files Walkthrough:
- `charts/kubescape-cloud-operator/Chart.yaml`: The chart version and the app version have been updated from 1.14.3 to 1.14.4.
- `charts/kubescape-cloud-operator/values.yaml`: The tag of the Kubescape image has been updated to v2.3.8-hotfix.
