### PR TITLE
removing storage initContainer no longer needed

### DIFF
--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -27,16 +27,6 @@ spec:
       securityContext:
         runAsUser: 65532
         fsGroup: 65532
-      initContainers:
-        - name: fix-permissions
-          image: "{{ .Values.storage.initImage.repository }}:{{ .Values.storage.initImage.tag }}"
-          imagePullPolicy: {{ .Values.storage.initImage.pullPolicy }}
-          securityContext:
-            runAsUser: 0
-          command: ["sh", "-c", "chown -Rc 65532:65532 /data"]
-          volumeMounts:
-            - name: "data"
-              mountPath: "/data"
       containers:
       - name: apiserver
         image: "{{ .Values.storage.image.repository }}:{{ .Values.storage.image.tag }}"

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2630,19 +2630,6 @@ matches the snapshot:
                 - mountPath: /etc/config
                   name: ks-cloud-config
                   readOnly: true
-          initContainers:
-            - command:
-                - sh
-                - -c
-                - chown -Rc 65532:65532 /data
-              image: docker.io/busybox:1.36.1
-              imagePullPolicy: IfNotPresent
-              name: fix-permissions
-              securityContext:
-                runAsUser: 0
-              volumeMounts:
-                - mountPath: /data
-                  name: data
           securityContext:
             fsGroup: 65532
             runAsUser: 65532

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -6,27 +6,27 @@ ksNamespace: kubescape
 ksLabel: kubescape
 
 capabilities:
-  # ====== configuration scanning related capabilities ====== 
-  # 
+  # ====== configuration scanning related capabilities ======
+  #
   # Default configuration scanning setup
   configurationScan: enable
   # Continuous Scanning continuously evaluates the security posture of your cluster.
   continuousScan: disable
   nodeScan: enable
 
-  # ====== Image vulnerabilities scanning related capabilities ====== 
-  # 
+  # ====== Image vulnerabilities scanning related capabilities ======
+  #
   vulnerabilityScan: enable
   relevancy: enable
   # Generate VEX documents alongside the image vulnerabilities report (experimental)
   vexGeneration: disable
 
-  # ====== Runtime related capabilities ====== 
-  # 
+  # ====== Runtime related capabilities ======
+  #
   runtimeObservability: disable
   networkPolicyService: disable
 
-  # ====== Other capabilities ====== 
+  # ====== Other capabilities ======
   #
   # This is an experimental capability with an elevated security risk. Read the
   # matching docs before enabling.
@@ -312,7 +312,7 @@ kubevulnScheduler:
 
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
-  
+
 # kubevuln - image vulnerability scanning microservice
 kubevuln:
 
@@ -507,7 +507,7 @@ registryScanScheduler:
     limits:
       cpu: 10m
       memory: 20Mi
-  
+
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
 
@@ -564,12 +564,6 @@ storage:
   image:
     repository: quay.io/kubescape/storage
     tag: v0.0.39
-    pullPolicy: IfNotPresent
-
-  # image for init container
-  initImage:
-    repository: docker.io/busybox
-    tag: 1.36.1
     pullPolicy: IfNotPresent
 
 grypeOfflineDB:


### PR DESCRIPTION
## type:
Refactoring

___
## description:
This PR focuses on the removal of an unnecessary initContainer from the storage deployment in the kubescape-operator chart. The initContainer named 'fix-permissions' was previously used to set permissions on a data volume. However, it seems this operation is no longer required, hence the initContainer has been removed. Additionally, the PR includes minor formatting changes in the values.yaml file.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `charts/kubescape-operator/templates/storage/deployment.yaml`: The 'fix-permissions' initContainer has been removed from the storage deployment. This initContainer was previously used to set permissions on a data volume.
- `charts/kubescape-operator/values.yaml`: Minor formatting changes have been made. No significant changes in the values. The initImage section, which was related to the removed initContainer, has been deleted.
</details>
