### PR TITLE
feat(serviceMonitor): Added option to customize interval and scrapeTi…

### DIFF
--- a/charts/kubescape-operator/templates/kubescape/servicemonitor.yaml
+++ b/charts/kubescape-operator/templates/kubescape/servicemonitor.yaml
@@ -21,6 +21,6 @@ spec:
   endpoints:
     - port: http
       path: /v1/metrics
-      interval: {{ .Value.kubescape.serviceMonitor.interval}}
-      scrapeTimeout: {{ .Value.kubescape.serviceMonitor.scrapeTimeout}}
+      interval: {{ .Value.kubescape.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Value.kubescape.serviceMonitor.scrapeTimeout }}
 {{ end }}

--- a/charts/kubescape-operator/templates/kubescape/servicemonitor.yaml
+++ b/charts/kubescape-operator/templates/kubescape/servicemonitor.yaml
@@ -21,6 +21,6 @@ spec:
   endpoints:
     - port: http
       path: /v1/metrics
-      interval: {{ .Value.kubescape.serviceMonitor.interval }}
-      scrapeTimeout: {{ .Value.kubescape.serviceMonitor.scrapeTimeout }}
+      interval: {{ .Values.kubescape.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.kubescape.serviceMonitor.scrapeTimeout }}
 {{ end }}

--- a/charts/kubescape-operator/templates/kubescape/servicemonitor.yaml
+++ b/charts/kubescape-operator/templates/kubescape/servicemonitor.yaml
@@ -21,6 +21,6 @@ spec:
   endpoints:
     - port: http
       path: /v1/metrics
-      interval: 200s
-      scrapeTimeout: 150s
+      interval: {{ .Value.kubescape.serviceMonitor.interval}}
+      scrapeTimeout: {{ .Value.kubescape.serviceMonitor.scrapeTimeout}}
 {{ end }}

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -180,6 +180,10 @@ kubescape:
     # -- enable/disable service monitor for prometheus (operator) integration
     enabled: false
 
+    # -- Customize prometheus interval and scrapeTimeout
+    interval: 200s
+    scrapeTimeout: 150s
+
     # If needed the service monitor can be deployed to a different namespace than the one kubescape is in
     #namespace: my-namespace
 


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces the ability to customize the interval and scrapeTimeout of the Service Monitor for the Kubescape operator. The changes include:
- Addition of interval and scrapeTimeout fields in the values.yaml file for the Kubescape operator.
- Modification of the servicemonitor.yaml file to use the interval and scrapeTimeout values from the values.yaml file.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`charts/kubescape-operator/templates/kubescape/servicemonitor.yaml`: The interval and scrapeTimeout values in the endpoints section have been replaced with placeholders that will fetch the values from the values.yaml file.
`charts/kubescape-operator/values.yaml`: New fields for interval and scrapeTimeout have been added under the serviceMonitor section. The default values for these fields are set to 200s and 150s respectively.
</details>

___
## User Description:
…meout of serviceMonitor

## Overview

Added option to customize prometheus interval and scrapeTimeout of Kubescape service monitor.
The default values are now in values.yaml but remain the same (interval = 200s and scrapeTimeout = 150s)
