### PR TITLE
Correct versions for Helm chart badges

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -1,6 +1,6 @@
 # Kubescape Operator
 
-![Version: 1.15.3](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.15.3](https://img.shields.io/badge/AppVersion-v1.11.0-informational?style=flat-square)
+![Version: 1.15.3](https://img.shields.io/badge/Version-1.15.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.15.3](https://img.shields.io/badge/AppVersion-v1.15.3-informational?style=flat-square)
 
 ## [Docs](https://hub.armosec.io/docs/installation-of-armo-in-cluster)
 


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR corrects the version numbers displayed in the Helm chart badges of the 'kubescape-operator' README file. The previous version was incorrectly showing as 1.11.0, but it has been updated to the correct version 1.15.3.

___
## PR Main Files Walkthrough:
`charts/kubescape-operator/README.md`: Updated the version numbers in the Helm chart badges from 1.11.0 to 1.15.3.

___
## User Description:
says 1.11
should say 1.15.3

Matthias says its OK
