### PR TITLE
fix: Add StorageClass to clusterrole under storage.k8s.io

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,7 +41,5 @@ put an [x] in the box to get it checked
 - [ ] If it is a core feature, I have added thorough tests.
 - [ ] New and existing unit tests pass locally with my changes
 
-**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
-
 -->
  

--- a/charts/kubescape-operator/templates/kubescape/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/kubescape/clusterrole.yaml
@@ -45,7 +45,7 @@ rules:
   resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["storage.k8s.io"]
-  resources: ["csistoragecapacities"]
+  resources: ["csistoragecapacities", "StorageClass"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
When running a configuration scan on a new installation the following error is present in the logs and the scan does not run.

```
{"level":"error","ts":"2023-12-14T17:55:07Z","msg":"scanning failed","ID":"adaf0696-5a89-4ab6-9bf1-c1b909d8fd9a","error":"failed to scan. reason: 'failed to get resource: storage.k8s.io/v1, Resource=StorageClass, labelSelector: , fieldSelector: , reason: StorageClass.storage.k8s.io is forbidden: User \"system:serviceaccount:kubescape:kubescape\" cannot list resource \"StorageClass\" in API group \"storage.k8s.io\" at the cluster scope'"}
```
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

## How to Test
<!--  Please provide instructions on how to test the changes made in this pull request
-->
Run a scan using `curl --header "Content-Type: application/json" --request POST --data '{"hostScanner":true}' http://127.0.0.1:8080/v1/scan` against a freshly installed version of the chart.

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
