### PR TITLE
Removing BPF/PERFMON capabilities (not supported in every kernel)

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -119,13 +119,13 @@ spec:
               add:
                 - SYS_ADMIN
                 - SYS_PTRACE
-                - BPF
-                - PERFMON
                 - NET_ADMIN
                 - SYSLOG
                 - SYS_RESOURCE
                 - IPC_LOCK
                 - NET_RAW
+            seLinuxOptions:
+              type: spc_t
           volumeMounts:
           - name: {{ .Values.global.cloudConfig }}
             mountPath: /etc/config/clusterData.json

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1720,10 +1720,10 @@ matches the snapshot:
                     - SYS_RESOURCE
                     - IPC_LOCK
                     - NET_RAW
-                seLinuxOptions:
-                  type: spc_t
                 privileged: false
                 runAsUser: 0
+                seLinuxOptions:
+                  type: spc_t
               volumeMounts:
                 - mountPath: /etc/config/clusterData.json
                   name: ks-cloud-config

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1715,13 +1715,13 @@ matches the snapshot:
                   add:
                     - SYS_ADMIN
                     - SYS_PTRACE
-                    - BPF
-                    - PERFMON
                     - NET_ADMIN
                     - SYSLOG
                     - SYS_RESOURCE
                     - IPC_LOCK
                     - NET_RAW
+                seLinuxOptions:
+				          type: spc_t
                 privileged: false
                 runAsUser: 0
               volumeMounts:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1721,7 +1721,7 @@ matches the snapshot:
                     - IPC_LOCK
                     - NET_RAW
                 seLinuxOptions:
-				          type: spc_t
+                  type: spc_t
                 privileged: false
                 runAsUser: 0
               volumeMounts:


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR includes the following changes:
- Removes the BPF and PERFMON capabilities from the node-agent container as they are not supported by newer kernel versions and are covered by other capabilities.
- Adds SE Linux context to the node-agent container for enhanced security.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`charts/kubescape-operator/templates/node-agent/daemonset.yaml`: - Removed BPF and PERFMON from the list of added capabilities for the node-agent container.
- Added SE Linux options with type 'spc_t' to the security context of the node-agent container.
</details>

___
## User Description:
## Overview

Removing the BPF and PERFMON capabilities from the node-agent container requirements. They are covered by other capabilities already but they are not supported by newer kernel versions.

Beyond this added SE Linux context to the node-agent container.
