### PR TITLE
support overriding KS branch in E2E workflow

### DIFF
--- a/.github/workflows/02-e2e-test.yaml
+++ b/.github/workflows/02-e2e-test.yaml
@@ -33,6 +33,11 @@ on:
         default: 'master'
         type: string
         description: 'tests branch name'
+      KS_BRANCH:
+        required: false
+        default: 'release'
+        type: string
+        description: 'kubescape branch name'
 
 jobs:
   e2e-test:
@@ -129,7 +134,7 @@ jobs:
           -b production           \
           -c CyberArmorTests      \
           --logger DEBUG          \
-          --kwargs helm_branch=${{ inputs.BRANCH }} 
+          --kwargs helm_branch=${{ inputs.BRANCH }} ks_branch=${{ inputs.KS_BRANCH }}
 
           deactivate
 


### PR DESCRIPTION
Overriding the following:
https://github.com/armosec/system-tests/blob/675cc383c77635354e9456d2fbc2cc61759a0fa1/tests_scripts/kubescape/base_kubescape.py#L79
Default value is `release`:
https://github.com/armosec/system-tests/blob/675cc383c77635354e9456d2fbc2cc61759a0fa1/tests_scripts/kubescape/base_kubescape.py#L20C1-L20C15

## PR Type:
Enhancement

___
## PR Description:
This PR introduces the ability to override the Kubescape branch in the end-to-end testing workflow. This is achieved by adding a new input parameter 'KS_BRANCH' to the GitHub Actions workflow. The default value for this parameter is 'release', but it can be overridden as needed.

___
## PR Main Files Walkthrough:
`.github/workflows/02-e2e-test.yaml`: Added a new input parameter 'KS_BRANCH' to the workflow, with a default value of 'release'. This parameter is then passed to the test command as 'ks_branch'.

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
