### PR TITLE
fix relevancy config

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.15.1
+version: 1.15.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.15.1
+appVersion: 1.15.2
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -31,7 +31,7 @@ data:
       "accountID": "{{ .Values.account }}",
       "clusterName": "{{ regexReplaceAll "\\W+" .Values.clusterName "-" }}",
       "storage": {{ $components.storage.enabled }},
-      "relevantImageVulnerabilitiesEnabled": {{ $components.kubevuln.enabled }},
+      "relevantImageVulnerabilitiesEnabled": {{ eq .Values.capabilities.relevancy "enable" }},
       "namespace": "{{ .Values.ksNamespace }}",
       "imageVulnerabilitiesScanningEnabled": {{ $components.kubevuln.enabled }},
       "postureScanEnabled": {{ $components.kubescape.enabled }},


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR fixes the configuration of the `relevantImageVulnerabilitiesEnabled` parameter to be based on the relevancy capability rather than the kubevuln component. It also includes a version bump for the application.

___
## PR Main Files Walkthrough:
`charts/kubescape-operator/Chart.yaml`: The application version and chart version have been incremented from 1.15.1 to 1.15.2.
`charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml`: The `relevantImageVulnerabilitiesEnabled` parameter is now set based on the value of `.Values.capabilities.relevancy` instead of `$components.kubevuln.enabled`.

___
## User Description:
## Overview

The value of `relevantImageVulnerabilitiesEnabled` should be based on the relevancy capability, instead of kubevuln.
