### PR TITLE
add cluster role

### DIFF
--- a/charts/kubescape-cloud-operator/templates/kubevuln/clusterrole.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubevuln/clusterrole.yaml
@@ -1,12 +1,14 @@
 {{- if .Values.kubevuln.enabled }}
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kubevuln.name }}
-  namespace: {{ .Values.ksNamespace }}
 rules:
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
-    resources: ["sbomspdxv2p3s", "vulnerabilitymanifests"]
+    resources: ["vulnerabilitymanifests", "workloadconfigurationscans"]
+    verbs: ["create", "get", "update",  "list", "patch"]
+  - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
+    resources: ["sbomspdxv2p3s"]
     verbs: ["create", "get", "update", "watch", "list", "patch"]
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
     resources: ["sbomspdxv2p3filtereds"]

--- a/charts/kubescape-cloud-operator/templates/kubevuln/clusterrolebinding.yaml
+++ b/charts/kubescape-cloud-operator/templates/kubevuln/clusterrolebinding.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.kubevuln.enabled }}
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kubevuln.name }}
-  namespace: {{ .Values.ksNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: {{ .Values.kubevuln.name }}
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR changes the Kubernetes Role to a ClusterRole for the Custom Resource Definitions (CRDs) permissions, making them cluster-wide. It also updates the associated RoleBinding to a ClusterRoleBinding.

___
## PR Main Files Walkthrough:
`charts/kubescape-cloud-operator/templates/kubevuln/clusterrole.yaml`: The Role has been changed to a ClusterRole. The namespace field has been removed as ClusterRoles are not namespace-specific. The resources list has been updated to include "workloadconfigurationscans". The verbs list has been updated to include "patch".
`charts/kubescape-cloud-operator/templates/kubevuln/clusterrolebinding.yaml`: The RoleBinding has been changed to a ClusterRoleBinding. The namespace field has been removed as ClusterRoleBindings are not namespace-specific. The kind in the roleRef has been updated from Role to ClusterRole.

___
## User Description:
Make CRD permissions be cluster-wide
