### PR TITLE
bump images

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.15.6
+version: 1.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.15.6
+appVersion: 1.16.0
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -1,6 +1,6 @@
 # Kubescape Operator
 
-![Version: 1.15.6](https://img.shields.io/badge/Version-1.15.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.15.6](https://img.shields.io/badge/AppVersion-v1.15.6-informational?style=flat-square)
+![Version: 1.16.0](https://img.shields.io/badge/Version-1.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.16.0](https://img.shields.io/badge/AppVersion-v1.16.0-informational?style=flat-square)
 
 ## [Docs](https://hub.armosec.io/docs/installation-of-armo-in-cluster)
 

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 matches the snapshot:
   1: |
     raw: |
-      Thank you for installing kubescape-operator version 1.15.6.
+      Thank you for installing kubescape-operator version 1.16.0.
 
       You can see and change the values of your's recurring configurations daily scan in the following link:
       https://cloud.armosec.io/settings/assets/clusters/scheduled-scans?cluster=kind-kind
@@ -72,7 +72,7 @@ matches the snapshot:
         app: gateway
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: gateway
-        helm.sh/chart: kubescape-operator-1.15.6
+        helm.sh/chart: kubescape-operator-1.16.0
         tier: ks-control-plane
       name: gateway
       namespace: kubescape
@@ -95,7 +95,7 @@ matches the snapshot:
             app: gateway
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: gateway
-            helm.sh/chart: kubescape-operator-1.15.6
+            helm.sh/chart: kubescape-operator-1.16.0
             helm.sh/revision: "0"
             tier: ks-control-plane
         spec:
@@ -170,7 +170,7 @@ matches the snapshot:
               command:
                 - /bin/sh
                 - -c
-              image: bitnami/kubectl:1.27.5
+              image: bitnami/kubectl:1.27.6
               imagePullPolicy: IfNotPresent
               name: wait-for-cloud-config
           securityContext:
@@ -195,7 +195,7 @@ matches the snapshot:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: kubescape-operator-1.15.6
+        helm.sh/chart: kubescape-operator-1.16.0
         tier: ks-control-plane
       name: gateway
       namespace: kubescape
@@ -309,7 +309,7 @@ matches the snapshot:
             app: grype-offline-db
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: grype-offline-db
-            helm.sh/chart: kubescape-operator-1.15.6
+            helm.sh/chart: kubescape-operator-1.16.0
             helm.sh/revision: "0"
             tier: ks-control-plane
         spec:
@@ -513,7 +513,7 @@ matches the snapshot:
             app: kollector
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kollector
-            helm.sh/chart: kubescape-operator-1.15.6
+            helm.sh/chart: kubescape-operator-1.16.0
             helm.sh/revision: "0"
             tier: ks-control-plane
         spec:
@@ -589,7 +589,7 @@ matches the snapshot:
               command:
                 - /bin/sh
                 - -c
-              image: bitnami/kubectl:1.27.5
+              image: bitnami/kubectl:1.27.6
               imagePullPolicy: IfNotPresent
               name: wait-for-cloud-config
           serviceAccountName: kollector
@@ -886,7 +886,7 @@ matches the snapshot:
         app: kubescape
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape
-        helm.sh/chart: kubescape-operator-1.15.6
+        helm.sh/chart: kubescape-operator-1.16.0
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -909,7 +909,7 @@ matches the snapshot:
             app: kubescape
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubescape
-            helm.sh/chart: kubescape-operator-1.15.6
+            helm.sh/chart: kubescape-operator-1.16.0
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane
@@ -953,7 +953,7 @@ matches the snapshot:
                   value: 9e6c0c2c-6bd0-4919-815b-55030de7c9a0
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/kubescape:v2.9.1
+              image: quay.io/kubescape/kubescape:v2.9.2
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -1009,7 +1009,7 @@ matches the snapshot:
               command:
                 - /bin/sh
                 - -c
-              image: bitnami/kubectl:1.27.5
+              image: bitnami/kubectl:1.27.6
               imagePullPolicy: IfNotPresent
               name: wait-for-cloud-config
           securityContext:
@@ -1136,7 +1136,7 @@ matches the snapshot:
     metadata:
       labels:
         app: kubescape
-        helm.sh/chart: kubescape-operator-1.15.6
+        helm.sh/chart: kubescape-operator-1.16.0
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -1228,7 +1228,7 @@ matches the snapshot:
     metadata:
       labels:
         app: kubescape
-        helm.sh/chart: kubescape-operator-1.15.6
+        helm.sh/chart: kubescape-operator-1.16.0
       name: kubescape-monitor
       namespace: kubescape
     spec:
@@ -1378,7 +1378,7 @@ matches the snapshot:
             app: kubevuln
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubevuln
-            helm.sh/chart: kubescape-operator-1.15.6
+            helm.sh/chart: kubescape-operator-1.16.0
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane
@@ -1404,7 +1404,7 @@ matches the snapshot:
                   value: 9e6c0c2c-6bd0-4919-815b-55030de7c9a0
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/kubevuln:v0.2.113
+              image: quay.io/kubescape/kubevuln:v0.2.116
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -1453,7 +1453,7 @@ matches the snapshot:
               command:
                 - /bin/sh
                 - -c
-              image: bitnami/kubectl:1.27.5
+              image: bitnami/kubectl:1.27.6
               imagePullPolicy: IfNotPresent
               name: wait-for-cloud-config
           securityContext:
@@ -1676,7 +1676,7 @@ matches the snapshot:
             app: node-agent
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: node-agent
-            helm.sh/chart: kubescape-operator-1.15.6
+            helm.sh/chart: kubescape-operator-1.16.0
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane
@@ -1712,7 +1712,7 @@ matches the snapshot:
                 - name: HOST_ROOT
                   value: /host
                 - name: NodeName
-              image: quay.io/kubescape/node-agent:v0.1.103
+              image: quay.io/kubescape/node-agent:v0.1.107
               imagePullPolicy: IfNotPresent
               name: node-agent
               resources:
@@ -1916,7 +1916,7 @@ matches the snapshot:
             app: operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: operator
-            helm.sh/chart: kubescape-operator-1.15.6
+            helm.sh/chart: kubescape-operator-1.16.0
             helm.sh/revision: "0"
             otel: enabled
             tier: ks-control-plane
@@ -1936,7 +1936,7 @@ matches the snapshot:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/operator:v0.1.50
+              image: quay.io/kubescape/operator:v0.1.52
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -2011,7 +2011,7 @@ matches the snapshot:
               command:
                 - /bin/sh
                 - -c
-              image: bitnami/kubectl:1.27.5
+              image: bitnami/kubectl:1.27.6
               imagePullPolicy: IfNotPresent
               name: update-configmap
               volumeMounts:
@@ -2209,7 +2209,7 @@ matches the snapshot:
         app: otel-collector
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: otel-collector
-        helm.sh/chart: kubescape-operator-1.15.6
+        helm.sh/chart: kubescape-operator-1.16.0
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -2232,7 +2232,7 @@ matches the snapshot:
             app: otel-collector
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: otel-collector
-            helm.sh/chart: kubescape-operator-1.15.6
+            helm.sh/chart: kubescape-operator-1.16.0
             helm.sh/revision: "0"
             tier: ks-control-plane
         spec:
@@ -2251,7 +2251,7 @@ matches the snapshot:
                   value: 500MiB
                 - name: GOGC
                   value: "80"
-              image: otel/opentelemetry-collector:0.81.0
+              image: otel/opentelemetry-collector:0.86.0
               imagePullPolicy: IfNotPresent
               name: otel-collector
               ports:
@@ -2282,7 +2282,7 @@ matches the snapshot:
               command:
                 - /bin/sh
                 - -c
-              image: bitnami/kubectl:1.27.5
+              image: bitnami/kubectl:1.27.6
               imagePullPolicy: IfNotPresent
               name: wait-for-cloud-config
           serviceAccountName: otel-collector
@@ -2299,7 +2299,7 @@ matches the snapshot:
     metadata:
       labels:
         app: otel-collector
-        helm.sh/chart: kubescape-operator-1.15.6
+        helm.sh/chart: kubescape-operator-1.16.0
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -2494,7 +2494,7 @@ matches the snapshot:
                   value: 400MiB
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/storage:v0.0.20
+              image: quay.io/kubescape/storage:v0.0.22
               imagePullPolicy: IfNotPresent
               name: apiserver
               resources:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -137,7 +137,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v2.9.1
+    tag: v2.9.2
     pullPolicy: IfNotPresent
 
   resources:
@@ -196,7 +196,7 @@ operator:
   image:
     # -- source code: https://github.com/kubescape/operator
     repository: quay.io/kubescape/operator
-    tag: v0.1.50
+    tag: v0.1.52
     pullPolicy: IfNotPresent
 
   service:
@@ -273,7 +273,7 @@ kubevuln:
   image:
     # -- source code: https://github.com/kubescape/kubevuln
     repository: quay.io/kubescape/kubevuln
-    tag: v0.2.113
+    tag: v0.2.116
     pullPolicy: IfNotPresent
 
   replicaCount: 1
@@ -472,7 +472,7 @@ otelCollector:
 
   image:
     repository: otel/opentelemetry-collector
-    tag: 0.81.0
+    tag: 0.86.0
     pullPolicy: IfNotPresent
 
   replicaCount: 1
@@ -508,7 +508,7 @@ storage:
   replicaCount: 1
   image:
     repository: quay.io/kubescape/storage
-    tag: v0.0.20
+    tag: v0.0.22
     pullPolicy: IfNotPresent
 
 grypeOfflineDB:
@@ -533,7 +533,7 @@ nodeAgent:
   name: node-agent
   image:
     repository: quay.io/kubescape/node-agent
-    tag: v0.1.103
+    tag: v0.1.107
     pullPolicy: IfNotPresent
 
   config:
@@ -631,12 +631,12 @@ serviceDiscovery:
     name: check-url-configmap
     image:
       repository: bitnami/kubectl
-      tag: 1.27.5
+      tag: 1.27.6
       pullPolicy: IfNotPresent
 
   configMapUpdate:
     name: update-configmap
     image:
       repository: bitnami/kubectl
-      tag: 1.27.5
+      tag: 1.27.6
       pullPolicy: IfNotPresent


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR updates the Kubescape Operator chart and images. It includes version bumps for the chart, app, and various images used within the chart. The changes aim to keep the application up-to-date with the latest versions.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`charts/kubescape-operator/Chart.yaml`: The chart and app versions have been updated from 1.15.6 to 1.16.0.
`charts/kubescape-operator/README.md`: The version badges in the README have been updated to reflect the new version, 1.16.0.
`charts/kubescape-operator/values.yaml`: The image tags for kubescape, operator, kubevuln, otelCollector, storage, nodeAgent, and serviceDiscovery have been updated to their respective newer versions.
</details>
