### PR TITLE
release: bump chart version

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.15.4
+version: 1.15.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.15.4
+appVersion: 1.15.5
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -1,6 +1,6 @@
 # Kubescape Operator
 
-![Version: 1.15.4](https://img.shields.io/badge/Version-1.15.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.15.4](https://img.shields.io/badge/AppVersion-v1.15.4-informational?style=flat-square)
+![Version: 1.15.5](https://img.shields.io/badge/Version-1.15.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.15.5](https://img.shields.io/badge/AppVersion-v1.15.5-informational?style=flat-square)
 
 ## [Docs](https://hub.armosec.io/docs/installation-of-armo-in-cluster)
 

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 matches the snapshot:
   1: |
     raw: |
-      Thank you for installing kubescape-operator version 1.15.4.
+      Thank you for installing kubescape-operator version 1.15.5.
 
       You can see and change the values of your's recurring configurations daily scan in the following link:
       https://cloud.armosec.io/settings/assets/clusters/scheduled-scans?cluster=kind-kind
@@ -77,7 +77,7 @@ matches the snapshot:
         app: gateway
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: gateway
-        helm.sh/chart: kubescape-operator-1.15.4
+        helm.sh/chart: kubescape-operator-1.15.5
         tier: ks-control-plane
       name: gateway
       namespace: kubescape
@@ -100,7 +100,7 @@ matches the snapshot:
             app: gateway
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: gateway
-            helm.sh/chart: kubescape-operator-1.15.4
+            helm.sh/chart: kubescape-operator-1.15.5
             helm.sh/revision: "0"
             tier: ks-control-plane
         spec:
@@ -189,7 +189,7 @@ matches the snapshot:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: kubescape-operator-1.15.4
+        helm.sh/chart: kubescape-operator-1.15.5
         tier: ks-control-plane
       name: gateway
       namespace: kubescape
@@ -267,7 +267,7 @@ matches the snapshot:
             app: grype-offline-db
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: grype-offline-db
-            helm.sh/chart: kubescape-operator-1.15.4
+            helm.sh/chart: kubescape-operator-1.15.5
             helm.sh/revision: "0"
             tier: ks-control-plane
         spec:
@@ -444,7 +444,7 @@ matches the snapshot:
             app: kollector
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kollector
-            helm.sh/chart: kubescape-operator-1.15.4
+            helm.sh/chart: kubescape-operator-1.15.5
             helm.sh/revision: "0"
             tier: ks-control-plane
         spec:
@@ -807,7 +807,7 @@ matches the snapshot:
         app: kubescape
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape
-        helm.sh/chart: kubescape-operator-1.15.4
+        helm.sh/chart: kubescape-operator-1.15.5
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -830,7 +830,7 @@ matches the snapshot:
             app: kubescape
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubescape
-            helm.sh/chart: kubescape-operator-1.15.4
+            helm.sh/chart: kubescape-operator-1.15.5
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane
@@ -1045,7 +1045,7 @@ matches the snapshot:
     metadata:
       labels:
         app: kubescape
-        helm.sh/chart: kubescape-operator-1.15.4
+        helm.sh/chart: kubescape-operator-1.15.5
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -1137,7 +1137,7 @@ matches the snapshot:
     metadata:
       labels:
         app: kubescape
-        helm.sh/chart: kubescape-operator-1.15.4
+        helm.sh/chart: kubescape-operator-1.15.5
       name: kubescape-monitor
       namespace: kubescape
     spec:
@@ -1287,7 +1287,7 @@ matches the snapshot:
             app: kubevuln
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubevuln
-            helm.sh/chart: kubescape-operator-1.15.4
+            helm.sh/chart: kubescape-operator-1.15.5
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane
@@ -1548,7 +1548,7 @@ matches the snapshot:
             app: node-agent
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: node-agent
-            helm.sh/chart: kubescape-operator-1.15.4
+            helm.sh/chart: kubescape-operator-1.15.5
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane
@@ -1788,7 +1788,7 @@ matches the snapshot:
             app: operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: operator
-            helm.sh/chart: kubescape-operator-1.15.4
+            helm.sh/chart: kubescape-operator-1.15.5
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane
@@ -2055,7 +2055,7 @@ matches the snapshot:
         app: otel-collector
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: otel-collector
-        helm.sh/chart: kubescape-operator-1.15.4
+        helm.sh/chart: kubescape-operator-1.15.5
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -2078,7 +2078,7 @@ matches the snapshot:
             app: otel-collector
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: otel-collector
-            helm.sh/chart: kubescape-operator-1.15.4
+            helm.sh/chart: kubescape-operator-1.15.5
             helm.sh/revision: "0"
             tier: ks-control-plane
         spec:
@@ -2134,7 +2134,7 @@ matches the snapshot:
     metadata:
       labels:
         app: otel-collector
-        helm.sh/chart: kubescape-operator-1.15.4
+        helm.sh/chart: kubescape-operator-1.15.5
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -2210,7 +2210,7 @@ matches the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: service-discovery
-            helm.sh/chart: kubescape-operator-1.15.4
+            helm.sh/chart: kubescape-operator-1.15.5
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR updates the version of the Kubescape Operator chart from 1.15.4 to 1.15.5. The changes are reflected in the Chart.yaml and README.md files.

___
## PR Main Files Walkthrough:
`charts/kubescape-operator/Chart.yaml`: Updated the 'version' and 'appVersion' from 1.15.4 to 1.15.5.
`charts/kubescape-operator/README.md`: Updated the version badge from 1.15.4 to 1.15.5.
