### PR TITLE
Fix global volumes & volumeMounts

### DIFF
--- a/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml
@@ -76,6 +76,9 @@ spec:
         volumeMounts:
         - mountPath: /host_fs
           name: host-filesystem
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 8 }}
+{{- end }}
 {{- if .Values.hostScanner.volumeMounts }}
 {{ toYaml .Values.hostScanner.volumeMounts | nindent 8 }}
 {{- end }}
@@ -98,6 +101,9 @@ spec:
           path: /
           type: Directory
         name: host-filesystem
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 6 }}
+{{- end }}
 {{- if .Values.hostScanner.volumes }}
 {{ toYaml .Values.hostScanner.volumes | nindent 6 }}
 {{- end }}

--- a/charts/kubescape-cloud-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-cloud-operator/templates/node-agent/daemonset.yaml
@@ -48,6 +48,9 @@ spec:
             items:
               - key: "config.json"
                 path: "config.json"
+        {{- if .Values.volumes }}
+        {{- toYaml .Values.volumes | nindent 8 }}
+        {{- end }}
         {{- range .Values.nodeAgent.volumes }}
         - name: {{ .name }}
         {{- if .configMap }}
@@ -120,6 +123,9 @@ spec:
             mountPath: /etc/config/config.json
             readOnly: true
             subPath: "config.json"
+          {{- if .Values.volumeMounts }}
+          {{- toYaml .Values.volumeMounts | nindent 10 }}
+          {{- end }}
           {{- range .Values.nodeAgent.volumeMounts }}
           - mountPath: {{ .mountPath }}
             name: {{ .name }}


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses the issue of missing global volumes and volumeMounts in the host scanner definition and node agent. The changes ensure that these elements are properly added to the respective components, enhancing the overall functionality and robustness of the system.

___
## PR Main Files Walkthrough:
`charts/kubescape-cloud-operator/assets/host-scanner-definition.yaml`: Added conditional checks to include global volumes and volumeMounts in the host scanner definition. If these values are present, they are now correctly added to the host scanner configuration.
`charts/kubescape-cloud-operator/templates/node-agent/daemonset.yaml`: Similar to the host scanner, global volumes and volumeMounts have been added to the node agent daemonset configuration. This ensures that the node agent has access to the necessary volumes and volumeMounts when required.

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
* Add missing global volumes & volumeMounts to host scanner definition.
* Add missing global volumes & volumeMounts to  node agent.
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
