### PR TITLE
fix duplicate labels

### DIFF
--- a/charts/kubescape-cloud-operator/templates/servicediscovery/job.yaml
+++ b/charts/kubescape-cloud-operator/templates/servicediscovery/job.yaml
@@ -20,9 +20,6 @@ spec:
       name: "{{ .Release.Name }}"
       labels:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-      labels:
         app.kubernetes.io/name: {{ .Values.serviceDiscovery.name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This pull request addresses an issue with duplicate labels in the service discovery job template of the kubescape-cloud-operator chart. The duplicate labels have been removed to ensure the correct functioning of the service discovery job.

___
## PR Main Files Walkthrough:
`charts/kubescape-cloud-operator/templates/servicediscovery/job.yaml`: The duplicate labels in the metadata section of the service discovery job template have been removed. The labels `app.kubernetes.io/instance` and `helm.sh/chart` were previously declared twice. The second declaration of these labels has been removed.

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
