### PR TITLE
fix runAsUser for kubescape deployment

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.15.3
+version: 1.15.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.15.3
+appVersion: 1.15.4
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -1,6 +1,6 @@
 # Kubescape Operator
 
-![Version: 1.15.3](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.15.3](https://img.shields.io/badge/AppVersion-v1.11.0-informational?style=flat-square)
+![Version: 1.15.4](https://img.shields.io/badge/Version-1.15.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.15.4](https://img.shields.io/badge/AppVersion-v1.15.4-informational?style=flat-square)
 
 ## [Docs](https://hub.armosec.io/docs/installation-of-armo-in-cluster)
 

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -51,17 +51,17 @@ spec:
       imagePullSecrets:
       - name: {{ toYaml .Values.imagePullSecrets }}
       {{- end }}
-      # securityContext:
-      #   runAsUser: 65532
-      #   fsGroup: 65532
+      securityContext:
+        runAsUser: 65532
+        fsGroup: 65532
       containers:
       - name: kubescape
         image: "{{ .Values.kubescape.image.repository }}:{{ .Values.kubescape.image.tag }}"
         imagePullPolicy: "{{ .Values.kubescape.image.pullPolicy }}"
         securityContext:
           allowPrivilegeEscalation: false
-          # readOnlyRootFilesystem: true
-          runAsUser: 0
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         ports:
           - name: http
             containerPort: 8080
@@ -140,6 +140,8 @@ spec:
         resources:
 {{ toYaml .Values.kubescape.resources | indent 14 }}
         volumeMounts:
+        - name: kubescape-volume
+          mountPath: /home/nonroot/.kubescape
         - name: kubescape-config-volume
           mountPath: /home/nonroot/.kubescape/config.json
           subPath: config.json
@@ -186,6 +188,8 @@ spec:
       - name: host-scanner-definition
         configMap:
           name: host-scanner-definition
+      - name: kubescape-volume
+        emptyDir: {}
       - name: results
         emptyDir: {}
       - name: failed

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -594,7 +594,7 @@ matches the snapshot:
                 - configMap:
                     name: kubescape-scheduler
                   name: kubescape-scheduler
-      schedule: 22 10 * * *
+      schedule: 27 14 * * *
   17: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
@@ -1218,7 +1218,7 @@ matches the snapshot:
                 - configMap:
                     name: kubevuln-scheduler
                   name: kubevuln-scheduler
-      schedule: 15 15 * * *
+      schedule: 37 11 * * *
   30: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
@@ -2402,7 +2402,7 @@ matches the snapshot:
                   value: 400MiB
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/storage:v0.0.18
+              image: quay.io/kubescape/storage:v0.0.20
               imagePullPolicy: IfNotPresent
               name: apiserver
               resources:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 matches the snapshot:
   1: |
     raw: |
-      Thank you for installing kubescape-operator version 1.15.1.
+      Thank you for installing kubescape-operator version 1.15.4.
 
       You can see and change the values of your's recurring configurations daily scan in the following link:
       https://cloud.armosec.io/settings/assets/clusters/scheduled-scans?cluster=kind-kind
@@ -36,9 +36,8 @@ matches the snapshot:
           "maxImageSize": 5.36870912e+09,
           "keepLocal": false,
           "scanTimeout": "5m",
-          "relevantImageVulnerabilitiesConfiguration": "enable",
           "listingURL": "http://grype-offline-db:80/listing.json",
-          "clusterProvider": ""
+          "relevantImageVulnerabilitiesConfiguration": "enable"
         }
       metrics: ""
       services: ""
@@ -78,7 +77,7 @@ matches the snapshot:
         app: gateway
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: gateway
-        helm.sh/chart: kubescape-operator-1.15.1
+        helm.sh/chart: kubescape-operator-1.15.4
         tier: ks-control-plane
       name: gateway
       namespace: kubescape
@@ -101,7 +100,7 @@ matches the snapshot:
             app: gateway
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: gateway
-            helm.sh/chart: kubescape-operator-1.15.1
+            helm.sh/chart: kubescape-operator-1.15.4
             helm.sh/revision: "0"
             tier: ks-control-plane
         spec:
@@ -190,7 +189,7 @@ matches the snapshot:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: kubescape-operator-1.15.1
+        helm.sh/chart: kubescape-operator-1.15.4
         tier: ks-control-plane
       name: gateway
       namespace: kubescape
@@ -268,7 +267,7 @@ matches the snapshot:
             app: grype-offline-db
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: grype-offline-db
-            helm.sh/chart: kubescape-operator-1.15.1
+            helm.sh/chart: kubescape-operator-1.15.4
             helm.sh/revision: "0"
             tier: ks-control-plane
         spec:
@@ -445,7 +444,7 @@ matches the snapshot:
             app: kollector
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kollector
-            helm.sh/chart: kubescape-operator-1.15.1
+            helm.sh/chart: kubescape-operator-1.15.4
             helm.sh/revision: "0"
             tier: ks-control-plane
         spec:
@@ -595,7 +594,7 @@ matches the snapshot:
                 - configMap:
                     name: kubescape-scheduler
                   name: kubescape-scheduler
-      schedule: 4 8 * * *
+      schedule: 22 10 * * *
   17: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
@@ -808,7 +807,7 @@ matches the snapshot:
         app: kubescape
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape
-        helm.sh/chart: kubescape-operator-1.15.1
+        helm.sh/chart: kubescape-operator-1.15.4
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -831,7 +830,7 @@ matches the snapshot:
             app: kubescape
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubescape
-            helm.sh/chart: kubescape-operator-1.15.1
+            helm.sh/chart: kubescape-operator-1.15.4
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane
@@ -901,8 +900,11 @@ matches the snapshot:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
-                runAsUser: 0
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
               volumeMounts:
+                - mountPath: /home/nonroot/.kubescape
+                  name: kubescape-volume
                 - mountPath: /home/nonroot/.kubescape/config.json
                   name: kubescape-config-volume
                   subPath: config.json
@@ -919,6 +921,9 @@ matches the snapshot:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+          securityContext:
+            fsGroup: 65532
+            runAsUser: 65532
           serviceAccountName: kubescape
           volumes:
             - name: proxy-secret
@@ -936,6 +941,8 @@ matches the snapshot:
             - configMap:
                 name: host-scanner-definition
               name: host-scanner-definition
+            - emptyDir: {}
+              name: kubescape-volume
             - emptyDir: {}
               name: results
             - emptyDir: {}
@@ -1038,7 +1045,7 @@ matches the snapshot:
     metadata:
       labels:
         app: kubescape
-        helm.sh/chart: kubescape-operator-1.15.1
+        helm.sh/chart: kubescape-operator-1.15.4
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -1130,7 +1137,7 @@ matches the snapshot:
     metadata:
       labels:
         app: kubescape
-        helm.sh/chart: kubescape-operator-1.15.1
+        helm.sh/chart: kubescape-operator-1.15.4
       name: kubescape-monitor
       namespace: kubescape
     spec:
@@ -1211,7 +1218,7 @@ matches the snapshot:
                 - configMap:
                     name: kubevuln-scheduler
                   name: kubevuln-scheduler
-      schedule: 16 3 * * *
+      schedule: 15 15 * * *
   30: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
@@ -1280,7 +1287,7 @@ matches the snapshot:
             app: kubevuln
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubevuln
-            helm.sh/chart: kubescape-operator-1.15.1
+            helm.sh/chart: kubescape-operator-1.15.4
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane
@@ -1541,7 +1548,7 @@ matches the snapshot:
             app: node-agent
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: node-agent
-            helm.sh/chart: kubescape-operator-1.15.1
+            helm.sh/chart: kubescape-operator-1.15.4
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane
@@ -1781,7 +1788,7 @@ matches the snapshot:
             app: operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: operator
-            helm.sh/chart: kubescape-operator-1.15.1
+            helm.sh/chart: kubescape-operator-1.15.4
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane
@@ -2048,7 +2055,7 @@ matches the snapshot:
         app: otel-collector
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: otel-collector
-        helm.sh/chart: kubescape-operator-1.15.1
+        helm.sh/chart: kubescape-operator-1.15.4
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -2071,7 +2078,7 @@ matches the snapshot:
             app: otel-collector
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: otel-collector
-            helm.sh/chart: kubescape-operator-1.15.1
+            helm.sh/chart: kubescape-operator-1.15.4
             helm.sh/revision: "0"
             tier: ks-control-plane
         spec:
@@ -2127,7 +2134,7 @@ matches the snapshot:
     metadata:
       labels:
         app: otel-collector
-        helm.sh/chart: kubescape-operator-1.15.1
+        helm.sh/chart: kubescape-operator-1.15.4
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -2203,7 +2210,7 @@ matches the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: service-discovery
-            helm.sh/chart: kubescape-operator-1.15.1
+            helm.sh/chart: kubescape-operator-1.15.4
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -507,7 +507,7 @@ storage:
   replicaCount: 1
   image:
     repository: quay.io/kubescape/storage
-    tag: v0.0.18
+    tag: v0.0.20
     pullPolicy: IfNotPresent
 
 grypeOfflineDB:


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR updates the Kubescape Operator chart and deployment configuration. It fixes the 'runAsUser' issue in the Kubescape deployment, enabling the security context and setting the 'runAsUser' and 'fsGroup' to 65532. It also sets the container to run as non-root and makes the root filesystem read-only. Additionally, the PR updates the version of the application in the chart and README from 1.15.3 to 1.15.4.

___
## PR Main Files Walkthrough:
`charts/kubescape-operator/Chart.yaml`: The application version and chart version have been updated from 1.15.3 to 1.15.4.
`charts/kubescape-operator/README.md`: The application version and chart version in the README badges have been updated from 1.15.3 to 1.15.4.
`charts/kubescape-operator/templates/kubescape/deployment.yaml`: The security context has been enabled with 'runAsUser' and 'fsGroup' set to 65532. The container is now set to run as non-root and the root filesystem is read-only. Additional volume mounts have been added for 'kubescape-volume' and 'kubescape-config-volume'.
