### PR TITLE
added label to configmaps

### DIFF
--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: {{ .Values.global.cloudConfig }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/infra: config
   {{- if $components.serviceDiscovery.enabled }}
   annotations:
     "argocd.argoproj.io/sync-options": Delete=false

--- a/charts/kubescape-operator/templates/kubescape/configmap.yaml
+++ b/charts/kubescape-operator/templates/kubescape/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app: {{ .Values.kubescape.name }}-config
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/infra: kubescape-config
 data:
   config.json: |
     {

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -51,6 +51,7 @@ matches the snapshot:
         helm.sh/resource-policy: keep
       labels:
         app: ks-cloud-config
+        kubescape.io/infra: config
         tier: ks-control-plane
       name: ks-cloud-config
       namespace: kubescape
@@ -797,6 +798,7 @@ matches the snapshot:
     metadata:
       labels:
         app: kubescape-config
+        kubescape.io/infra: kubescape-config
         tier: ks-control-plane
       name: kubescape-config
       namespace: kubescape


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR enhances the labeling of ConfigMaps in the Kubescape Operator. It introduces a new label `kubescape.io/infra` to the `cloudapi-configmap.yaml` and `kubescape/configmap.yaml` files. This label helps in better identification and management of ConfigMaps.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml`: Added a new label `kubescape.io/infra: config` to the metadata of the ConfigMap.
`charts/kubescape-operator/templates/kubescape/configmap.yaml`: Added a new label `kubescape.io/infra: kubescape-config` to the metadata of the ConfigMap.
</details>

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
