### PR TITLE
Add docker.io image registry identifier where missing

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -518,7 +518,7 @@ Each component is built as a distroless image. This means that the image does no
 In order to troubleshoot a component, you can use the `kubectl debug` command to add an [ephemeral container](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container) to the pod and run a shell in it:
 
 ```bash
-kubectl -n kubescape debug -it <pod-name> --image=busybox --target=<container-name>
+kubectl -n kubescape debug -it <pod-name> --image=docker.io/busybox --target=<container-name>
 ```
 
 **Note:** The `--target` parameter must be supported by the Container Runtime.

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         fsGroup: 65532
       initContainers:
         - name: fix-permissions
-          image: busybox
+          image: docker.io/busybox
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0

--- a/charts/kubescape-operator/templates/storage/tests/test-connection.yaml
+++ b/charts/kubescape-operator/templates/storage/tests/test-connection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: docker.io/busybox
       command: ['wget']
       args: ['{{ .Values.storage.name }}:80']
   restartPolicy: Never

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2554,7 +2554,7 @@ matches the snapshot:
                 - sh
                 - -c
                 - chown -Rc 65532:65532 /data
-              image: busybox
+              image: docker.io/busybox
               imagePullPolicy: IfNotPresent
               name: fix-permissions
               securityContext:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -475,7 +475,7 @@ otelCollector:
     scrapeInterval: 30s
 
   image:
-    repository: otel/opentelemetry-collector
+    repository: docker.io/otel/opentelemetry-collector
     tag: 0.86.0
     pullPolicy: IfNotPresent
 
@@ -637,14 +637,14 @@ serviceDiscovery:
   configMapCheck:
     name: check-url-configmap
     image:
-      repository: bitnami/kubectl
+      repository: docker.io/bitnami/kubectl
       tag: 1.27.6
       pullPolicy: IfNotPresent
 
   configMapUpdate:
     name: update-configmap
     image:
-      repository: bitnami/kubectl
+      repository: docker.io/bitnami/kubectl
       tag: 1.27.6
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR aims to improve the reliability of Kubescape's deployment by explicitly specifying 'docker.io' as the image registry in various places where it was previously omitted. This change is necessary due to varying default configurations in different container engines or systems, which could lead to deployment failures. The PR affects the Kubescape helm charts and updates the image repository references in several YAML files.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`charts/kubescape-operator/README.md`: Updated the image reference for the debug command to include 'docker.io'.
`charts/kubescape-operator/templates/storage/deployment.yaml`: Updated the image reference for the initContainers to include 'docker.io'.
`charts/kubescape-operator/templates/storage/tests/test-connection.yaml`: Updated the image reference for the test connection to include 'docker.io'.
`charts/kubescape-operator/values.yaml`: Updated the image repository references for otelCollector, serviceDiscovery, configMapCheck, and configMapUpdate to include 'docker.io'.
</details>

___
## User Description:
## Overview

Add **docker.io** image registry identifier where missing.

Historically, docker.io was considered default and was being omitted in code when specifying image repository. Docker container engine would add it implicitly where not specified. It's not a good practice anymore since various container engines or systems apply different configuration, resulting in Kubescape deployment failures.

<!--
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

## How to Test

Deploy Kubescape using helm chart on a Kubernetes system deployed eg. with cri-o container engine in default configuration.

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes
