### PR TITLE
Bump KS image tag

### DIFF
--- a/charts/kubescape-operator/templates/_helpers.tpl
+++ b/charts/kubescape-operator/templates/_helpers.tpl
@@ -26,13 +26,13 @@ hostScanner:
 kollector:
   enabled: {{ $configurations.submit }}
 kubescape:
-  enabled: {{ or (eq .Values.capabilities.configurationScan "enable") (eq .Values.capabilities.nodeScan "enable") }}
+  enabled: {{ or (eq .Values.capabilities.configurationScan "enable") (eq .Values.capabilities.continuousScan "enable") }}
 kubescapeScheduler:
-  enabled: {{ and $configurations.submit (or (eq .Values.capabilities.configurationScan "enable") (eq .Values.capabilities.nodeScan "enable")) }}
+  enabled: {{ and $configurations.submit (eq .Values.capabilities.configurationScan "enable") }}
 kubevuln:
-  enabled: {{ or (eq .Values.capabilities.relevancy "enable") (eq .Values.capabilities.vulnerabilityScan "enable") }}
+  enabled: {{ eq .Values.capabilities.vulnerabilityScan "enable" }}
 kubevulnScheduler:
-  enabled: {{ and $configurations.submit (or (eq .Values.capabilities.relevancy "enable") (eq .Values.capabilities.vulnerabilityScan "enable")) }}
+  enabled: {{ and $configurations.submit (eq .Values.capabilities.vulnerabilityScan "enable") }}
 nodeAgent:
   enabled: {{ (eq .Values.capabilities.relevancy "enable") }}
 operator:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -999,7 +999,7 @@ matches the snapshot:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/kubescape:v3.0.0
+              image: quay.io/kubescape/kubescape:v3.0.1
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -6,16 +6,29 @@ ksNamespace: kubescape
 ksLabel: kubescape
 
 capabilities:
-  relevancy: enable
+  # ====== configuration scanning related capabilities ====== 
+  # 
+  # Default configuration scanning setup
   configurationScan: enable
   # Continuous Scanning continuously evaluates the security posture of your cluster.
   continuousScan: disable
-  vulnerabilityScan: enable
   nodeScan: enable
+
+  # ====== Image vulnerabilities scanning related capabilities ====== 
+  # 
+  vulnerabilityScan: enable
+  relevancy: enable
+
+  # ====== Runtime related capabilities ====== 
+  # 
   runtimeObservability: disable
+
+  # ====== Other capabilities ====== 
+  #
   # This is an experimental capability with an elevated security risk. Read the
   # matching docs before enabling.
   autoUpgrading: disable
+
   # networkGenerator: disable
   # seccompGenerator: disable
 

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -170,7 +170,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v3.0.0
+    tag: v3.0.1
     pullPolicy: IfNotPresent
 
   resources:


### PR DESCRIPTION
## PR Type:
Refactoring, Enhancement

___
## PR Description:
This PR includes two main changes:
- The KS image tag has been updated from v3.0.0 to v3.0.1.
- The capabilities logic in the _helpers.tpl file has been refactored for better clarity and organization. The capabilities have been grouped into categories: configuration scanning, image vulnerabilities scanning, runtime, and others. Some conditions have also been simplified.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`charts/kubescape-operator/templates/_helpers.tpl`: The logic for enabling various capabilities has been refactored. The conditions for enabling 'kubescape', 'kubescapeScheduler', 'kubevuln', and 'kubevulnScheduler' have been simplified. The 'nodeScan' capability is no longer a condition for enabling 'kubescape' and 'kubescapeScheduler'.
`charts/kubescape-operator/values.yaml`: The 'capabilities' section has been reorganized into categories for better clarity. The KS image tag has been updated from v3.0.0 to v3.0.1.
</details>

___
## User Description:
## Overview
* Update KS image tag
* Fix capabilities
 
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
