### PR TITLE
Adding Vex support in the helm-chart

### DIFF
--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -41,6 +41,7 @@ data:
       "maxImageSize": {{ .Values.kubevuln.config.maxImageSize }},
       "keepLocal": {{ not $components.serviceDiscovery.enabled }},
       "scanTimeout": "{{ .Values.kubevuln.config.scanTimeout }}",
+      "vexGeneration": "{{ .Values.kubevuln.config.vexGeneration }}",
       "continuousPostureScan": {{ and (eq .Values.capabilities.continuousScan "enable") ($components.storage.enabled) }},
 {{- if .Values.grypeOfflineDB.enabled }}
       "listingURL": "http://{{ .Values.grypeOfflineDB.name }}:80/listing.json",

--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -41,7 +41,7 @@ data:
       "maxImageSize": {{ .Values.kubevuln.config.maxImageSize }},
       "keepLocal": {{ not $components.serviceDiscovery.enabled }},
       "scanTimeout": "{{ .Values.kubevuln.config.scanTimeout }}",
-      "vexGeneration": "{{ .Values.kubevuln.config.vexGeneration }}",
+      "vexGeneration": {{ .Values.kubevuln.config.vexGeneration }},
       "continuousPostureScan": {{ and (eq .Values.capabilities.continuousScan "enable") ($components.storage.enabled) }},
 {{- if .Values.grypeOfflineDB.enabled }}
       "listingURL": "http://{{ .Values.grypeOfflineDB.name }}:80/listing.json",

--- a/charts/kubescape-operator/templates/kubevuln/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ .Values.kubevuln.name }}
 rules:
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
-    resources: ["vulnerabilitymanifests", "vulnerabilitymanifestsummaries", "sbomsummaries", "sbomspdxv2p3s"]
+    resources: ["vulnerabilitymanifests", "vulnerabilitymanifestsummaries", "sbomsummaries", "sbomspdxv2p3s","openvulnerabilityexchangecontainers"]
     verbs: ["create", "get", "update", "watch", "list", "patch"]
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
     resources: ["sbomspdxv2p3filtereds"]

--- a/charts/kubescape-operator/templates/operator/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/operator/clusterrole.yaml
@@ -15,6 +15,6 @@ rules:
     resources: ["deployments", "daemonsets", "statefulsets", "replicasets"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
-    resources: ["sbomspdxv2p3s", "sbomspdxv2p3filtereds", "vulnerabilitymanifests", "sbomsummaries", "vulnerabilitymanifestsummaries", "workloadconfigurationscans", "workloadconfigurationscansummaries"]
+    resources: ["sbomspdxv2p3s", "sbomspdxv2p3filtereds", "vulnerabilitymanifests", "sbomsummaries", "vulnerabilitymanifestsummaries", "workloadconfigurationscans", "workloadconfigurationscansummaries","openvulnerabilityexchangecontainers"]
     verbs: ["get", "watch", "list", "delete"]
 {{- end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -135,6 +135,7 @@ matches the snapshot:
           "maxImageSize": 5.36870912e+09,
           "keepLocal": false,
           "scanTimeout": "5m",
+          "vexGeneration": false,
           "continuousPostureScan": false,
           "listingURL": "http://grype-offline-db:80/listing.json",
           "relevantImageVulnerabilitiesConfiguration": "enable"
@@ -1334,6 +1335,7 @@ matches the snapshot:
           - vulnerabilitymanifestsummaries
           - sbomsummaries
           - sbomspdxv2p3s
+          - openvulnerabilityexchangecontainers
         verbs:
           - create
           - get
@@ -1840,6 +1842,7 @@ matches the snapshot:
           - vulnerabilitymanifestsummaries
           - workloadconfigurationscans
           - workloadconfigurationscansummaries
+          - openvulnerabilityexchangecontainers
         verbs:
           - get
           - watch

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -303,6 +303,7 @@ kubevuln:
   config:
     maxImageSize: 5368709120 # set max image size for scanning, It is recommended to use the same as the requested ephemeral-storage
     scanTimeout: 5m # set timeout for scanning an image
+    vexGeneration: false # set the feature of vex generation (experimental)
 
   env:
     - name: CA_MAX_VULN_SCAN_ROUTINES # TODO update the kubevuln


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces the experimental feature of Vex generation to the Kubescape Operator Helm chart. It adds a new flag `--set kubevuln.config.vexGeneration=true` to enable this feature. Additionally, it modifies the ClusterRoles for Kubevuln and Operator to provide the necessary access to the objects.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml`: Added a new configuration parameter "vexGeneration" to enable or disable the experimental feature of Vex generation.
`charts/kubescape-operator/templates/kubevuln/clusterrole.yaml`: Updated the resources list to include "openvulnerabilityexchangecontainers" to provide necessary access for the Vex generation feature.
`charts/kubescape-operator/templates/operator/clusterrole.yaml`: Similar to the kubevuln clusterrole, the resources list has been updated to include "openvulnerabilityexchangecontainers" for the operator.
`charts/kubescape-operator/values.yaml`: Added a new configuration option "vexGeneration" under kubevuln config. This option is set to false by default, indicating that the Vex generation feature is disabled by default.
</details>

___
## User Description:
## Overview

Adding VEX support in the Kubescape Operator Helm chart:
* Adding the ability to enable the experimental feature through flag `--set kubevuln.config.vexGeneration=true`
* Changing ClusterRoles for Kubevuln and Operator to have proper access to the objects

This is related to ticket https://github.com/kubescape/kubevuln/issues/155
