### PR TITLE
add rbac for application profile CRDs

### DIFF
--- a/charts/kubescape-operator/templates/_helpers.tpl
+++ b/charts/kubescape-operator/templates/_helpers.tpl
@@ -5,6 +5,7 @@
 ksOtel: {{ $submit }}
 otel: {{ $otel }}
 otelPort : {{ if $otel }}{{ splitList ":" .Values.configurations.otelUrl | last }}{{ else }}""{{ end }}
+runtimeObservability: {{ eq .Values.capabilities.runtimeObservability "enable" }}
 submit: {{ $submit }}
   {{- if $submit -}}
     {{- if empty .Values.account -}}

--- a/charts/kubescape-operator/templates/node-agent/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/node-agent/clusterrole.yaml
@@ -21,6 +21,6 @@ rules:
   resources: ["sbomspdxv2p3s", "sbomsummaries"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
-  resources: ["sbomspdxv2p3filtereds"]
+  resources: ["sbomspdxv2p3filtereds", "applicationactivities", "applicationprofiles", "applicationprofilesummaries"]
   verbs: ["create", "get", "update", "watch", "list", "patch"]
 {{- end }}

--- a/charts/kubescape-operator/templates/node-agent/configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/configmap.yaml
@@ -1,4 +1,5 @@
 {{- $components := fromYaml (include "components" .) }}
+{{- $configurations := fromYaml (include "configurations" .) }}
 {{- if $components.nodeAgent.enabled }}
 apiVersion: v1
 kind: ConfigMap
@@ -8,6 +9,7 @@ metadata:
 data:
   config.json: |
     {
+        "applicationProfileServiceEnabled": {{ $configurations.runtimeObservability }},
         "relevantCVEServiceEnabled": true,
         "InitialDelay": "{{ .Values.nodeAgent.config.learningPeriod }}",
         "updateDataPeriod": "{{ .Values.nodeAgent.config.updatePeriod }}",

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -58,7 +58,7 @@ matches the snapshot:
     data:
       capabilities: |
         {
-          "capabilities":{"configurationScan":"enable","continuousScan":"disable","nodeScan":"enable","relevancy":"enable","vulnerabilityScan":"enable"},
+          "capabilities":{"configurationScan":"enable","continuousScan":"disable","nodeScan":"enable","relevancy":"enable","runtimeObservability":"disable","vulnerabilityScan":"enable"},
           "components":{"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true}},
           "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable"}
         }
@@ -1490,6 +1490,9 @@ matches the snapshot:
           - spdx.softwarecomposition.kubescape.io
         resources:
           - sbomspdxv2p3filtereds
+          - applicationactivities
+          - applicationprofiles
+          - applicationprofilesummaries
         verbs:
           - create
           - get
@@ -1515,6 +1518,7 @@ matches the snapshot:
     data:
       config.json: |
         {
+            "applicationProfileServiceEnabled": false,
             "relevantCVEServiceEnabled": true,
             "InitialDelay": "2m",
             "updateDataPeriod": "10m",
@@ -1584,7 +1588,7 @@ matches the snapshot:
                 - name: HOST_ROOT
                   value: /host
                 - name: NodeName
-              image: quay.io/kubescape/node-agent:v0.1.103
+              image: quay.io/kubescape/node-agent:v0.1.107
               imagePullPolicy: IfNotPresent
               name: node-agent
               resources:
@@ -2402,7 +2406,7 @@ matches the snapshot:
                   value: 400MiB
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/storage:v0.0.20
+              image: quay.io/kubescape/storage:v0.0.22
               imagePullPolicy: IfNotPresent
               name: apiserver
               resources:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -11,9 +11,9 @@ capabilities:
   continuousScan: disable
   vulnerabilityScan: enable
   nodeScan: enable
+  runtimeObservability: disable
   # networkGenerator: disable
-  # seccomp: disable
-  # runtimeObservability: disable
+  # seccompGenerator: disable
 
 configurations:
   otelUrl: # default is empty
@@ -507,7 +507,7 @@ storage:
   replicaCount: 1
   image:
     repository: quay.io/kubescape/storage
-    tag: v0.0.20
+    tag: v0.0.22
     pullPolicy: IfNotPresent
 
 grypeOfflineDB:
@@ -532,7 +532,7 @@ nodeAgent:
   name: node-agent
   image:
     repository: quay.io/kubescape/node-agent
-    tag: v0.1.103
+    tag: v0.1.107
     pullPolicy: IfNotPresent
 
   config:


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR enhances the Role-Based Access Control (RBAC) for application profile CRDs by adding new resources to the cluster role. It also introduces a new configuration for enabling the application profile service. Additionally, the PR updates the image repositories and tags for the storage and node-agent services to use a different source.

___
## PR Main Files Walkthrough:
`charts/kubescape-operator/templates/_helpers.tpl`: Added a new helper for runtime observability configuration.
`charts/kubescape-cloud-operator/README.md`: Removed the content of the README file, indicating the deprecation of the Kubescape Operator.
`charts/kubescape-operator/templates/node-agent/clusterrole.yaml`: Added new resources ("applicationactivities", "applicationprofiles", "applicationprofilesummaries") to the cluster role for the node-agent.
`charts/kubescape-operator/templates/node-agent/configmap.yaml`: Added a new configuration for enabling the application profile service in the node-agent's configmap.
`charts/kubescape-operator/values.yaml`: Updated the image repositories and tags for the storage and node-agent services. Also, added a new configuration for runtime observability.
