### PR TITLE
remove cloud_provider

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.15.2
+version: 1.15.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.15.2
+appVersion: 1.15.3
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/templates/_helpers.tpl
+++ b/charts/kubescape-operator/templates/_helpers.tpl
@@ -1,15 +1,3 @@
-{{/* standardize cloud provider */}}
-{{- define "cloud_provider" -}}
-  {{- if contains "eks" .Capabilities.KubeVersion.GitVersion -}}
-    {{- print "eks" -}}
-  {{- else if contains "gke" .Capabilities.KubeVersion.GitVersion -}}
-    {{- print "gke" -}}
-  {{- else if contains "azmk8s.io" .Values.clusterServer -}}
-    {{- print "aks" -}}
-  {{- else -}}
-    {{- print "" -}}
-  {{- end }}
-{{- end }}
 
 {{- define "configurations" -}}
 {{- $otel := not (empty .Values.configurations.otelUrl) -}}

--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -40,9 +40,8 @@ data:
       "maxImageSize": {{ .Values.kubevuln.config.maxImageSize }},
       "keepLocal": {{ not $components.serviceDiscovery.enabled }},
       "scanTimeout": "{{ .Values.kubevuln.config.scanTimeout }}",
-      "relevantImageVulnerabilitiesConfiguration": "{{ .Values.capabilities.relevancy }}",
 {{- if .Values.grypeOfflineDB.enabled }}
       "listingURL": "http://{{ .Values.grypeOfflineDB.name }}:80/listing.json",
 {{- end }}
-      "clusterProvider": "{{ include "cloud_provider" . }}"
+      "relevantImageVulnerabilitiesConfiguration": "{{ .Values.capabilities.relevancy }}"
     }

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -1,7 +1,6 @@
 {{- $components := fromYaml (include "components" .) }}
 {{- if $components.kubescape.enabled }}
 {{- $configurations := fromYaml (include "configurations" .) }}
-{{- $cloud_provider := (include "cloud_provider" .) -}}
 {{- $no_proxy_envar_list := (include "no_proxy_envar_list" .) -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -108,23 +107,21 @@ spec:
           value: "/home/nonroot/.kubescape/host-scanner.yaml"
         - name: LARGE_CLUSTER_SIZE
           value: "1500"
-        {{- if $cloud_provider }}
-        - name: KS_CLOUD_PROVIDER
-          value: "{{ $cloud_provider }}"
+        {{- if .Values.cloudProviderMetadata.cloudRegion }}
         - name: KS_CLOUD_REGION
           value: "{{ .Values.cloudProviderMetadata.cloudRegion }}"
-        - name: KS_KUBE_CLUSTER
-          value: "{{ .Values.clusterName }}"
-        {{- if eq "gke" $cloud_provider }}
+        {{- end }}
+        {{- if .Values.cloudProviderMetadata.gkeProject }}
         - name: KS_GKE_PROJECT
           value: "{{ .Values.cloudProviderMetadata.gkeProject }}"
-        {{- end -}}
-        {{- if eq "aks" $cloud_provider }}
+        {{- end }}
+        {{- if .Values.cloudProviderMetadata.aksSubscriptionID }}
         - name: AZURE_SUBSCRIPTION_ID
           value: "{{ .Values.cloudProviderMetadata.aksSubscriptionID }}"
+        {{- end }}
+        {{- if .Values.cloudProviderMetadata.aksResourceGroup }}
         - name: AZURE_RESOURCE_GROUP
           value: "{{ .Values.cloudProviderMetadata.aksResourceGroup }}"
-        {{- end }}
         {{- end }}
         {{- if $components.otelCollector.enabled }}
         - name: ACCOUNT_ID

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -24,9 +24,7 @@ server: api.armosec.io
 # Customer Specific Data
 # account is deliberately not defined here and it should be defined by the user
 # --set clusterName=`kubectl config current-context`
-clusterName: # cluster name must be defined by the user
-# --set clusterServer=`kubectl config view -o jsonpath="{.clusters[?(@.name=='$(kubectl config current-context)')].cluster.server}"`
-clusterServer: ""
+clusterName:  # cluster name must be defined by the user
 
 # -- set the image pull secrets for private registry support
 imagePullSecrets: ""


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR removes the cloud_provider logic from the helm chart of the kubescape-operator. It also includes a version bump for the helm chart from 1.15.2 to 1.15.3. 
The clusterServer value has been removed

___
## PR Main Files Walkthrough:
`charts/kubescape-operator/templates/_helpers.tpl`: The cloud_provider logic has been removed from this file.
`charts/kubescape-operator/Chart.yaml`: The version and appVersion have been updated from 1.15.2 to 1.15.3.
`charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml`: The reference to cloud_provider has been removed from the clusterProvider field.
`charts/kubescape-operator/templates/kubescape/deployment.yaml`: The cloud_provider logic has been removed and replaced with specific cloud provider metadata fields.


