### PR TITLE
Adding namespace to the environment variable

### DIFF
--- a/charts/kubescape-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-operator/assets/host-scanner-definition.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: host-scanner
-  namespace: kubescape
+  namespace: {{ .Values.ksNamespace }}
   labels:
     app: host-scanner
     k8s-app: kubescape-host-scanner

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -67,6 +67,10 @@ spec:
           resources:
 {{ toYaml .Values.kubevuln.resources | indent 12 }}
           env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: GOMEMLIMIT
               value: "{{ .Values.kubevuln.resources.requests.memory }}B"
             - name: KS_LOGGER_LEVEL

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -104,6 +104,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: HOST_ROOT
               value: "/host"
             {{- range .Values.nodeAgent.env }}


### PR DESCRIPTION
## Overview
This PR will enable the run of the Kubescape-Operator in other namespaces rather than just in the Kubescape namespace.

Depending on [this PR](https://github.com/kubescape/kubevuln/pull/182). 

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 