### PR TITLE
Global vars

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -44,7 +44,7 @@ kubectl get vulnerabilitymanifests -A
 ## Uninstall
 
 You can uninstall this helm chart by running the following command:
-```
+```shell
 helm uninstall kubescape -n kubescape
 ```
 Then, delete the kubescape namespace:
@@ -163,6 +163,9 @@ docker-compose logs uptrace
 | global.kubescapePsp.enabled | bool | `false` | Enable all privileges in Pod Security Policies for Kubescape namespace |
 | global.httpsProxy | string | `""` | Set https egress proxy for all components. Must supply also port.  |
 | global.proxySecretFile | string | `""` | Set proxy certificate / RootCA for all components to be used for proxy configured in global.httpsProxy |
+| customScheduling.affinity | yaml |  | Use the `affinity` sub-section to define affinity rules that will apply to all of the workloads managed by the kubescape-operator |
+| customScheduling.nodeSelector | yaml | | Configure `nodeSelector` rules under the nodeSelector sub-section that will apply to all of the workloads managed by the kubescape-operator |
+| customScheduling.tolerations | yaml | | Define `tolerations` in the tolerations sub-section that will apply to all of the workloads managed by the kubescape-operator |
 | credentials.cloudSecret | string | `""` | Leave it blank for the default secret. If you have an existing secret, override with the existing secret name to avoid Helm creating a default one |
 | kollector.affinity | object | `{}` | Assign custom [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) rules to the StatefulSet |
 | kollector.env[0] | object | `{"name":"PRINT_REPORT","value":"false"}` | print in verbose mode (print all reported data) |

--- a/charts/kubescape-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-operator/assets/host-scanner-definition.yaml
@@ -80,6 +80,9 @@ spec:
         volumeMounts:
         - mountPath: /host_fs
           name: host-filesystem
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 8 }}
+{{- end }}
 {{- if .Values.hostScanner.volumeMounts }}
 {{ toYaml .Values.hostScanner.volumeMounts | nindent 8 }}
 {{- end }}
@@ -102,6 +105,9 @@ spec:
           path: /
           type: Directory
         name: host-filesystem
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 6 }}
+{{- end }}
 {{- if .Values.hostScanner.volumes }}
 {{ toYaml .Values.hostScanner.volumes | nindent 6 }}
 {{- end }}

--- a/charts/kubescape-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-operator/assets/host-scanner-definition.yaml
@@ -19,27 +19,28 @@ spec:
         otel: enabled
         {{- end }}
     spec:
+      nodeSelector:
+      {{- if .Values.hostScanner.nodeSelector }}
+      {{- toYaml .Values.hostScanner.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
+      {{- end }}
+      affinity:
+      {{- if .Values.hostScanner.affinity }}
+      {{- toYaml .Values.hostScanner.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
+      {{- end }}
+      tolerations:
+      {{- if .Values.hostScanner.tolerations }}
+      {{- toYaml .Values.hostScanner.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
+      {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ toYaml .Values.imagePullSecrets }}
       {{- end }}
-
-      tolerations:
-    {{- with .Values.hostScanner.tolerations }}
-        {{- toYaml . | nindent 6 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-        {{- toYaml . | nindent 6 }}
-    {{- end }}
-
-    {{- with .Values.hostScanner.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.hostScanner.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
       containers:
       - name: host-sensor
         image: "{{ .Values.hostScanner.image.repository }}:{{ .Values.hostScanner.image.tag }}"

--- a/charts/kubescape-operator/assets/kubescape-cronjob-full.yaml
+++ b/charts/kubescape-operator/assets/kubescape-cronjob-full.yaml
@@ -18,18 +18,6 @@ apiVersion: batch/v1
               labels:
                 armo.tier: "kubescape-scan"
             spec:
-            {{- with .Values.tolerations }}
-              tolerations:
-                {{- toYaml . | nindent 16 }}
-            {{- end }}
-            {{- with .Values.kubescapeScheduler.nodeSelector }}
-              nodeSelector:
-                {{- toYaml . | nindent 16 }}
-            {{- end }}
-            {{- with .Values.kubescapeScheduler.affinity }}
-              affinity:
-                {{- toYaml . | nindent 16 }}
-            {{- end }}
               {{- if .Values.imagePullSecrets }}
               imagePullSecrets:
               - name: {{ toYaml .Values.imagePullSecrets }}
@@ -65,6 +53,24 @@ apiVersion: batch/v1
 {{- end }}
               restartPolicy: Never
               automountServiceAccountToken: false
+              nodeSelector:
+              {{- if .Values.kubescapeScheduler.nodeSelector }}
+              {{- toYaml .Values.kubescapeScheduler.nodeSelector | nindent 16 }}
+              {{- else if .Values.customScheduling.nodeSelector }}
+              {{- toYaml .Values.customScheduling.nodeSelector | nindent 16 }}
+              {{- end }}
+              affinity:
+              {{- if .Values.kubescapeScheduler.affinity }}
+              {{- toYaml .Values.kubescapeScheduler.affinity | nindent 16 }}
+              {{- else if .Values.customScheduling.affinity }}
+              {{- toYaml .Values.customScheduling.affinity | nindent 16 }}
+              {{- end }}
+              tolerations:
+              {{- if .Values.kubescapeScheduler.tolerations }}
+              {{- toYaml .Values.kubescapeScheduler.tolerations | nindent 16 }}
+              {{- else if .Values.customScheduling.tolerations }}
+              {{- toYaml .Values.customScheduling.tolerations | nindent 16 }}
+              {{- end }}
               volumes:
                 - name: "request-body-volume" # placeholder
                   configMap:

--- a/charts/kubescape-operator/assets/kubevuln-cronjob-full.yaml
+++ b/charts/kubescape-operator/assets/kubevuln-cronjob-full.yaml
@@ -18,18 +18,6 @@ apiVersion: batch/v1
               labels:
                 armo.tier: "vuln-scan"
             spec:
-            {{- with .Values.tolerations }}
-              tolerations:
-                {{- toYaml . | nindent 16 }}
-            {{- end }}
-            {{- with .Values.kubevulnScheduler.nodeSelector }}
-              nodeSelector:
-                {{- toYaml . | nindent 16 }}
-            {{- end }}
-            {{- with .Values.kubevulnScheduler.affinity }}
-              affinity:
-                {{- toYaml . | nindent 16 }}
-            {{- end }}
             {{- if .Values.imagePullSecrets }}
               imagePullSecrets:
               - name: {{ toYaml .Values.imagePullSecrets }}
@@ -65,6 +53,24 @@ apiVersion: batch/v1
 {{- end }}
               restartPolicy: Never
               automountServiceAccountToken: false
+              nodeSelector:
+              {{- if .Values.kubevulnScheduler.nodeSelector }}
+              {{- toYaml .Values.kubevulnScheduler.nodeSelector | nindent 16 }}
+              {{- else if .Values.customScheduling.nodeSelector }}
+              {{- toYaml .Values.customScheduling.nodeSelector | nindent 16 }}
+              {{- end }}
+              affinity:
+              {{- if .Values.kubevulnScheduler.affinity }}
+              {{- toYaml .Values.kubevulnScheduler.affinity | nindent 16 }}
+              {{- else if .Values.customScheduling.affinity }}
+              {{- toYaml .Values.customScheduling.affinity | nindent 16 }}
+              {{- end }}
+              tolerations:
+              {{- if .Values.kubevulnScheduler.tolerations }}
+              {{- toYaml .Values.kubevulnScheduler.tolerations | nindent 16 }}
+              {{- else if .Values.customScheduling.tolerations }}
+              {{- toYaml .Values.customScheduling.tolerations | nindent 16 }}
+              {{- end }}
               volumes:
                 - name: "request-body-volume" # placeholder
                   configMap:

--- a/charts/kubescape-operator/assets/registry-scan-cronjob-full.yaml
+++ b/charts/kubescape-operator/assets/registry-scan-cronjob-full.yaml
@@ -18,18 +18,6 @@ apiVersion: batch/v1
               labels:
                 armo.tier: "registry-scan"
             spec:
-            {{- with .Values.tolerations }}
-              tolerations:
-                {{- toYaml . | nindent 16 }}
-            {{- end }}
-            {{- with .Values.registryScanScheduler.nodeSelector }}
-              nodeSelector:
-                {{- toYaml . | nindent 16 }}
-            {{- end }}
-            {{- with .Values.registryScanScheduler.affinity }}
-              affinity:
-                {{- toYaml . | nindent 16 }}
-            {{- end }}
               {{- if .Values.imagePullSecrets }}
               imagePullSecrets:
               - name: {{ toYaml .Values.imagePullSecrets }}
@@ -65,6 +53,24 @@ apiVersion: batch/v1
 {{- end }}
               restartPolicy: Never
               automountServiceAccountToken: false
+              nodeSelector:
+              {{- if .Values.registryScanScheduler.nodeSelector }}
+              {{- toYaml .Values.registryScanScheduler.nodeSelector | nindent 16 }}
+              {{- else if .Values.customScheduling.nodeSelector }}
+              {{- toYaml .Values.customScheduling.nodeSelector | nindent 16 }}
+              {{- end }}
+              affinity:
+              {{- if .Values.registryScanScheduler.affinity }}
+              {{- toYaml .Values.registryScanScheduler.affinity | nindent 16 }}
+              {{- else if .Values.customScheduling.affinity }}
+              {{- toYaml .Values.customScheduling.affinity | nindent 16 }}
+              {{- end }}
+              tolerations:
+              {{- if .Values.registryScanScheduler.tolerations }}
+              {{- toYaml .Values.registryScanScheduler.tolerations | nindent 16 }}
+              {{- else if .Values.customScheduling.tolerations }}
+              {{- toYaml .Values.customScheduling.tolerations | nindent 16 }}
+              {{- end }}
               volumes:
                 - name: "request-body-volume" # placeholder
                   configMap:

--- a/charts/kubescape-operator/templates/gateway/deployment.yaml
+++ b/charts/kubescape-operator/templates/gateway/deployment.yaml
@@ -157,16 +157,22 @@ spec:
 {{ toYaml .Values.gateway.volumes | indent 8 }}
 {{- end }}
       automountServiceAccountToken: false
-      {{- with .Values.gateway.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.gateway.nodeSelector }}
+      {{- toYaml .Values.gateway.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.gateway.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.gateway.affinity }}
+      {{- toYaml .Values.gateway.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
-    {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- if .Values.gateway.tolerations }}
+      {{- toYaml .Values.gateway.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/gateway/deployment.yaml
+++ b/charts/kubescape-operator/templates/gateway/deployment.yaml
@@ -160,19 +160,19 @@ spec:
       nodeSelector:
       {{- if .Values.gateway.nodeSelector }}
       {{- toYaml .Values.gateway.nodeSelector | nindent 8 }}
-      {{- else if .Values.nodeSelector }}
-      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
       {{- end }}
       affinity:
       {{- if .Values.gateway.affinity }}
       {{- toYaml .Values.gateway.affinity | nindent 8 }}
-      {{- else if .Values.affinity }}
-      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
       {{- end }}
       tolerations:
       {{- if .Values.gateway.tolerations }}
       {{- toYaml .Values.gateway.tolerations | nindent 8 }}
-      {{- else if .Values.tolerations }}
-      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
@@ -46,23 +46,23 @@ spec:
           - containerPort: 8080
             protocol: TCP
           resources:
-      {{ toYaml .Values.grypeOfflineDB.resources | indent 12 }}
+{{ toYaml .Values.grypeOfflineDB.resources | indent 12 }}
       nodeSelector:
       {{- if .Values.grypeOfflineDB.nodeSelector }}
       {{- toYaml .Values.grypeOfflineDB.nodeSelector | nindent 8 }}
-      {{- else if .Values.nodeSelector }}
-      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
       {{- end }}
       affinity:
       {{- if .Values.grypeOfflineDB.affinity }}
       {{- toYaml .Values.grypeOfflineDB.affinity | nindent 8 }}
-      {{- else if .Values.affinity }}
-      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
       {{- end }}
       tolerations:
       {{- if .Values.grypeOfflineDB.tolerations }}
       {{- toYaml .Values.grypeOfflineDB.tolerations | nindent 8 }}
-      {{- else if .Values.tolerations }}
-      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
@@ -46,17 +46,23 @@ spec:
           - containerPort: 8080
             protocol: TCP
           resources:
-{{ toYaml .Values.grypeOfflineDB.resources | indent 12 }}
-    {{- with .Values.grypeOfflineDB.nodeSelector }}
+      {{ toYaml .Values.grypeOfflineDB.resources | indent 12 }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.grypeOfflineDB.nodeSelector }}
+      {{- toYaml .Values.grypeOfflineDB.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.grypeOfflineDB.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.grypeOfflineDB.affinity }}
+      {{- toYaml .Values.grypeOfflineDB.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
-    {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- if .Values.grypeOfflineDB.tolerations }}
+      {{- toYaml .Values.grypeOfflineDB.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/kollector/statefulset.yaml
+++ b/charts/kubescape-operator/templates/kollector/statefulset.yaml
@@ -150,22 +150,23 @@ spec:
 {{ toYaml .Values.kollector.volumes | indent 8 }}
 {{- end }}
       serviceAccountName: {{ .Values.kollector.name }}
+      automountServiceAccountToken: true
       nodeSelector:
       {{- if .Values.kollector.nodeSelector }}
       {{- toYaml .Values.kollector.nodeSelector | nindent 8 }}
-      {{- else if .Values.nodeSelector }}
-      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
       {{- end }}
       affinity:
       {{- if .Values.kollector.affinity }}
       {{- toYaml .Values.kollector.affinity | nindent 8 }}
-      {{- else if .Values.affinity }}
-      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
       {{- end }}
       tolerations:
       {{- if .Values.kollector.tolerations }}
       {{- toYaml .Values.kollector.tolerations | nindent 8 }}
-      {{- else if .Values.tolerations }}
-      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/kollector/statefulset.yaml
+++ b/charts/kubescape-operator/templates/kollector/statefulset.yaml
@@ -150,17 +150,22 @@ spec:
 {{ toYaml .Values.kollector.volumes | indent 8 }}
 {{- end }}
       serviceAccountName: {{ .Values.kollector.name }}
-      automountServiceAccountToken: true
-      {{- with .Values.kollector.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.kollector.nodeSelector }}
+      {{- toYaml .Values.kollector.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.kollector.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.kollector.affinity }}
+      {{- toYaml .Values.kollector.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
-    {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- if .Values.kollector.tolerations }}
+      {{- toYaml .Values.kollector.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml
+++ b/charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml
@@ -27,18 +27,6 @@ spec:
             app: {{ .Values.kubescapeScheduler.name }}
             armo.tier: "kubescape-scan"
         spec:
-        {{- with .Values.kubescapeScheduler.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 10 }}
-          {{- end }}
-          {{- with .Values.kubescapeScheduler.affinity }}
-          affinity:
-            {{- toYaml . | nindent 10 }}
-          {{- end }}
-        {{- with .Values.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 10 }}
-        {{- end }}
           {{- if .Values.imagePullSecrets }}
           imagePullSecrets:
           - name: {{ toYaml .Values.imagePullSecrets }}
@@ -74,6 +62,24 @@ spec:
 {{- end }}
           restartPolicy: Never
           automountServiceAccountToken: false
+          nodeSelector:
+          {{- if .Values.kubescapeScheduler.nodeSelector }}
+          {{- toYaml .Values.kubescapeScheduler.nodeSelector | nindent 12 }}
+          {{- else if .Values.customScheduling.nodeSelector }}
+          {{- toYaml .Values.customScheduling.nodeSelector | nindent 12 }}
+          {{- end }}
+          affinity:
+          {{- if .Values.kubescapeScheduler.affinity }}
+          {{- toYaml .Values.kubescapeScheduler.affinity | nindent 12 }}
+          {{- else if .Values.customScheduling.affinity }}
+          {{- toYaml .Values.customScheduling.affinity | nindent 12 }}
+          {{- end }}
+          tolerations:
+          {{- if .Values.kubescapeScheduler.tolerations }}
+          {{- toYaml .Values.kubescapeScheduler.tolerations | nindent 12 }}
+          {{- else if .Values.customScheduling.tolerations }}
+          {{- toYaml .Values.customScheduling.tolerations | nindent 12 }}
+          {{- end }}
           volumes:
           - name: {{ .Values.kubescapeScheduler.name }}
             configMap:

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -227,16 +227,22 @@ spec:
 {{- end }}
       serviceAccountName: {{ .Values.kubescape.name }}
       automountServiceAccountToken: true
-      {{- with .Values.kubescape.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.kubescape.nodeSelector }}
+      {{- toYaml .Values.kubescape.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.kubescape.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.kubescape.affinity }}
+      {{- toYaml .Values.kubescape.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
-    {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- if .Values.kubescape.tolerations }}
+      {{- toYaml .Values.kubescape.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -230,19 +230,19 @@ spec:
       nodeSelector:
       {{- if .Values.kubescape.nodeSelector }}
       {{- toYaml .Values.kubescape.nodeSelector | nindent 8 }}
-      {{- else if .Values.nodeSelector }}
-      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
       {{- end }}
       affinity:
       {{- if .Values.kubescape.affinity }}
       {{- toYaml .Values.kubescape.affinity | nindent 8 }}
-      {{- else if .Values.affinity }}
-      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
       {{- end }}
       tolerations:
       {{- if .Values.kubescape.tolerations }}
       {{- toYaml .Values.kubescape.tolerations | nindent 8 }}
-      {{- else if .Values.tolerations }}
-      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml
+++ b/charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml
@@ -27,18 +27,6 @@ spec:
             app: {{ .Values.kubevulnScheduler.name }}
             armo.tier: "vuln-scan"
         spec:
-        {{- with .Values.kubescapeScheduler.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 10 }}
-          {{- end }}
-          {{- with .Values.kubescapeScheduler.affinity }}
-          affinity:
-            {{- toYaml . | nindent 10 }}
-          {{- end }}
-        {{- with .Values.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 10 }}
-        {{- end }}
         {{- if .Values.imagePullSecrets }}
           imagePullSecrets:
           - name: {{ toYaml .Values.imagePullSecrets }}
@@ -74,6 +62,24 @@ spec:
 {{- end }}
           restartPolicy: Never
           automountServiceAccountToken: false
+          nodeSelector:
+          {{- if .Values.kubevulnScheduler.nodeSelector }}
+          {{- toYaml .Values.kubevulnScheduler.nodeSelector | nindent 12 }}
+          {{- else if .Values.customScheduling.nodeSelector }}
+          {{- toYaml .Values.customScheduling.nodeSelector | nindent 12 }}
+          {{- end }}
+          affinity:
+          {{- if .Values.kubevulnScheduler.affinity }}
+          {{- toYaml .Values.kubevulnScheduler.affinity | nindent 12 }}
+          {{- else if .Values.customScheduling.affinity }}
+          {{- toYaml .Values.customScheduling.affinity | nindent 12 }}
+          {{- end }}
+          tolerations:
+          {{- if .Values.kubevulnScheduler.tolerations }}
+          {{- toYaml .Values.kubevulnScheduler.tolerations | nindent 12 }}
+          {{- else if .Values.customScheduling.tolerations }}
+          {{- toYaml .Values.customScheduling.tolerations | nindent 12 }}
+          {{- end }}
           volumes:
           - name: {{ .Values.kubevulnScheduler.name }}
             configMap:

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -162,19 +162,19 @@ spec:
       nodeSelector:
       {{- if .Values.kubevuln.nodeSelector }}
       {{- toYaml .Values.kubevuln.nodeSelector | nindent 8 }}
-      {{- else if .Values.nodeSelector }}
-      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
       {{- end }}
       affinity:
       {{- if .Values.kubevuln.affinity }}
       {{- toYaml .Values.kubevuln.affinity | nindent 8 }}
-      {{- else if .Values.affinity }}
-      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
       {{- end }}
       tolerations:
       {{- if .Values.kubevuln.tolerations }}
       {{- toYaml .Values.kubevuln.tolerations | nindent 8 }}
-      {{- else if .Values.tolerations }}
-      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -159,16 +159,22 @@ spec:
 {{- end }}
       serviceAccountName: {{ .Values.kubevuln.name }}
       automountServiceAccountToken: true
-      {{- with .Values.kubevuln.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.kubevuln.nodeSelector }}
+      {{- toYaml .Values.kubevuln.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.kubevuln.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.kubevuln.affinity }}
+      {{- toYaml .Values.kubevuln.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
-    {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- if .Values.kubevuln.tolerations }}
+      {{- toYaml .Values.kubevuln.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -154,19 +154,19 @@ spec:
       nodeSelector:
       {{- if .Values.nodeAgent.nodeSelector }}
       {{- toYaml .Values.nodeAgent.nodeSelector | nindent 8 }}
-      {{- else if .Values.nodeSelector }}
-      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
       {{- end }}
       affinity:
       {{- if .Values.nodeAgent.affinity }}
       {{- toYaml .Values.nodeAgent.affinity | nindent 8 }}
-      {{- else if .Values.affinity }}
-      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
       {{- end }}
       tolerations:
       {{- if .Values.nodeAgent.tolerations }}
       {{- toYaml .Values.nodeAgent.tolerations | nindent 8 }}
-      {{- else if .Values.tolerations }}
-      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -43,6 +43,12 @@ spec:
       automountServiceAccountToken: true
       hostPID: true
       volumes:
+      {{- if .Values.nodeAgent.volumes }}
+      {{- toYaml .Values.nodeAgent.volumes | nindent 8 }}
+      {{- end }}
+      {{- if .Values.volumes }}
+      {{- toYaml .Values.volumes | nindent 8 }}
+      {{- end }}
         - name: {{ $components.cloudSecret.name }}
           secret:
             secretName: {{ $components.cloudSecret.name }}
@@ -62,19 +68,8 @@ spec:
             items:
               - key: "config.json"
                 path: "config.json"
-        {{- range .Values.nodeAgent.volumes }}
-        - name: {{ .name }}
-        {{- if .configMap }}
-          configMap:
-            name: {{ .configMap.name }}
-        {{ else if .emptyDir }}
-          emptyDir: {}
-        {{ else if .hostPath }}
-          hostPath:
-            path: {{ .hostPath.path }}
-            type: {{ .hostPath.type }}
-        {{- end }}
-        {{- end }}
+
+
         {{- if ne .Values.global.proxySecretFile "" }}
         - name: proxy-secret
           secret:
@@ -134,6 +129,12 @@ spec:
             seLinuxOptions:
               type: {{ .Values.nodeAgent.seLinuxType }}
           volumeMounts:
+          {{- if .Values.volumeMounts }}
+          {{- toYaml .Values.volumeMounts | nindent 10 }}
+          {{- end }}
+          {{- if .Values.nodeAgent.volumeMounts }}
+          {{- toYaml .Values.nodeAgent.volumeMounts | nindent 10 }}
+          {{- end }}
           - name: {{ $components.cloudSecret.name }}
             mountPath: /etc/credentials
             readOnly: true
@@ -145,25 +146,27 @@ spec:
             mountPath: /etc/config/config.json
             readOnly: true
             subPath: "config.json"
-          {{- range .Values.nodeAgent.volumeMounts }}
-          - mountPath: {{ .mountPath }}
-            name: {{ .name }}
-          {{- end }}
           {{- if ne .Values.global.proxySecretFile "" }}
           - name: proxy-secret
             mountPath: /etc/ssl/certs/proxy.crt
             subPath: proxy.crt
           {{- end }}
-    {{- with .Values.nodeAgent.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.nodeAgent.nodeSelector }}
+      {{- toYaml .Values.nodeAgent.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeAgent.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.nodeAgent.affinity }}
+      {{- toYaml .Values.nodeAgent.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
-    {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- if .Values.nodeAgent.tolerations }}
+      {{- toYaml .Values.nodeAgent.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -196,19 +196,19 @@ spec:
       nodeSelector:
       {{- if .Values.operator.nodeSelector }}
       {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
-      {{- else if .Values.nodeSelector }}
-      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
       {{- end }}
       affinity:
       {{- if .Values.operator.affinity }}
       {{- toYaml .Values.operator.affinity | nindent 8 }}
-      {{- else if .Values.affinity }}
-      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
       {{- end }}
       tolerations:
       {{- if .Values.operator.tolerations }}
       {{- toYaml .Values.operator.tolerations | nindent 8 }}
-      {{- else if .Values.tolerations }}
-      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -193,16 +193,22 @@ spec:
 {{- end }}
       serviceAccountName: {{ .Values.operator.name }}
       automountServiceAccountToken: true
-      {{- with .Values.operator.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.operator.nodeSelector }}
+      {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.operator.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.operator.affinity }}
+      {{- toYaml .Values.operator.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
-    {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- if .Values.operator.tolerations }}
+      {{- toYaml .Values.operator.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/otel-collector/deployment.yaml
+++ b/charts/kubescape-operator/templates/otel-collector/deployment.yaml
@@ -106,16 +106,22 @@ spec:
 {{ toYaml .Values.otelCollector.volumes | indent 6 }}
 {{- end }}
       serviceAccountName: default
-      {{- with .Values.otelCollector.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.otelCollector.nodeSelector }}
+      {{- toYaml .Values.otelCollector.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.otelCollector.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.otelCollector.affinity }}
+      {{- toYaml .Values.otelCollector.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
-    {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- if .Values.otelCollector.tolerations }}
+      {{- toYaml .Values.otelCollector.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/otel-collector/deployment.yaml
+++ b/charts/kubescape-operator/templates/otel-collector/deployment.yaml
@@ -109,19 +109,19 @@ spec:
       nodeSelector:
       {{- if .Values.otelCollector.nodeSelector }}
       {{- toYaml .Values.otelCollector.nodeSelector | nindent 8 }}
-      {{- else if .Values.nodeSelector }}
-      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
       {{- end }}
       affinity:
       {{- if .Values.otelCollector.affinity }}
       {{- toYaml .Values.otelCollector.affinity | nindent 8 }}
-      {{- else if .Values.affinity }}
-      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
       {{- end }}
       tolerations:
       {{- if .Values.otelCollector.tolerations }}
       {{- toYaml .Values.otelCollector.tolerations | nindent 8 }}
-      {{- else if .Values.tolerations }}
-      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/servicediscovery/job.yaml
+++ b/charts/kubescape-operator/templates/servicediscovery/job.yaml
@@ -70,4 +70,22 @@ spec:
       - name: shared-data
         emptyDir: {}
       serviceAccountName: {{ .Values.serviceDiscovery.name }}
+      nodeSelector:
+      {{- if .Values.serviceDiscovery.nodeSelector }}
+      {{- toYaml .Values.serviceDiscovery.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
+      {{- end }}
+      affinity:
+      {{- if .Values.serviceDiscovery.affinity }}
+      {{- toYaml .Values.serviceDiscovery.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
+      {{- end }}
+      tolerations:
+      {{- if .Values.serviceDiscovery.tolerations }}
+      {{- toYaml .Values.serviceDiscovery.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -54,18 +54,24 @@ spec:
             readOnly: true
         resources:
 {{ toYaml .Values.storage.resources | indent 12 }}
-    {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.storage.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.storage.affinity }}
+      {{- if .Values.storage.nodeSelector }}
+      {{- toYaml .Values.storage.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
+      {{- end }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- if .Values.storage.affinity }}
+      {{- toYaml .Values.storage.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
+      {{- end }}
+      tolerations:
+      {{- if .Values.storage.tolerations }}
+      {{- toYaml .Values.storage.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
+      {{- end }}
       volumes:
         - name: "data"
           {{- if eq .Values.configurations.persistence "enable" }}

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -156,19 +156,19 @@ spec:
       nodeSelector:
       {{- if .Values.synchronizer.nodeSelector }}
       {{- toYaml .Values.synchronizer.nodeSelector | nindent 8 }}
-      {{- else if .Values.nodeSelector }}
-      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- else if .Values.customScheduling.nodeSelector }}
+      {{- toYaml .Values.customScheduling.nodeSelector | nindent 8 }}
       {{- end }}
       affinity:
       {{- if .Values.synchronizer.affinity }}
       {{- toYaml .Values.synchronizer.affinity | nindent 8 }}
-      {{- else if .Values.affinity }}
-      {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.customScheduling.affinity }}
+      {{- toYaml .Values.customScheduling.affinity | nindent 8 }}
       {{- end }}
       tolerations:
       {{- if .Values.synchronizer.tolerations }}
       {{- toYaml .Values.synchronizer.tolerations | nindent 8 }}
-      {{- else if .Values.tolerations }}
-      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- else if .Values.customScheduling.tolerations }}
+      {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -153,16 +153,22 @@ spec:
 {{- end }}
       serviceAccountName: {{ .Values.synchronizer.name }}
       automountServiceAccountToken: true
-      {{- with .Values.synchronizer.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.synchronizer.nodeSelector }}
+      {{- toYaml .Values.synchronizer.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
-      {{- with .Values.synchronizer.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.synchronizer.affinity }}
+      {{- toYaml .Values.synchronizer.affinity | nindent 8 }}
+      {{- else if .Values.affinity }}
+      {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
-    {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- if .Values.synchronizer.tolerations }}
+      {{- toYaml .Values.synchronizer.tolerations | nindent 8 }}
+      {{- else if .Values.tolerations }}
+      {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -212,6 +212,7 @@ matches the snapshot:
             app.kubernetes.io/name: gateway
             tier: ks-control-plane
         spec:
+          affinity: null
           automountServiceAccountToken: false
           containers:
             - args:
@@ -282,9 +283,11 @@ matches the snapshot:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+          nodeSelector: null
           securityContext:
             fsGroup: 65532
             runAsUser: 65532
+          tolerations: null
           volumes:
             - name: cloud-secret
               secret:
@@ -387,6 +390,7 @@ matches the snapshot:
             helm.sh/chart: kubescape-operator-1.16.7
             tier: ks-control-plane
         spec:
+          affinity: null
           containers:
             - image: ghcr.io/alexandreroman/grype-offline-db@sha256:155db3be4baa461a50cebadfc8f52108fca71aa4ce5e460a30a4e0922e899ed2
               imagePullPolicy: IfNotPresent
@@ -404,6 +408,8 @@ matches the snapshot:
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true
+          nodeSelector: null
+          tolerations: null
   14: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
@@ -567,6 +573,7 @@ matches the snapshot:
             helm.sh/chart: kubescape-operator-1.16.7
             tier: ks-control-plane
         spec:
+          affinity: null
           automountServiceAccountToken: true
           containers:
             - args:
@@ -638,7 +645,9 @@ matches the snapshot:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+          nodeSelector: null
           serviceAccountName: kollector
+          tolerations: null
           volumes:
             - name: cloud-secret
               secret:
@@ -689,6 +698,7 @@ matches the snapshot:
                 app.kubernetes.io/name: kubescape-scheduler
                 armo.tier: kubescape-scan
             spec:
+              affinity: null
               automountServiceAccountToken: false
               containers:
                 - args:
@@ -718,7 +728,9 @@ matches the snapshot:
                       name: kubescape-scheduler
                       readOnly: true
                       subPath: request-body.json
+              nodeSelector: null
               restartPolicy: Never
+              tolerations: null
               volumes:
                 - configMap:
                     name: kubescape-scheduler
@@ -946,7 +958,7 @@ matches the snapshot:
           annotations:
             checksum/cloud-config: 253f0c05e8d2915ab3627479c2f810d8cf3d40b03c0807ec6af34da0e1d1e049
             checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
-            checksum/host-scanner-configmap: 329050cbdabb0c88161e510252b8e3116c6a57d397f321ecb0cfa8837ce31f23
+            checksum/host-scanner-configmap: 2f2feb524edeabfcf23a0ded8294cb5169dbba6ad4251e9525564f3da04cae43
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
           labels:
             app: kubescape
@@ -956,6 +968,7 @@ matches the snapshot:
             otel: enabled
             tier: ks-control-plane
         spec:
+          affinity: null
           automountServiceAccountToken: true
           containers:
             - command:
@@ -1046,10 +1059,12 @@ matches the snapshot:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+          nodeSelector: null
           securityContext:
             fsGroup: 65532
             runAsUser: 65532
           serviceAccountName: kubescape
+          tolerations: null
           volumes:
             - name: cloud-secret
               secret:
@@ -1096,14 +1111,15 @@ matches the snapshot:
                 name: host-scanner
                 otel: enabled
             spec:
-
+              nodeSelector:
+              affinity:
               tolerations:
-              - effect: NoSchedule
-                key: node-role.kubernetes.io/control-plane
-                operator: Exists
-              - effect: NoSchedule
-                key: node-role.kubernetes.io/master
-                operator: Exists
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/master
+                  operator: Exists
               containers:
               - name: host-sensor
                 image: "quay.io/kubescape/host-scanner:v1.0.66"
@@ -1314,6 +1330,7 @@ matches the snapshot:
                 app.kubernetes.io/name: kubevuln-scheduler
                 armo.tier: vuln-scan
             spec:
+              affinity: null
               automountServiceAccountToken: false
               containers:
                 - args:
@@ -1343,7 +1360,9 @@ matches the snapshot:
                       name: kubevuln-scheduler
                       readOnly: true
                       subPath: request-body.json
+              nodeSelector: null
               restartPolicy: Never
+              tolerations: null
               volumes:
                 - configMap:
                     name: kubevuln-scheduler
@@ -1427,6 +1446,7 @@ matches the snapshot:
             otel: enabled
             tier: ks-control-plane
         spec:
+          affinity: null
           automountServiceAccountToken: true
           containers:
             - args:
@@ -1496,10 +1516,12 @@ matches the snapshot:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+          nodeSelector: null
           securityContext:
             fsGroup: 65532
             runAsUser: 65532
           serviceAccountName: kubevuln
+          tolerations: null
           volumes:
             - name: cloud-secret
               secret:
@@ -1766,17 +1788,6 @@ matches the snapshot:
                 seLinuxOptions:
                   type: spc_t
               volumeMounts:
-                - mountPath: /etc/credentials
-                  name: cloud-secret
-                  readOnly: true
-                - mountPath: /etc/config/clusterData.json
-                  name: ks-cloud-config
-                  readOnly: true
-                  subPath: clusterData.json
-                - mountPath: /etc/config/config.json
-                  name: config
-                  readOnly: true
-                  subPath: config.json
                 - mountPath: /host
                   name: host
                 - mountPath: /run
@@ -1791,6 +1802,17 @@ matches the snapshot:
                   name: bpffs
                 - mountPath: /data
                   name: data
+                - mountPath: /etc/credentials
+                  name: cloud-secret
+                  readOnly: true
+                - mountPath: /etc/config/clusterData.json
+                  name: ks-cloud-config
+                  readOnly: true
+                  subPath: clusterData.json
+                - mountPath: /etc/config/config.json
+                  name: config
+                  readOnly: true
+                  subPath: config.json
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
@@ -1798,7 +1820,28 @@ matches the snapshot:
           nodeSelector:
             kubernetes.io/os: linux
           serviceAccountName: node-agent
+          tolerations: null
           volumes:
+            - hostPath:
+                path: /
+              name: host
+            - hostPath:
+                path: /run
+              name: run
+            - hostPath:
+                path: /sys/fs/cgroup
+              name: cgroup
+            - hostPath:
+                path: /lib/modules
+              name: modules
+            - hostPath:
+                path: /sys/fs/bpf
+              name: bpffs
+            - hostPath:
+                path: /sys/kernel/debug
+              name: debugfs
+            - emptyDir: null
+              name: data
             - name: cloud-secret
               secret:
                 secretName: cloud-secret
@@ -1816,31 +1859,6 @@ matches the snapshot:
                     path: config.json
                 name: node-agent
               name: config
-            - hostPath:
-                path: /
-                type: null
-              name: host
-            - hostPath:
-                path: /run
-                type: null
-              name: run
-            - hostPath:
-                path: /sys/fs/cgroup
-                type: null
-              name: cgroup
-            - hostPath:
-                path: /lib/modules
-                type: null
-              name: modules
-            - hostPath:
-                path: /sys/fs/bpf
-                type: null
-              name: bpffs
-            - hostPath:
-                path: /sys/kernel/debug
-                type: null
-              name: debugfs
-            - name: data
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
@@ -1970,6 +1988,7 @@ matches the snapshot:
             otel: enabled
             tier: ks-control-plane
         spec:
+          affinity: null
           automountServiceAccountToken: true
           containers:
             - args:
@@ -2047,10 +2066,12 @@ matches the snapshot:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+          nodeSelector: null
           securityContext:
             fsGroup: 65532
             runAsUser: 65532
           serviceAccountName: operator
+          tolerations: null
           volumes:
             - name: cloud-secret
               secret:
@@ -2089,7 +2110,7 @@ matches the snapshot:
   50: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
     kind: ConfigMap
     metadata:
       labels:
@@ -2100,7 +2121,7 @@ matches the snapshot:
   51: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
     kind: ConfigMap
     metadata:
       labels:
@@ -2150,7 +2171,7 @@ matches the snapshot:
   53: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
     kind: ConfigMap
     metadata:
       labels:
@@ -2276,6 +2297,7 @@ matches the snapshot:
             app.kubernetes.io/name: otel-collector
             tier: ks-control-plane
         spec:
+          affinity: null
           containers:
             - command:
                 - /otelcol
@@ -2314,7 +2336,9 @@ matches the snapshot:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+          nodeSelector: null
           serviceAccountName: default
+          tolerations: null
           volumes:
             - name: proxy-secret
               secret:
@@ -2409,6 +2433,7 @@ matches the snapshot:
             tier: ks-control-plane
           name: RELEASE-NAME
         spec:
+          affinity: null
           containers:
             - args:
                 - |
@@ -2450,8 +2475,10 @@ matches the snapshot:
               volumeMounts:
                 - mountPath: /data
                   name: shared-data
+          nodeSelector: null
           restartPolicy: Never
           serviceAccountName: service-discovery
+          tolerations: null
           volumes:
             - emptyDir: {}
               name: shared-data
@@ -2603,6 +2630,7 @@ matches the snapshot:
             app.kubernetes.io/part-of: kubescape-storage
             otel: enabled
         spec:
+          affinity: null
           containers:
             - env:
                 - name: GOMEMLIMIT
@@ -2633,10 +2661,12 @@ matches the snapshot:
                 - mountPath: /etc/config
                   name: ks-cloud-config
                   readOnly: true
+          nodeSelector: null
           securityContext:
             fsGroup: 65532
             runAsUser: 65532
           serviceAccountName: storage
+          tolerations: null
           volumes:
             - name: data
               persistentVolumeClaim:
@@ -2899,6 +2929,7 @@ matches the snapshot:
             otel: enabled
             tier: ks-control-plane
         spec:
+          affinity: null
           automountServiceAccountToken: true
           containers:
             - command:
@@ -2956,10 +2987,12 @@ matches the snapshot:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+          nodeSelector: null
           securityContext:
             fsGroup: 65532
             runAsUser: 65532
           serviceAccountName: synchronizer
+          tolerations: null
           volumes:
             - name: cloud-secret
               secret:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -78,6 +78,14 @@ volumes: [ ]
 # Additional volumeMounts applied to all containers
 volumeMounts: [ ]
 
+customScheduling:
+  affinity:
+    # Specify affinity rules here
+  nodeSelector:
+    # Define nodeSelector rules here
+  tolerations:
+    # Set tolerations for nodes here
+
 # Enable persistence using Persistent Volume Claims
 persistence:
 


### PR DESCRIPTION
## Type
enhancement


___

## Description
This PR introduces several enhancements to the kubescape-operator Helm chart:
- Global volumes and volumeMounts have been added to various components, including the node agent, host scanner, and others. This allows for more flexible configuration of volumes across different components.
- Custom scheduling options have been introduced, allowing for the configuration of nodeSelector, affinity, and tolerations at a global level. These settings apply to all workloads managed by the kubescape-operator.
- The individual volume, volumeMount, and scheduling configurations in each component have been removed and replaced with the new global configurations.
- The README and values.yaml files have been updated to reflect these changes.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>daemonset.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/node-agent/daemonset.yaml<br><br>

**The file `daemonset.yaml` has been updated to include global <br>volumes and volumeMounts. It also includes custom scheduling <br>options for nodeSelector, affinity, and tolerations. The <br>previous individual volume and volumeMount configurations <br>have been removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/359/files#diff-87cf3c6035cbedc17bdc75a7055fa64e7e38d2e83f4b0a79654a4c37c94f4efd"> +27/-24</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>host-scanner-definition.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/assets/host-scanner-definition.yaml<br><br>

**The `host-scanner-definition.yaml` file has been updated to <br>include custom scheduling options for nodeSelector, <br>affinity, and tolerations. It also includes global volumes <br>and volumeMounts. The previous individual scheduling <br>configurations have been removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/359/files#diff-88152015cf1e3581505b2f76d7aa94865377739b68a0bf2cb83579b1f15cd7f9"> +24/-17</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cronjob.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml<br><br>

**The `cronjob.yaml` file under `kubevuln-scheduler` has been <br>updated to include custom scheduling options for <br>nodeSelector, affinity, and tolerations. The previous <br>individual scheduling configurations have been removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/359/files#diff-ddff8e50d506d0a065ea3d72b011a7e3d8e84da8e9f3d47f02b2fba92cd45d79"> +18/-12</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kubevuln-cronjob-full.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/assets/kubevuln-cronjob-full.yaml<br><br>

**The `kubevuln-cronjob-full.yaml` file has been updated to <br>include custom scheduling options for nodeSelector, <br>affinity, and tolerations. The previous individual <br>scheduling configurations have been removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/359/files#diff-a6c71225bcec775a304738cdcfc01ac0feb870555f0fa2297b0aaca4bc62cdd6"> +18/-12</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cronjob.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml<br><br>

**The `cronjob.yaml` file under `kubescape-scheduler` has been <br>updated to include custom scheduling options for <br>nodeSelector, affinity, and tolerations. The previous <br>individual scheduling configurations have been removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/359/files#diff-3b0bc577fe1782b485836dc0ac4bfdee71c366f129cb4b402b28ed83abecccb6"> +18/-12</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kubescape-cronjob-full.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/assets/kubescape-cronjob-full.yaml<br><br>

**The `kubescape-cronjob-full.yaml` file has been updated to <br>include custom scheduling options for nodeSelector, <br>affinity, and tolerations. The previous individual <br>scheduling configurations have been removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/359/files#diff-eff376bb4ed26da80ea2c541feba5a682792a562b5ae071ea12272f14497c7cb"> +18/-12</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>registry-scan-cronjob-full.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/assets/registry-scan-cronjob-full.yaml<br><br>

**The `registry-scan-cronjob-full.yaml` file has been updated <br>to include custom scheduling options for nodeSelector, <br>affinity, and tolerations. The previous individual <br>scheduling configurations have been removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/359/files#diff-efdcc6e194c517f765750120607f404139ecab11aa8612674cd3281f8355f96f"> +18/-12</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/storage/deployment.yaml<br><br>

**The `deployment.yaml` file under `storage` has been updated <br>to include custom scheduling options for nodeSelector, <br>affinity, and tolerations. The previous individual <br>scheduling configurations have been removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/359/files#diff-a0d251bc3c5b81dfcb6c909fcb6d0ec7675b475379cf1632ae3dfa22f0e6e52a"> +16/-10</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/kubevuln/deployment.yaml<br><br>

**The `deployment.yaml` file under `kubevuln` has been updated <br>to include custom scheduling options for nodeSelector, <br>affinity, and tolerations. The previous individual <br>scheduling configurations have been removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/359/files#diff-f7294729ce6b129a91f13f4ed1b7df6aaab5898ef645730498ad6b331d88d3f9"> +13/-7</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>statefulset.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/kollector/statefulset.yaml<br><br>

**The `statefulset.yaml` file under `kollector` has been <br>updated to include custom scheduling options for <br>nodeSelector, affinity, and tolerations. The previous <br>individual scheduling configurations have been removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/359/files#diff-0c2bffc690eb62fd6640a180b6b98fce986def31226f818700dc37f2f4fd4b74"> +13/-7</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/values.yaml<br><br>

**The `values.yaml` file has been updated to include new <br>`customScheduling` configuration options for nodeSelector, <br>affinity, and tolerations.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/359/files#diff-2d5611f69251d498d71f52fa778f6ce1bc93e1e1f46951ede1c50d975bdcad02"> +8/-0</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/README.md<br><br>

**The `README.md` file has been updated to include <br>documentation for the new `customScheduling` configuration <br>options.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/359/files#diff-29301ee79c4acf85dcfdaa8326521bc7676bd383dff72b2e41a08c86b6727327"> +4/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
