### PR TITLE
Get busybox image from values file

### DIFF
--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -29,8 +29,8 @@ spec:
         fsGroup: 65532
       initContainers:
         - name: fix-permissions
-          image: docker.io/busybox
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.storage.initImage.repository }}:{{ .Values.storage.initImage.tag }}"
+          imagePullPolicy: {{ .Values.storage.initImage.pullPolicy }}
           securityContext:
             runAsUser: 0
           command: ["sh", "-c", "chown -Rc 65532:65532 /data"]
@@ -39,8 +39,8 @@ spec:
               mountPath: "/data"
       containers:
       - name: apiserver
-        image: {{ printf "%s:%s" .Values.storage.image.repository .Values.storage.image.tag  | quote }}
-        imagePullPolicy: {{ .Values.storage.image.pullPolicy | quote }}
+        image: "{{ .Values.storage.image.repository }}:{{ .Values.storage.image.tag }}"
+        imagePullPolicy: {{ .Values.storage.image.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2571,7 +2571,7 @@ matches the snapshot:
                 - sh
                 - -c
                 - chown -Rc 65532:65532 /data
-              image: docker.io/busybox
+              image: docker.io/busybox:1.36.1
               imagePullPolicy: IfNotPresent
               name: fix-permissions
               securityContext:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -516,6 +516,12 @@ storage:
     tag: v0.0.30
     pullPolicy: IfNotPresent
 
+  # image for init container
+  initImage:
+    repository: docker.io/busybox
+    tag: 1.36.1
+    pullPolicy: IfNotPresent
+
 grypeOfflineDB:
   enabled: false
 


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR allows the busybox image used in the Kubescape Operator to be configurable via the values file. The main changes include:
- Addition of `initImage` field in the values file for the busybox image configuration.
- Modification of the `deployment.yaml` to use the busybox image configuration from the values file.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`charts/kubescape-operator/templates/storage/deployment.yaml`: The busybox image and its pull policy used in the init container are now fetched from the values file instead of being hardcoded.
`charts/kubescape-operator/values.yaml`: Added a new `initImage` field under `storage` for configuring the busybox image repository, tag, and pull policy.
</details>

___
## User Description:
## Overview

Resolves [Add value for the Busybox pod registry and version](https://github.com/kubescape/kubescape/issues/1460)

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
