### PR TITLE
Removing privileged flag on the node-agent Pod

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -114,6 +114,7 @@ spec:
             {{- end }}
           securityContext:
             runAsUser: 0
+            privileged: {{ .Values.nodeAgent.privileged }}
             capabilities:
               add:
                 - SYS_ADMIN

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -19,6 +19,8 @@ spec:
       tier: {{ .Values.global.namespaceTier }}
   template:
     metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
       labels:
         app.kubernetes.io/name: {{ .Values.nodeAgent.name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -112,7 +114,6 @@ spec:
             {{- end }}
           securityContext:
             runAsUser: 0
-            privileged: {{ .Values.nodeAgent.privileged }}
             capabilities:
               add:
                 - SYS_ADMIN

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -112,10 +112,18 @@ spec:
             {{- end }}
           securityContext:
             runAsUser: 0
-            privileged: true
+            privileged: {{ .Values.nodeAgent.privileged }}
             capabilities:
               add:
                 - SYS_ADMIN
+                - SYS_PTRACE
+                - BPF
+                - PERFMON
+                - NET_ADMIN
+                - SYSLOG
+                - SYS_RESOURCE
+                - IPC_LOCK
+                - NET_RAW
           volumeMounts:
           - name: {{ .Values.global.cloudConfig }}
             mountPath: /etc/config/clusterData.json

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1720,6 +1720,7 @@ matches the snapshot:
                     - SYS_RESOURCE
                     - IPC_LOCK
                     - NET_RAW
+                privileged: false
                 runAsUser: 0
               volumeMounts:
                 - mountPath: /etc/config/clusterData.json

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1655,6 +1655,8 @@ matches the snapshot:
           tier: ks-control-plane
       template:
         metadata:
+          annotations:
+            container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             alt-name: node-agent
             app: node-agent

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1709,7 +1709,6 @@ matches the snapshot:
                   cpu: 100m
                   memory: 180Mi
               securityContext:
-                privileged: false
                 capabilities:
                   add:
                     - SYS_ADMIN

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1709,6 +1709,7 @@ matches the snapshot:
                   cpu: 100m
                   memory: 180Mi
               securityContext:
+                privileged: false
                 capabilities:
                   add:
                     - SYS_ADMIN

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1710,7 +1710,14 @@ matches the snapshot:
                 capabilities:
                   add:
                     - SYS_ADMIN
-                privileged: true
+                    - SYS_PTRACE
+                    - BPF
+                    - PERFMON
+                    - NET_ADMIN
+                    - SYSLOG
+                    - SYS_RESOURCE
+                    - IPC_LOCK
+                    - NET_RAW
                 runAsUser: 0
               volumeMounts:
                 - mountPath: /etc/config/clusterData.json

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -559,6 +559,8 @@ nodeAgent:
         fieldRef:
           fieldPath: spec.nodeName
 
+  privileged: true
+
   volumeMounts:
     - mountPath: /host
       name: host
@@ -596,6 +598,7 @@ nodeAgent:
       name: debugfs
     - emptyDir:
       name: data
+
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -559,8 +559,6 @@ nodeAgent:
         fieldRef:
           fieldPath: spec.nodeName
 
-  privileged: true
-
   volumeMounts:
     - mountPath: /host
       name: host

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -559,6 +559,8 @@ nodeAgent:
         fieldRef:
           fieldPath: spec.nodeName
 
+  privileged: false
+
   volumeMounts:
     - mountPath: /host
       name: host


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR removes the `privileged: true` flag from the node-agent pod and adds specific capabilities to the security context of the pod. It also adds an annotation to allow the node-agent to run on kernels with AppArmor. The changes are based on similar modifications in the Inspektor Gadget project and have been tested on Ubuntu (minikube) and GCP with Linux 5.15.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`charts/kubescape-operator/templates/node-agent/daemonset.yaml`: Removed the `privileged: true` flag from the security context of the node-agent pod and added specific capabilities. Also added an annotation to allow the node-agent to run on kernels with AppArmor.
`charts/kubescape-operator/values.yaml`: No significant changes, just a minor formatting adjustment.
</details>

___
## User Description:
## Overview

As per popular request I am removing the `privileged: true` flag on the node-agent.

It is based on [this](https://github.com/inspektor-gadget/inspektor-gadget/pull/348) PR and [this](https://github.com/inspektor-gadget/inspektor-gadget/commit/deeee9ea2c362c4c94a55bc07251ec1d828057dd) commit in inspektor gadget.

It was tested on Ubuntu (minikube) and GCP with Linux 5.15
