### PR TITLE
Adding Prometheus Exporter to Helm Charts

### DIFF
--- a/charts/kubescape-operator/templates/_helpers.tpl
+++ b/charts/kubescape-operator/templates/_helpers.tpl
@@ -61,6 +61,8 @@ serviceDiscovery:
   enabled: {{ $configurations.submit }}
 storage:
   enabled: true
+prometheusExporter:
+  enabled: {{ eq .Values.capabilities.prometheusExporter "enable" }}
 cloudSecret:
   create: {{ $configurations.createCloudSecret }}
   name: {{ if $configurations.createCloudSecret }}"cloud-secret"{{ else }}{{ .Values.credentials.cloudSecret }}{{ end }}

--- a/charts/kubescape-operator/templates/prometheus-exporter/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/clusterrole.yaml
@@ -1,0 +1,11 @@
+{{- $components := fromYaml (include "components" .) }}
+{{- if $components.prometheusExporter.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.prometheusExporter.name }}
+rules:
+  - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
+    resources: ["configurationscansummaries", "vulnerabilitysummaries"]
+    verbs: ["get", "watch", "list"]
+{{- end }}

--- a/charts/kubescape-operator/templates/prometheus-exporter/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- $components := fromYaml (include "components" .) }}
+{{- if $components.prometheusExporter.enabled }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.prometheusExporter.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.prometheusExporter.name }}
+  namespace: {{ .Values.ksNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.prometheusExporter.name }}
+{{- end }}

--- a/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
@@ -1,0 +1,111 @@
+{{- $components := fromYaml (include "components" .) }}
+{{- if $components.prometheusExporter.enabled }}
+{{- $no_proxy_envar_list := (include "no_proxy_envar_list" .) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.prometheusExporter.name }}
+  namespace: {{ .Values.ksNamespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.prometheusExporter.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app: {{ .Values.prometheusExporter.name }}
+    tier: {{ .Values.global.namespaceTier }}
+spec:
+  replicas: {{ .Values.prometheusExporter.replicaCount }}
+  revisionHistoryLimit: 2
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.prometheusExporter.name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      tier: {{ .Values.global.namespaceTier }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Values.prometheusExporter.name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        tier: {{ .Values.global.namespaceTier }}
+        app: {{ .Values.prometheusExporter.name }}
+    spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ toYaml .Values.imagePullSecrets }}
+      {{- end }}
+      securityContext:
+        runAsUser: 65532
+        fsGroup: 65532
+      containers:
+        - name: {{ .Values.prometheusExporter.name }}
+          image: {{ .Values.prometheusExporter.image.repository }}:{{ .Values.prometheusExporter.image.tag }}
+          imagePullPolicy: {{ .Values.prometheusExporter.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          ports:
+          - name: metrics
+            containerPort: {{ .Values.prometheusExporter.service.port }}
+            protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.prometheusExporter.service.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.prometheusExporter.service.port }}
+          resources:
+{{ toYaml .Values.prometheusExporter.resources | indent 12 }}
+          env:
+            - name: GOMEMLIMIT
+              value: "{{ .Values.prometheusExporter.resources.requests.memory }}B"
+            - name: KS_LOGGER_LEVEL
+              value: "{{ .Values.logger.level }}"
+            - name: KS_LOGGER_NAME
+              value: "{{ .Values.logger.name }}"
+          volumeMounts:
+            - name: {{ .Values.global.cloudConfig }}
+              mountPath: /etc/config
+              readOnly: true
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 12 }}
+{{- end }}
+{{- if .Values.kubevuln.volumeMounts }}
+{{ toYaml .Values.kubevuln.volumeMounts | indent 12 }}
+{{- end }}
+      volumes:
+        - name: {{ .Values.global.cloudConfig }}
+          configMap:
+            name: {{ .Values.global.cloudConfig }}
+            items:
+            - key: "clusterData"
+              path: "clusterData.json"
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 8 }}
+{{- end }}
+{{- if .Values.prometheusExporter.volumes }}
+{{ toYaml .Values.prometheusExporter.volumes | indent 8 }}
+{{- end }}
+      serviceAccountName: {{ .Values.prometheusExporter.name }}
+      automountServiceAccountToken: true
+      nodeSelector:
+      {{- if .Values.prometheusExporter.nodeSelector }}
+      {{- toYaml .Values.prometheusExporter.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
+      {{- end }}
+      affinity:
+      {{- if .Values.prometheusExporter.affinity }}
+      {{- toYaml .Values.prometheusExporter.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
+      {{- end }}
+      tolerations:
+      {{- if .Values.prometheusExporter.tolerations }}
+      {{- toYaml .Values.prometheusExporter.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/kubescape-operator/templates/prometheus-exporter/networkpolicy.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- $components := fromYaml (include "components" .) }}
+{{- if and .Values.global.networkPolicy.enabled $components.prometheusExporter.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Values.prometheusExporter.name }}
+  namespace: {{ .Values.ksNamespace }}
+  labels:
+    app: {{ .Values.prometheusExporter.name }}
+    tier: {{ .Values.global.namespaceTier }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.prometheusExporter.name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      tier: {{ .Values.global.namespaceTier }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: {{ .Values.prometheusExporter.service.port }}
+          protocol: TCP
+{{- end }}

--- a/charts/kubescape-operator/templates/prometheus-exporter/service.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/service.yaml
@@ -1,0 +1,18 @@
+{{- $components := fromYaml (include "components" .) }}
+{{- if $components.prometheusExporter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.prometheusExporter.name }}
+  namespace: {{ .Values.ksNamespace }}
+  labels:
+    app: {{ .Values.prometheusExporter.name }}
+spec:
+  type: {{ .Values.prometheusExporter.service.type }}
+  ports:
+    - port: {{ .Values.prometheusExporter.service.port }}
+      targetPort: {{ .Values.prometheusExporter.service.targetPort }}
+      protocol: {{ .Values.prometheusExporter.service.protocol }}
+  selector:
+    app: {{ .Values.prometheusExporter.name }}
+{{- end }}

--- a/charts/kubescape-operator/templates/prometheus-exporter/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- $components := fromYaml (include "components" .) }}
+{{- if $components.prometheusExporter.enabled }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+{{- if .Values.cloudProviderMetadata.awsIamRoleArn }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.cloudProviderMetadata.awsIamRoleArn }}
+  {{- else if .Values.cloudProviderMetadata.gkeServiceAccount }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ .Values.cloudProviderMetadata.gkeServiceAccount }}
+{{- end }}
+  labels:
+    app: {{ .Values.prometheusExporter.name }}
+  name: {{ .Values.prometheusExporter.name }}
+  namespace: {{ .Values.ksNamespace }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/kubescape-operator/templates/prometheus-exporter/servicemonitor.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/servicemonitor.yaml
@@ -1,0 +1,17 @@
+{{- $components := fromYaml (include "components" .) }}
+{{- if $components.prometheusExporter.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.prometheusExporter.name }}
+  namespace: {{ .Values.ksNamespace }}
+  labels:
+    app: {{ .Values.prometheusExporter.name }}
+spec:
+  namespaceSelector:
+    matchNames:
+      -  {{ .Values.ksNamespace }}
+  selector:
+    matchLabels:
+      app: {{ .Values.prometheusExporter.name }}
+{{ end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2397,6 +2397,162 @@ all capabilities:
         app: otel-collector
       type: ClusterIP
   62: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: prometheus-exporter
+    rules:
+      - apiGroups:
+          - spdx.softwarecomposition.kubescape.io
+        resources:
+          - configurationscansummaries
+          - vulnerabilitysummaries
+        verbs:
+          - get
+          - watch
+          - list
+  63: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: prometheus-exporter
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: prometheus-exporter
+    subjects:
+      - kind: ServiceAccount
+        name: prometheus-exporter
+        namespace: kubescape
+  64: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: prometheus-exporter
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: prometheus-exporter
+        tier: ks-control-plane
+      name: prometheus-exporter
+      namespace: kubescape
+    spec:
+      replicas: null
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: prometheus-exporter
+          tier: ks-control-plane
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            app: prometheus-exporter
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: prometheus-exporter
+            tier: ks-control-plane
+        spec:
+          affinity: null
+          automountServiceAccountToken: true
+          containers:
+            - env:
+                - name: GOMEMLIMIT
+                  value: 100MiB
+                - name: KS_LOGGER_LEVEL
+                  value: info
+                - name: KS_LOGGER_NAME
+                  value: zap
+              image: quay.io/matthiasb_1/prometheus-exporter:latest
+              imagePullPolicy: Always
+              livenessProbe:
+                initialDelaySeconds: 3
+                periodSeconds: 3
+                tcpSocket:
+                  port: 8080
+              name: prometheus-exporter
+              ports:
+                - containerPort: 8080
+                  name: metrics
+                  protocol: TCP
+              readinessProbe:
+                tcpSocket:
+                  port: 8080
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 500Mi
+                requests:
+                  cpu: 100m
+                  memory: 100Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              volumeMounts:
+                - mountPath: /etc/config
+                  name: ks-cloud-config
+                  readOnly: true
+          nodeSelector: null
+          securityContext:
+            fsGroup: 65532
+            runAsUser: 65532
+          serviceAccountName: prometheus-exporter
+          tolerations: null
+          volumes:
+            - configMap:
+                items:
+                  - key: clusterData
+                    path: clusterData.json
+                name: ks-cloud-config
+              name: ks-cloud-config
+  65: |
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      labels:
+        app: prometheus-exporter
+        tier: ks-control-plane
+      name: prometheus-exporter
+      namespace: kubescape
+    spec:
+      ingress:
+        - ports:
+            - port: 8080
+              protocol: TCP
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: prometheus-exporter
+          tier: ks-control-plane
+      policyTypes:
+        - Ingress
+  66: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: prometheus-exporter
+      name: prometheus-exporter
+      namespace: kubescape
+    spec:
+      ports:
+        - port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app: prometheus-exporter
+      type: null
+  67: |
+    apiVersion: v1
+    automountServiceAccountToken: false
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app: prometheus-exporter
+      name: prometheus-exporter
+      namespace: kubescape
+  68: |
     apiVersion: v1
     data:
       proxy.crt: foo
@@ -2405,7 +2561,7 @@ all capabilities:
       name: kubescape-proxy-certificate
       namespace: kubescape
     type: Opaque
-  63: |
+  69: |
     apiVersion: batch/v1
     kind: Job
     metadata:
@@ -2482,7 +2638,7 @@ all capabilities:
           volumes:
             - emptyDir: {}
               name: shared-data
-  64: |
+  70: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -2503,7 +2659,7 @@ all capabilities:
           - patch
           - get
           - list
-  65: |
+  71: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -2520,7 +2676,7 @@ all capabilities:
       - kind: ServiceAccount
         name: service-discovery
         namespace: kubescape
-  66: |
+  72: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -2530,7 +2686,7 @@ all capabilities:
         helm.sh/hook-weight: "0"
       name: service-discovery
       namespace: kubescape
-  67: |
+  73: |
     apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
@@ -2544,7 +2700,7 @@ all capabilities:
         namespace: kubescape
       version: v1beta1
       versionPriority: 15
-  68: |
+  74: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -2653,7 +2809,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  70: |
+  76: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2666,7 +2822,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  71: |
+  77: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -2749,7 +2905,7 @@ all capabilities:
                     path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  72: |
+  78: |
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
@@ -2765,7 +2921,7 @@ all capabilities:
       resources:
         requests:
           storage: 5Gi
-  73: |
+  79: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -2779,7 +2935,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  74: |
+  80: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -2794,13 +2950,13 @@ all capabilities:
         app.kubernetes.io/component: apiserver
         app.kubernetes.io/name: storage
         app.kubernetes.io/part-of: kubescape-storage
-  75: |
+  81: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
       name: storage
       namespace: kubescape
-  76: |
+  82: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -2864,7 +3020,7 @@ all capabilities:
           - update
           - patch
           - delete
-  77: |
+  83: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2877,7 +3033,7 @@ all capabilities:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  78: |
+  84: |
     apiVersion: v1
     data:
       config.json: |
@@ -2963,7 +3119,7 @@ all capabilities:
     metadata:
       name: synchronizer
       namespace: kubescape
-  79: |
+  85: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -3084,7 +3240,7 @@ all capabilities:
                     path: config.json
                 name: synchronizer
               name: config
-  80: |
+  86: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -3106,7 +3262,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  81: |
+  87: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2458,12 +2458,12 @@ all capabilities:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  value: 100MiB
+                  value: 10MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/matthiasb_1/prometheus-exporter:latest
+              image: quay.io/kubescape/prometheus-exporter:v0.0.6
               imagePullPolicy: Always
               livenessProbe:
                 initialDelaySeconds: 3
@@ -2480,11 +2480,11 @@ all capabilities:
                   port: 8080
               resources:
                 limits:
-                  cpu: 500m
-                  memory: 500Mi
-                requests:
-                  cpu: 100m
+                  cpu: 50m
                   memory: 100Mi
+                requests:
+                  cpu: 10m
+                  memory: 10Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
@@ -2553,6 +2553,21 @@ all capabilities:
       name: prometheus-exporter
       namespace: kubescape
   68: |
+    apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        app: prometheus-exporter
+      name: prometheus-exporter
+      namespace: kubescape
+    spec:
+      namespaceSelector:
+        matchNames:
+          - kubescape
+      selector:
+        matchLabels:
+          app: prometheus-exporter
+  69: |
     apiVersion: v1
     data:
       proxy.crt: foo
@@ -2561,7 +2576,7 @@ all capabilities:
       name: kubescape-proxy-certificate
       namespace: kubescape
     type: Opaque
-  69: |
+  70: |
     apiVersion: batch/v1
     kind: Job
     metadata:
@@ -2638,7 +2653,7 @@ all capabilities:
           volumes:
             - emptyDir: {}
               name: shared-data
-  70: |
+  71: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -2659,7 +2674,7 @@ all capabilities:
           - patch
           - get
           - list
-  71: |
+  72: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -2676,7 +2691,7 @@ all capabilities:
       - kind: ServiceAccount
         name: service-discovery
         namespace: kubescape
-  72: |
+  73: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -2686,7 +2701,7 @@ all capabilities:
         helm.sh/hook-weight: "0"
       name: service-discovery
       namespace: kubescape
-  73: |
+  74: |
     apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
@@ -2700,7 +2715,7 @@ all capabilities:
         namespace: kubescape
       version: v1beta1
       versionPriority: 15
-  74: |
+  75: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -2809,7 +2824,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  76: |
+  77: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2822,7 +2837,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  77: |
+  78: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -2905,7 +2920,7 @@ all capabilities:
                     path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  78: |
+  79: |
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
@@ -2921,7 +2936,7 @@ all capabilities:
       resources:
         requests:
           storage: 5Gi
-  79: |
+  80: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -2935,7 +2950,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  80: |
+  81: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -2950,13 +2965,13 @@ all capabilities:
         app.kubernetes.io/component: apiserver
         app.kubernetes.io/name: storage
         app.kubernetes.io/part-of: kubescape-storage
-  81: |
+  82: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
       name: storage
       namespace: kubescape
-  82: |
+  83: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -3020,7 +3035,7 @@ all capabilities:
           - update
           - patch
           - delete
-  83: |
+  84: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -3033,7 +3048,7 @@ all capabilities:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  84: |
+  85: |
     apiVersion: v1
     data:
       config.json: |
@@ -3119,7 +3134,7 @@ all capabilities:
     metadata:
       name: synchronizer
       namespace: kubescape
-  85: |
+  86: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -3240,7 +3255,7 @@ all capabilities:
                     path: config.json
                 name: synchronizer
               name: config
-  86: |
+  87: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -3262,7 +3277,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  87: |
+  88: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -19,48 +19,7 @@ tests:
         runtimeObservability: enable
         networkPolicyService: enable
         autoUpgrading: enable
-      server: api.armosec.io
-      configurations.otelUrl: "otelCollector:4317"
-      clusterName: kind-kind
-      global:
-        networkPolicy:
-          createEgressRules: true
-          enabled: true
-        proxySecretFile: foo
-      grypeOfflineDB.enabled: true
-      kubescape.serviceMonitor.enabled: true
-      kubescapeScheduler.scanSchedule: "1 2 3 4 5"
-      kubevulnScheduler.scanSchedule: "1 2 3 4 5"
-  - it: minimal capabilities
-    asserts:
-      - matchSnapshot: {}
-    capabilities:
-      apiVersions:
-        - batch/v1
-    set:
-      configurations.otelUrl: "otelCollector:4317"
-      clusterName: kind-kind
-      kubescapeScheduler.scanSchedule: "1 2 3 4 5"
-      kubevulnScheduler.scanSchedule: "1 2 3 4 5"
-  - it: default capabilities
-    asserts:
-      - matchSnapshot: {}
-    capabilities:
-      apiVersions:
-        - batch/v1
-    set:
-      account: 9e6c0c2c-6bd0-4919-815b-55030de7c9a0
-      accessKey: f304d73b-d43c-412b-82ea-e4c859493ce6
-      capabilities:
-        configurationScan: enable
-        continuousScan: disable
-        nodeScan: enable
-        vulnerabilityScan: enable
-        relevancy: enable
-        vexGeneration: disable
-        runtimeObservability: enable
-        networkPolicyService: enable
-        autoUpgrading: disable
+        prometheusExporter: enable
       server: api.armosec.io
       configurations.otelUrl: "otelCollector:4317"
       clusterName: kind-kind

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -756,17 +756,17 @@ helmReleaseUpgrader:
 prometheusExporter:
   name: "prometheus-exporter"
   image:
-    repository: "quay.io/matthiasb_1/prometheus-exporter"
-    tag: "latest"
-    pullPolicy: "Always"
+    repository: "quay.io/kubescape/prometheus-exporter"
+    tag: "v0.0.6"
+    pullPolicy: "IfNotPresent"
 
   resources:
     requests:
-      cpu: 100m
-      memory: 100Mi
+      cpu: 10m
+      memory: 10Mi
     limits:
-      cpu: 500m
-      memory: 500Mi
+      cpu: 50m
+      memory: 100Mi
 
   service:
     port: 8080

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -31,7 +31,7 @@ capabilities:
   # This is an experimental capability with an elevated security risk. Read the
   # matching docs before enabling.
   autoUpgrading: disable
-
+  prometheusExporter: disable
   # seccompGenerator: disable
 
 configurations:
@@ -750,3 +750,25 @@ helmReleaseUpgrader:
 
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
+
+
+# Prometheus exporter
+prometheusExporter:
+  name: "prometheus-exporter"
+  image:
+    repository: "quay.io/matthiasb_1/prometheus-exporter"
+    tag: "latest"
+    pullPolicy: "Always"
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 500m
+      memory: 500Mi
+
+  service:
+    port: 8080
+    targetPort: 8080
+    protocol: TCP


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR introduces the integration of Prometheus Exporter into the Helm charts of the kubescape-operator. The main changes include:
- Enabling Prometheus Exporter in the Helm charts.
- Adding new YAML configuration files for Prometheus Exporter, including deployment, service, service account, network policy, cluster role, and cluster role binding.
- Updating the values.yaml file to include configurations for Prometheus Exporter.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>_helpers.tpl&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/_helpers.tpl<br><br>
        <strong>Added a new configuration for Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-aa81f2ba9ca60237f5e62c64faf4e05f73d0f94f6ed0b9773aed5a84aedf993c"> +2/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>clusterrole.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/prometheus-exporter/clusterrole.yaml<br><br>
        <strong>Added a new cluster role for Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-364e1a0843b3c591667fda1234f466bbfde41995a38b42a57470cfa3e6bbb209"> +14/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>clusterrolebinding.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/prometheus-exporter/clusterrolebinding.yaml<br><br>
        <strong>Added a new cluster role binding for Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-8b7ddc41a537f99d2ff8c3bb7aa5b6f063573c717356324b40fec6d403cfdff0"> +15/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml<br><br>
        <strong>Added a new deployment configuration for Prometheus <br>Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-f90f59f8051ce40677b2a880bb44e61ca07c515f03990e6144219dd687d1333e"> +82/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>networkpolicy.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/prometheus-exporter/networkpolicy.yaml<br><br>
        <strong>Added a new network policy for Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-486d5346bcfcdeb11709bc3dc0936dc86f11ef425496dc22a3742344ba4a421c"> +39/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>service.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/prometheus-exporter/service.yaml<br><br>
        <strong>Added a new service configuration for Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-4b8ce7e4189a44a122b4de3ec31723bdf240d82e751aca45dcc5d427d3a0e1f5"> +19/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>serviceaccount.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/prometheus-exporter/serviceaccount.yaml<br><br>
        <strong>Added a new service account for Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-f9b699f8e2f9d453bd286f0873eed3b6efa6b0773566d055dc350954ad89843c"> +19/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/values.yaml<br><br>
        <strong>Updated the values.yaml file to include configurations for <br>Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-2d5611f69251d498d71f52fa778f6ce1bc93e1e1f46951ede1c50d975bdcad02"> +24/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
## Type
Enhancement

___
## Description
This PR introduces the integration of Prometheus Exporter into the Helm charts of the kubescape-operator. The main changes include:
- Enabling Prometheus Exporter in the Helm charts.
- Adding new YAML configuration files for Prometheus Exporter, including deployment, service, service account, network policy, cluster role, and cluster role binding.
- Updating the values.yaml file to include configurations for Prometheus Exporter.

___
## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>_helpers.tpl&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/_helpers.tpl<br><br>
        <strong>Added a new configuration for Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-aa81f2ba9ca60237f5e62c64faf4e05f73d0f94f6ed0b9773aed5a84aedf993c"> +2/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>clusterrole.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/prometheus-exporter/clusterrole.yaml<br><br>
        <strong>Added a new ClusterRole for Prometheus Exporter with <br>specific rules.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-364e1a0843b3c591667fda1234f466bbfde41995a38b42a57470cfa3e6bbb209"> +14/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>clusterrolebinding.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/prometheus-exporter/clusterrolebinding.yaml<br><br>
        <strong>Added a new ClusterRoleBinding for Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-8b7ddc41a537f99d2ff8c3bb7aa5b6f063573c717356324b40fec6d403cfdff0"> +15/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml<br><br>
        <strong>Added a new Deployment configuration for Prometheus <br>Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-f90f59f8051ce40677b2a880bb44e61ca07c515f03990e6144219dd687d1333e"> +82/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>networkpolicy.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/prometheus-exporter/networkpolicy.yaml<br><br>
        <strong>Added a new NetworkPolicy for Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-486d5346bcfcdeb11709bc3dc0936dc86f11ef425496dc22a3742344ba4a421c"> +39/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>service.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/prometheus-exporter/service.yaml<br><br>
        <strong>Added a new Service configuration for Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-4b8ce7e4189a44a122b4de3ec31723bdf240d82e751aca45dcc5d427d3a0e1f5"> +19/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>serviceaccount.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/prometheus-exporter/serviceaccount.yaml<br><br>
        <strong>Added a new ServiceAccount for Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-f9b699f8e2f9d453bd286f0873eed3b6efa6b0773566d055dc350954ad89843c"> +19/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/values.yaml<br><br>
        <strong>Updated the values.yaml file to include configurations for <br>Prometheus Exporter.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/343/files#diff-2d5611f69251d498d71f52fa778f6ce1bc93e1e1f46951ede1c50d975bdcad02"> +24/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>
___
## User description
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
- This PR will add the prometheus exporter to the helm charts.
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
