### PR TITLE
Enable overriding seLinux type for custom type tags

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
                 - IPC_LOCK
                 - NET_RAW
             seLinuxOptions:
-              type: spc_t
+              type: {{ .Values.nodeAgent.seLinuxType }}
           volumeMounts:
           - name: {{ $components.cloudSecret.name }}
             mountPath: /etc/credentials

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -97,7 +97,7 @@ persistence:
 
 credentials:
   cloudSecret: # If left blank, the secret will be generated using the default name. Override this option if you already have a secret and wish to prevent Helm from creating the default secret on your behalf
- 
+
 global:
   httpsProxy: ""
   proxySecretFile: ""
@@ -605,6 +605,7 @@ nodeAgent:
           fieldPath: spec.nodeName
 
   privileged: false
+  seLinuxType: scp_t
 
   volumeMounts:
     - mountPath: /host


### PR DESCRIPTION
## Overview
In different environments, privileged SELinux type tags can differ. In this PR we add capability for the user to override the most common type `scp_t` with custom tag that fits the give environment.

## Additional Information
This issue came around in Bottlerocket OS environment in AWS.

## Related issues/PRs:
https://github.com/bottlerocket-os/bottlerocket/issues/3677
