### PR TITLE
feat: add the automatic upgrading capability

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -678,3 +678,56 @@ classDef plain fill:#ddd,stroke:#fff,stroke-width:1px,color:#000
 class k8sApi k8s
 class pr plain
 ```
+
+# Automatic Release Upgrade
+
+The Helm chart provides a capability to automatically fetch the latest chart version and upgrade the installed release.
+
+## How to Use
+
+To enable this capability, simply simply set the `capabilities.autoUpgrading` to `enable` and configure how often you would like to check for updates by adjusting the cron schedule:
+
+```yaml
+capabilities:
+  autoUpgrading: enable
+
+# [Omitted for brevity...]
+
+autoUpgrader:
+  schedule: "0 14 * * *"  # Check for updates every day at 14:00
+```
+
+Helm will then install the Kubescape Helm Release Upgrader CronJob and its supporting resources.
+They will keep your Kubescape release up to date.
+
+> [!WARNING]
+> Due to how Helm works, the Helm Release Upgrader requires highly elevated RBAC permissions and leaves orphaned resources even after you uninstall the Kubescape release.
+
+## How it Works
+
+The Auto Upgrading capability is experimental.
+
+It works as follows:
+- Creates a cluster admin ClusterRole, ClusterRoleBinding and ServiceAccount to have all the permissions necessary to create resources with Helm.
+- Creates a CronJob that updates the local Kubescape Helm repo (`helm repo update`) to fetch the latest chart versions and upgrades the Helm release accordingly (`helm upgrade`).
+- To account for Helm removing and re-creating the release resources during `helm upgrade`, it keeps the RBAC definitions and the CronJob in the cluster with `"helm.sh/resource-policy": keep`.
+
+This means:
+- The upgrader runs in a very priviledged RBAC context: it can create resources, list Secrets etc.
+- Even after you remove the Kubescape release with `helm -n kubescape uninstall kubescape`, it will still keep the highly priviledged RBACs and CronJob in your cluster.
+
+While the CronJob runs in a non-root security context and you can clean up the leftover resources on your own, please evaluate the risks the Release Upgrader introduces against your security needs and threat model.
+
+
+## How to Clean Up
+
+To clean up the resources left by the Release Upgrader, run the following command:
+
+```
+kubectl -n kubescape delete clusterrolebinding/helm-release-upgrader \
+    clusterrole/helm-release-upgrader \
+    serviceaccount/helm-release-upgrader \
+    cj/helm-release-upgrader
+```
+
+Once it finishes, you should have no traces of the Release Upgrader in your cluster.

--- a/charts/kubescape-operator/templates/autoupdater/cronjob.yaml
+++ b/charts/kubescape-operator/templates/autoupdater/cronjob.yaml
@@ -1,0 +1,46 @@
+{{- if eq .Values.capabilities.autoUpgrading "enable" }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Values.helmReleaseUpgrader.name }}
+  namespace: {{ .Values.ksNamespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  schedule: {{ .Values.helmReleaseUpgrader.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Values.helmReleaseUpgrader.name }}
+          securityContext:
+            runAsNonRoot: true
+            # User and Group IDs as defined in the Helm Release Upgrader image
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          volumes:
+            - name: "helm-scratch-data"
+              emptyDir:
+                sizeLimit: 500Mi
+          containers:
+          - name: {{ .Values.helmReleaseUpgrader.name }}
+            image: {{ printf "%s:%s" .Values.helmReleaseUpgrader.image.repository .Values.helmReleaseUpgrader.image.tag  | quote }}
+            imagePullPolicy: {{ .Values.helmReleaseUpgrader.image.pullPolicy | quote }}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+            volumeMounts:
+              - name: "helm-scratch-data"
+                mountPath: /data/helm-scratch-data
+            env:
+              - name: "HELM_CACHE_HOME"
+                value: "/data/helm-scratch-data/.cache"
+              - name: "HELM_CONFIG_HOME"
+                value: "/data/helm-scratch-data/.config"
+              - name: "HELM_DATA_HOME"
+                value: "/data/helm-scratch-data/.data"
+            resources:
+{{ toYaml .Values.helmReleaseUpgrader.resources | indent 14 }}
+          restartPolicy: OnFailure
+{{ end }}

--- a/charts/kubescape-operator/templates/autoupdater/rbac.yaml
+++ b/charts/kubescape-operator/templates/autoupdater/rbac.yaml
@@ -1,0 +1,27 @@
+{{- if eq .Values.capabilities.autoUpgrading "enable" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.helmReleaseUpgrader.name }}
+  annotations:
+    "helm.sh/resource-policy": keep
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.helmReleaseUpgrader.name }}
+  annotations:
+    "helm.sh/resource-policy": keep
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.helmReleaseUpgrader.name }}
+  namespace: {{ .Values.ksNamespace }}
+roleRef:
+  apiGroup: "rbac.authorization.k8s.io"
+  kind: ClusterRole
+  name: {{ .Values.helmReleaseUpgrader.name }}
+{{ end }}

--- a/charts/kubescape-operator/templates/autoupdater/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/autoupdater/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if eq .Values.capabilities.autoUpgrading "enable" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Values.ksNamespace }}
+  name: {{ .Values.helmReleaseUpgrader.name }}
+  annotations:
+    "helm.sh/resource-policy": keep
+{{ end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -13,6 +13,92 @@ matches the snapshot:
 
       See you!!!
   2: |
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      annotations:
+        helm.sh/resource-policy: keep
+      name: helm-release-upgrader
+      namespace: kubescape
+    spec:
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+                - env:
+                    - name: HELM_CACHE_HOME
+                      value: /data/helm-scratch-data/.cache
+                    - name: HELM_CONFIG_HOME
+                      value: /data/helm-scratch-data/.config
+                    - name: HELM_DATA_HOME
+                      value: /data/helm-scratch-data/.data
+                  image: quay.io/kubescape/helm-release-upgrader:v0.1.0
+                  imagePullPolicy: IfNotPresent
+                  name: helm-release-upgrader
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 256Mi
+                    requests:
+                      cpu: 500m
+                      memory: 256Mi
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: true
+                  volumeMounts:
+                    - mountPath: /data/helm-scratch-data
+                      name: helm-scratch-data
+              restartPolicy: OnFailure
+              securityContext:
+                fsGroup: 1000
+                runAsGroup: 1000
+                runAsNonRoot: true
+                runAsUser: 1000
+              serviceAccountName: helm-release-upgrader
+              volumes:
+                - emptyDir:
+                    sizeLimit: 500Mi
+                  name: helm-scratch-data
+      schedule: 0 14 * * *
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations:
+        helm.sh/resource-policy: keep
+      name: helm-release-upgrader
+    rules:
+      - apiGroups:
+          - '*'
+        resources:
+          - '*'
+        verbs:
+          - '*'
+  4: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations:
+        helm.sh/resource-policy: keep
+      name: helm-release-upgrader
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: helm-release-upgrader
+    subjects:
+      - kind: ServiceAccount
+        name: helm-release-upgrader
+        namespace: kubescape
+  5: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations:
+        helm.sh/resource-policy: keep
+      name: helm-release-upgrader
+      namespace: kubescape
+  6: |
     apiVersion: v1
     data:
       clusterData: |
@@ -55,12 +141,12 @@ matches the snapshot:
         tier: ks-control-plane
       name: ks-cloud-config
       namespace: kubescape
-  3: |
+  7: |
     apiVersion: v1
     data:
       capabilities: |
         {
-          "capabilities":{"configurationScan":"enable","continuousScan":"disable","nodeScan":"enable","relevancy":"enable","runtimeObservability":"disable","vulnerabilityScan":"enable"},
+          "capabilities":{"autoUpgrading":"enable","configurationScan":"enable","continuousScan":"disable","nodeScan":"enable","relevancy":"enable","runtimeObservability":"disable","vulnerabilityScan":"enable"},
           "components":{"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true}},
           "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable"}
         }
@@ -71,7 +157,7 @@ matches the snapshot:
         tier: ks-control-plane
       name: ks-capabilities
       namespace: kubescape
-  4: |
+  8: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -185,7 +271,7 @@ matches the snapshot:
                     path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  5: |
+  9: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -218,7 +304,7 @@ matches the snapshot:
       policyTypes:
         - Ingress
         - Egress
-  6: |
+  10: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -239,7 +325,7 @@ matches the snapshot:
       selector:
         app: gateway
       type: ClusterIP
-  7: |
+  11: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -290,7 +376,7 @@ matches the snapshot:
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true
-  8: |
+  12: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -317,7 +403,7 @@ matches the snapshot:
           tier: ks-control-plane
       policyTypes:
         - Ingress
-  9: |
+  13: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -333,7 +419,7 @@ matches the snapshot:
       selector:
         app: grype-offline-db
       type: ClusterIP
-  10: |
+  14: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -372,7 +458,7 @@ matches the snapshot:
           - get
           - watch
           - list
-  11: |
+  15: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -385,7 +471,7 @@ matches the snapshot:
       - kind: ServiceAccount
         name: kollector
         namespace: kubescape
-  12: |
+  16: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -412,7 +498,7 @@ matches the snapshot:
           tier: ks-control-plane
       policyTypes:
         - Egress
-  13: |
+  17: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -421,7 +507,7 @@ matches the snapshot:
         app: kollector
       name: kollector
       namespace: kubescape
-  14: |
+  18: |
     apiVersion: apps/v1
     kind: StatefulSet
     metadata:
@@ -530,7 +616,7 @@ matches the snapshot:
                     path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  15: |
+  19: |
     apiVersion: v1
     data:
       request-body.json: '{"commands":[{"CommandName":"kubescapeScan","args":{"scanV1": {}}}]}'
@@ -541,7 +627,7 @@ matches the snapshot:
         tier: ks-control-plane
       name: kubescape-scheduler
       namespace: kubescape
-  16: |
+  20: |
     apiVersion: batch/v1
     kind: CronJob
     metadata:
@@ -597,7 +683,7 @@ matches the snapshot:
                     name: kubescape-scheduler
                   name: kubescape-scheduler
       schedule: 1 2 3 4 5
-  17: |
+  21: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -773,7 +859,7 @@ matches the snapshot:
           - create
           - update
           - patch
-  18: |
+  22: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -786,7 +872,7 @@ matches the snapshot:
       - kind: ServiceAccount
         name: kubescape
         namespace: kubescape
-  19: |
+  23: |
     apiVersion: v1
     data:
       config.json: |
@@ -802,7 +888,7 @@ matches the snapshot:
         tier: ks-control-plane
       name: kubescape-config
       namespace: kubescape
-  20: |
+  24: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -952,7 +1038,7 @@ matches the snapshot:
               name: results
             - emptyDir: {}
               name: failed
-  21: |
+  25: |
     apiVersion: v1
     data:
       host-scanner-yaml: |-
@@ -1044,7 +1130,7 @@ matches the snapshot:
         tier: ks-control-plane
       name: host-scanner-definition
       namespace: kubescape
-  22: |
+  26: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -1077,7 +1163,7 @@ matches the snapshot:
       policyTypes:
         - Ingress
         - Egress
-  23: |
+  27: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -1096,7 +1182,7 @@ matches the snapshot:
           - list
           - patch
           - delete
-  24: |
+  28: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -1110,7 +1196,7 @@ matches the snapshot:
       - kind: ServiceAccount
         name: kubescape
         namespace: kubescape
-  25: |
+  29: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -1127,7 +1213,7 @@ matches the snapshot:
       selector:
         app: kubescape
       type: ClusterIP
-  26: |
+  30: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -1136,7 +1222,7 @@ matches the snapshot:
         app: kubescape
       name: kubescape
       namespace: kubescape
-  27: |
+  31: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -1157,7 +1243,7 @@ matches the snapshot:
       selector:
         matchLabels:
           app: kubescape
-  28: |
+  32: |
     apiVersion: v1
     data:
       request-body.json: '{"commands":[{"commandName":"scan","designators":[{"designatorType":"Attributes","attributes":{}}]}]}'
@@ -1168,7 +1254,7 @@ matches the snapshot:
         tier: ks-control-plane
       name: kubevuln-scheduler
       namespace: kubescape
-  29: |
+  33: |
     apiVersion: batch/v1
     kind: CronJob
     metadata:
@@ -1224,7 +1310,7 @@ matches the snapshot:
                     name: kubevuln-scheduler
                   name: kubevuln-scheduler
       schedule: 1 2 3 4 5
-  30: |
+  34: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -1252,7 +1338,7 @@ matches the snapshot:
           - get
           - watch
           - list
-  31: |
+  35: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -1265,7 +1351,7 @@ matches the snapshot:
       - kind: ServiceAccount
         name: kubevuln
         namespace: kubescape
-  32: |
+  36: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -1382,7 +1468,7 @@ matches the snapshot:
               name: ks-cloud-config
             - emptyDir: {}
               name: grype-db
-  33: |
+  37: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -1414,7 +1500,7 @@ matches the snapshot:
       policyTypes:
         - Ingress
         - Egress
-  34: |
+  38: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -1430,7 +1516,7 @@ matches the snapshot:
       selector:
         app: kubevuln
       type: ClusterIP
-  35: |
+  39: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -1439,7 +1525,7 @@ matches the snapshot:
         app: kubevuln
       name: kubevuln
       namespace: kubescape
-  36: |
+  40: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -1505,7 +1591,7 @@ matches the snapshot:
           - watch
           - list
           - patch
-  37: |
+  41: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -1518,7 +1604,7 @@ matches the snapshot:
       - kind: ServiceAccount
         name: node-agent
         namespace: kubescape
-  38: |
+  42: |
     apiVersion: v1
     data:
       config.json: |
@@ -1533,7 +1619,7 @@ matches the snapshot:
     metadata:
       name: node-agent
       namespace: kubescape
-  39: |
+  43: |
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
@@ -1683,13 +1769,13 @@ matches the snapshot:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
-  40: |
+  44: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
       name: node-agent
       namespace: kubescape
-  41: |
+  45: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -1742,7 +1828,7 @@ matches the snapshot:
           - watch
           - list
           - delete
-  42: |
+  46: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -1755,7 +1841,7 @@ matches the snapshot:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  43: |
+  47: |
     apiVersion: v1
     data:
       config.json: |
@@ -1767,7 +1853,7 @@ matches the snapshot:
     metadata:
       name: operator
       namespace: kubescape
-  44: |
+  48: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -1902,7 +1988,7 @@ matches the snapshot:
                     path: config.json
                 name: operator
               name: config
-  45: |
+  49: |
     apiVersion: v1
     data:
       cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
@@ -1913,7 +1999,7 @@ matches the snapshot:
         tier: ks-control-plane
       name: kubescape-cronjob-template
       namespace: kubescape
-  46: |
+  50: |
     apiVersion: v1
     data:
       cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
@@ -1924,7 +2010,7 @@ matches the snapshot:
         tier: ks-control-plane
       name: kubevuln-cronjob-template
       namespace: kubescape
-  47: |
+  51: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -1963,7 +2049,7 @@ matches the snapshot:
       policyTypes:
         - Ingress
         - Egress
-  48: |
+  52: |
     apiVersion: v1
     data:
       cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
@@ -1974,7 +2060,7 @@ matches the snapshot:
         tier: ks-control-plane
       name: registry-scan-cronjob-template
       namespace: kubescape
-  49: |
+  53: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -2006,7 +2092,7 @@ matches the snapshot:
           - list
           - patch
           - delete
-  50: |
+  54: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -2020,7 +2106,7 @@ matches the snapshot:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  51: |
+  55: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -2036,7 +2122,7 @@ matches the snapshot:
       selector:
         app: operator
       type: ClusterIP
-  52: |
+  56: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -2045,7 +2131,7 @@ matches the snapshot:
         app: operator
       name: operator
       namespace: kubescape
-  53: |
+  57: |
     apiVersion: v1
     data:
       otel-collector-config.yaml: "\n# receivers configure how data gets into the Collector.\nreceivers:\n  otlp:\n    protocols:\n      grpc:\n      http:\n  hostmetrics:\n    collection_interval: 30s\n    scrapers:\n      cpu:\n      memory:\n\n# processors specify what happens with the received data.\nprocessors:\n  attributes/ksCloud:\n    actions:\n      - key: account_id\n        value: \"9e6c0c2c-6bd0-4919-815b-55030de7c9a0\"\n        action: upsert\n      - key: cluster_name\n        value: \"kind-kind\"\n        action: upsert\n  batch:\n    send_batch_size: 10000\n    timeout: 10s\n\n# exporters configure how to send processed data to one or more backends.\nexporters:\n  otlp/ksCloud:\n    endpoint: ${env:CLOUD_OTEL_COLLECTOR_URL}\n    tls:\n      insecure: false\n  otlp:\n    endpoint: \"otelCollector:4317\"\n    tls:\n      insecure: true\n    headers:\n      uptrace-dsn: \n\n# service pulls the configured receivers, processors, and exporters together into\n# processing pipelines. Unused receivers/processors/exporters are ignored.\nservice:\n  pipelines:\n    traces:\n      receivers: [otlp]\n      processors: [batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp\n    metrics/2:\n      receivers: [hostmetrics]\n      processors: [attributes/ksCloud, batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp\n    metrics:\n      receivers: [otlp]\n      processors: [batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp\n    logs:\n      receivers: [otlp]\n      processors: [batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp"
@@ -2056,7 +2142,7 @@ matches the snapshot:
         tier: ks-control-plane
       name: otel-collector-config
       namespace: kubescape
-  54: |
+  58: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -2137,7 +2223,7 @@ matches the snapshot:
             - configMap:
                 name: otel-collector-config
               name: otel-collector-config-volume
-  55: |
+  59: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -2170,7 +2256,7 @@ matches the snapshot:
       policyTypes:
         - Ingress
         - Egress
-  56: |
+  60: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -2187,7 +2273,7 @@ matches the snapshot:
       selector:
         app: otel-collector
       type: ClusterIP
-  57: |
+  61: |
     apiVersion: v1
     data:
       proxy.crt: foo
@@ -2196,7 +2282,7 @@ matches the snapshot:
       name: kubescape-proxy-certificate
       namespace: kubescape
     type: Opaque
-  58: |
+  62: |
     apiVersion: batch/v1
     kind: Job
     metadata:
@@ -2257,7 +2343,7 @@ matches the snapshot:
           volumes:
             - emptyDir: {}
               name: shared-data
-  59: |
+  63: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -2278,7 +2364,7 @@ matches the snapshot:
           - patch
           - get
           - list
-  60: |
+  64: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -2295,7 +2381,7 @@ matches the snapshot:
       - kind: ServiceAccount
         name: service-discovery
         namespace: kubescape
-  61: |
+  65: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -2305,7 +2391,7 @@ matches the snapshot:
         helm.sh/hook-weight: "0"
       name: service-discovery
       namespace: kubescape
-  62: |
+  66: |
     apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
@@ -2319,7 +2405,7 @@ matches the snapshot:
         namespace: kubescape
       version: v1beta1
       versionPriority: 15
-  63: |
+  67: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -2351,7 +2437,7 @@ matches the snapshot:
           - get
           - watch
           - list
-  64: |
+  68: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2364,7 +2450,7 @@ matches the snapshot:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  65: |
+  69: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2377,7 +2463,7 @@ matches the snapshot:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  66: |
+  70: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -2459,7 +2545,7 @@ matches the snapshot:
                     path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  67: |
+  71: |
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
@@ -2475,7 +2561,7 @@ matches the snapshot:
       resources:
         requests:
           storage: 5Gi
-  68: |
+  72: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -2489,7 +2575,7 @@ matches the snapshot:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  69: |
+  73: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -2504,7 +2590,7 @@ matches the snapshot:
         app.kubernetes.io/component: apiserver
         app.kubernetes.io/name: storage
         app.kubernetes.io/part-of: kubescape-storage
-  70: |
+  74: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -8,7 +8,9 @@ tests:
         - batch/v1/CronJob
     set:
       account: 9e6c0c2c-6bd0-4919-815b-55030de7c9a0
-      capabilities.relevancy: enable
+      capabilities:
+        relevancy: enable
+        autoUpgrading: enable
       server: api.armosec.io
       configurations.otelUrl: "otelCollector:4317"
       clusterName: kind-kind

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -12,6 +12,9 @@ capabilities:
   vulnerabilityScan: enable
   nodeScan: enable
   runtimeObservability: disable
+  # This is an experimental capability with an elevated security risk. Read the
+  # matching README section before enabling.
+  autoUpgrading: disable
   # networkGenerator: disable
   # seccompGenerator: disable
 
@@ -640,3 +643,33 @@ serviceDiscovery:
       repository: bitnami/kubectl
       tag: 1.27.6
       pullPolicy: IfNotPresent
+
+# Configures the Helm Release Upgrader
+helmReleaseUpgrader:
+  name: "helm-release-upgrader"
+  image:
+    repository: "quay.io/kubescape/helm-release-upgrader"
+    tag: "v0.1.0"
+    pullPolicy: "IfNotPresent"
+
+  # A cron schedule of how often the updating CronJob should run
+  schedule: "0 14 * * *"
+
+  # Resource requests and limits for the CronJob
+  resources:
+    # Requests and Limits are the same to make the CronJob Burstable
+    requests:
+      # Setting a higher CPU request helps with the Job runtime. If you don’t
+      # care about job execution speed and want to save on resources, feel free
+      # to lower this
+      cpu: 500m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      # Keep the memory limit sufficiently high.
+      #
+      # The updating CronJob runs an image that runs `helm upgrade`. It renders
+      # the chart and that can require a lot of memory. If you don’t want your
+      # updating job to be OOM Killed, keep this at 256 MiB or higher depending
+      # on the size of your cluster.
+      memory: 256Mi


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

This PR adds the automatic upgrading capability. It’s an experimental feature that checks for the Kubescape Helm chart updates in the background and upgrades the Kubescape release accordingly.

Since it comes with an elevated security risk, users should make sure to read the associated README changes before they decide to use it.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

## How to Test

Run the following command to install the Helm chart with the Helm Release Upgrader enabled:
```
helm upgrade --install kubescape ./charts/kubescape-operator/ -n kubescape --create-namespace \
  --set clusterName=`kubectl config current-context` \
  --set account=YOUR_ACCOUNT_ID \
  --set server=api.armosec.io \
  --set capabilities.autoUpgrading="enable"
```

Then take a look at your Kubescape release revsions with:
```
helm -n kubescape list
```

You should see the release number increasing.

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->