### PR TITLE
Fail on missing access key

### DIFF
--- a/charts/kubescape-operator/templates/_helpers.tpl
+++ b/charts/kubescape-operator/templates/_helpers.tpl
@@ -26,6 +26,9 @@ submit: {{ $submit }}
     {{- if and (empty .Values.account) $createCloudSecret -}}
       {{- fail "submitting is enabled but value for account is not defined: please register at https://cloud.armosec.io to get yours and re-run with  --set account=<your Guid>" }}
     {{- end -}}
+    {{- if and (empty .Values.accessKey) $createCloudSecret -}}
+      {{- fail "submitting is enabled but value for accessKey is not defined: To obtain an access key, go to 'Settings' -> 'Agent Access Keys' at https://cloud.armosec.io and re-run with  --set accessKey=<your key>" }}
+    {{- end -}}
     {{- if empty .Values.clusterName -}}
       {{- fail "value for clusterName is not defined: re-run with  --set clusterName=<your cluster name>" }}
     {{- end -}}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -92,7 +92,7 @@ all capabilities:
   6: |
     apiVersion: v1
     data:
-      accessKey: ""
+      accessKey: ZjMwNGQ3M2ItZDQzYy00MTJiLTgyZWEtZTRjODU5NDkzY2U2
       account: OWU2YzBjMmMtNmJkMC00OTE5LTgxNWItNTUwMzBkZTdjOWEw
     kind: Secret
     metadata:
@@ -204,7 +204,7 @@ all capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 253f0c05e8d2915ab3627479c2f810d8cf3d40b03c0807ec6af34da0e1d1e049
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
           labels:
             app: gateway
@@ -564,7 +564,7 @@ all capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 253f0c05e8d2915ab3627479c2f810d8cf3d40b03c0807ec6af34da0e1d1e049
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
           labels:
             app: kollector
@@ -957,7 +957,7 @@ all capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 253f0c05e8d2915ab3627479c2f810d8cf3d40b03c0807ec6af34da0e1d1e049
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/host-scanner-configmap: 2f2feb524edeabfcf23a0ded8294cb5169dbba6ad4251e9525564f3da04cae43
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
           labels:
@@ -1436,7 +1436,7 @@ all capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 253f0c05e8d2915ab3627479c2f810d8cf3d40b03c0807ec6af34da0e1d1e049
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
           labels:
             app: kubevuln
@@ -1719,7 +1719,7 @@ all capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 253f0c05e8d2915ab3627479c2f810d8cf3d40b03c0807ec6af34da0e1d1e049
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/node-agent-config: 1f1ed354ec149975e60a35866c9b74c952b526adddf8fdc41ecb1ca64e0aafa5
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
@@ -1976,7 +1976,7 @@ all capabilities:
           annotations:
             checksum/capabilities-config: 1805053085011dffd5ad88e6a8be1aaa7416d06688e1244b3cdfb857325cf957
             checksum/cloud-config: 253f0c05e8d2915ab3627479c2f810d8cf3d40b03c0807ec6af34da0e1d1e049
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/matching-rules-config: 0fe866ff165ca62399198397c07ab2d49af3181c569b3d0cce4a4cb310796824
             checksum/operator-config: df99a2aba9854372143be03476352384d33d686923ae071dde264c8c7ffbc999
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
@@ -2922,7 +2922,7 @@ all capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 253f0c05e8d2915ab3627479c2f810d8cf3d40b03c0807ec6af34da0e1d1e049
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
             checksum/synchronizer-configmap: 848dd8561ee759e419b37415a20528258c55a5ece19bb07df5df328bd0378fa7
           labels:
@@ -3051,11 +3051,11 @@ all capabilities:
       namespace: kubescape
 default capabilities:
   1: |
-    raw: "Thank you for installing kubescape-operator version 1.17.0.\nView your cluster's configuration scanning schedule:  \n> kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'\n\nTo change the schedule, set `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubescape-scheduler\nView your cluster's image scanning schedule:  \n> kubectl -n kubescape get cj kubevuln-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'  \n\nTo change the schedule, edit `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubevuln-scheduler\n\n\nView your image vulnerabilities scan summaries:  \n> kubectl get vulnerabilitymanifestsummaries -A\n\nDetailed reports are also available:  \n> kubectl get vulnerabilitymanifests -A\n\nkubescape-operator generates suggested network policies. To view them:  \n> kubectl get generatednetworkpolicies -n <namespace>\n\n"
+    raw: "Thank you for installing kubescape-operator version 1.17.1.\nView your cluster's configuration scanning schedule:  \n> kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'\n\nTo change the schedule, set `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubescape-scheduler\nView your cluster's image scanning schedule:  \n> kubectl -n kubescape get cj kubevuln-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'  \n\nTo change the schedule, edit `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubevuln-scheduler\n\n\nView your image vulnerabilities scan summaries:  \n> kubectl get vulnerabilitymanifestsummaries -A\n\nDetailed reports are also available:  \n> kubectl get vulnerabilitymanifests -A\n\nkubescape-operator generates suggested network policies. To view them:  \n> kubectl get generatednetworkpolicies -n <namespace>\n\n"
   2: |
     apiVersion: v1
     data:
-      accessKey: ""
+      accessKey: ZjMwNGQ3M2ItZDQzYy00MTJiLTgyZWEtZTRjODU5NDkzY2U2
       account: OWU2YzBjMmMtNmJkMC00OTE5LTgxNWItNTUwMzBkZTdjOWEw
     kind: Secret
     metadata:
@@ -3146,7 +3146,7 @@ default capabilities:
         app: gateway
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: gateway
-        helm.sh/chart: kubescape-operator-1.17.0
+        helm.sh/chart: kubescape-operator-1.17.1
         tier: ks-control-plane
       name: gateway
       namespace: kubescape
@@ -3167,7 +3167,7 @@ default capabilities:
         metadata:
           annotations:
             checksum/cloud-config: bc11c557570531f1993ebd8a8d6ee8174a1dd9f35c00e7640181b82eab213945
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
           labels:
             app: gateway
@@ -3272,7 +3272,7 @@ default capabilities:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: kubescape-operator-1.17.0
+        helm.sh/chart: kubescape-operator-1.17.1
         tier: ks-control-plane
       name: gateway
       namespace: kubescape
@@ -3350,7 +3350,7 @@ default capabilities:
             app: grype-offline-db
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: grype-offline-db
-            helm.sh/chart: kubescape-operator-1.17.0
+            helm.sh/chart: kubescape-operator-1.17.1
             tier: ks-control-plane
         spec:
           affinity: null
@@ -3527,13 +3527,13 @@ default capabilities:
         metadata:
           annotations:
             checksum/cloud-config: bc11c557570531f1993ebd8a8d6ee8174a1dd9f35c00e7640181b82eab213945
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
           labels:
             app: kollector
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kollector
-            helm.sh/chart: kubescape-operator-1.17.0
+            helm.sh/chart: kubescape-operator-1.17.1
             tier: ks-control-plane
         spec:
           affinity: null
@@ -3899,7 +3899,7 @@ default capabilities:
         app: kubescape
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape
-        helm.sh/chart: kubescape-operator-1.17.0
+        helm.sh/chart: kubescape-operator-1.17.1
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -3920,14 +3920,14 @@ default capabilities:
         metadata:
           annotations:
             checksum/cloud-config: bc11c557570531f1993ebd8a8d6ee8174a1dd9f35c00e7640181b82eab213945
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/host-scanner-configmap: 2f2feb524edeabfcf23a0ded8294cb5169dbba6ad4251e9525564f3da04cae43
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
           labels:
             app: kubescape
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubescape
-            helm.sh/chart: kubescape-operator-1.17.0
+            helm.sh/chart: kubescape-operator-1.17.1
             otel: enabled
             tier: ks-control-plane
         spec:
@@ -4154,7 +4154,7 @@ default capabilities:
     metadata:
       labels:
         app: kubescape
-        helm.sh/chart: kubescape-operator-1.17.0
+        helm.sh/chart: kubescape-operator-1.17.1
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -4399,13 +4399,13 @@ default capabilities:
         metadata:
           annotations:
             checksum/cloud-config: bc11c557570531f1993ebd8a8d6ee8174a1dd9f35c00e7640181b82eab213945
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
           labels:
             app: kubevuln
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubevuln
-            helm.sh/chart: kubescape-operator-1.17.0
+            helm.sh/chart: kubescape-operator-1.17.1
             otel: enabled
             tier: ks-control-plane
         spec:
@@ -4682,7 +4682,7 @@ default capabilities:
         metadata:
           annotations:
             checksum/cloud-config: bc11c557570531f1993ebd8a8d6ee8174a1dd9f35c00e7640181b82eab213945
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/node-agent-config: 1f1ed354ec149975e60a35866c9b74c952b526adddf8fdc41ecb1ca64e0aafa5
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
@@ -4691,7 +4691,7 @@ default capabilities:
             app: node-agent
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: node-agent
-            helm.sh/chart: kubescape-operator-1.17.0
+            helm.sh/chart: kubescape-operator-1.17.1
             otel: enabled
             tier: ks-control-plane
         spec:
@@ -4939,7 +4939,7 @@ default capabilities:
           annotations:
             checksum/capabilities-config: bbb5ef64298b555653ccfba6f72882a866f6108952db91250471993045ee7d74
             checksum/cloud-config: bc11c557570531f1993ebd8a8d6ee8174a1dd9f35c00e7640181b82eab213945
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/matching-rules-config: 0fe866ff165ca62399198397c07ab2d49af3181c569b3d0cce4a4cb310796824
             checksum/operator-config: df99a2aba9854372143be03476352384d33d686923ae071dde264c8c7ffbc999
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
@@ -4947,7 +4947,7 @@ default capabilities:
             app: operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: operator
-            helm.sh/chart: kubescape-operator-1.17.0
+            helm.sh/chart: kubescape-operator-1.17.1
             otel: enabled
             tier: ks-control-plane
         spec:
@@ -5232,7 +5232,7 @@ default capabilities:
         app: otel-collector
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: otel-collector
-        helm.sh/chart: kubescape-operator-1.17.0
+        helm.sh/chart: kubescape-operator-1.17.1
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -5315,7 +5315,7 @@ default capabilities:
     metadata:
       labels:
         app: otel-collector
-        helm.sh/chart: kubescape-operator-1.17.0
+        helm.sh/chart: kubescape-operator-1.17.1
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -5391,7 +5391,7 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: service-discovery
-            helm.sh/chart: kubescape-operator-1.17.0
+            helm.sh/chart: kubescape-operator-1.17.1
             otel: enabled
             tier: ks-control-plane
           name: RELEASE-NAME
@@ -5609,7 +5609,7 @@ default capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/storage:v0.0.51
+              image: quay.io/kubescape/storage:v0.0.54
               imagePullPolicy: IfNotPresent
               name: apiserver
               resources:
@@ -5885,14 +5885,14 @@ default capabilities:
         metadata:
           annotations:
             checksum/cloud-config: bc11c557570531f1993ebd8a8d6ee8174a1dd9f35c00e7640181b82eab213945
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
             checksum/synchronizer-configmap: 848dd8561ee759e419b37415a20528258c55a5ece19bb07df5df328bd0378fa7
           labels:
             app: synchronizer
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: synchronizer
-            helm.sh/chart: kubescape-operator-1.17.0
+            helm.sh/chart: kubescape-operator-1.17.1
             otel: enabled
             tier: ks-control-plane
         spec:
@@ -5915,7 +5915,7 @@ default capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/synchronizer:v0.0.28
+              image: quay.io/kubescape/synchronizer:v0.0.31
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -6014,12 +6014,12 @@ default capabilities:
       namespace: kubescape
 minimal capabilities:
   1: |
-    raw: "Thank you for installing kubescape-operator version 1.17.0.\nView your cluster's configuration scanning schedule:  \n> kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'\n\nTo change the schedule, set `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubescape-scheduler\nView your cluster's image scanning schedule:  \n> kubectl -n kubescape get cj kubevuln-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'  \n\nTo change the schedule, edit `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubevuln-scheduler\n\n\nView your image vulnerabilities scan summaries:  \n> kubectl get vulnerabilitymanifestsummaries -A\n\nDetailed reports are also available:  \n> kubectl get vulnerabilitymanifests -A\n\nkubescape-operator generates suggested network policies. To view them:  \n> kubectl get generatednetworkpolicies -n <namespace>\n\n"
+    raw: "Thank you for installing kubescape-operator version 1.17.1.\n\n\n\n\nView your image vulnerabilities scan summaries:  \n> kubectl get vulnerabilitymanifestsummaries -A\n\nDetailed reports are also available:  \n> kubectl get vulnerabilitymanifests -A\n\n\n\n"
   2: |
     apiVersion: v1
     data:
       accessKey: ""
-      account: OWU2YzBjMmMtNmJkMC00OTE5LTgxNWItNTUwMzBkZTdjOWEw
+      account: ""
     kind: Secret
     metadata:
       labels:
@@ -6034,7 +6034,7 @@ minimal capabilities:
     data:
       clusterData: |
         {
-          "serviceDiscovery": true,
+          "serviceDiscovery": false,
           "gatewayWebsocketURL": "gateway:8001",
           "gatewayRestURL": "gateway:8002",
           "vulnScanURL": "kubevuln:8080",
@@ -6050,22 +6050,14 @@ minimal capabilities:
           "otelCollector": true,
           "nodeAgent": "true",
           "maxImageSize": 5.36870912e+09,
-          "keepLocal": false,
+          "keepLocal": true,
           "scanTimeout": "5m",
           "vexGeneration": false,
           "continuousPostureScan": false,
           "relevantImageVulnerabilitiesConfiguration": "enable"
         }
-      metrics: ""
-      services: ""
     kind: ConfigMap
     metadata:
-      annotations:
-        argocd.argoproj.io/sync-options: Delete=false
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-delete-policy: before-hook-creation
-        helm.sh/hook-weight: "0"
-        helm.sh/resource-policy: keep
       labels:
         app: ks-cloud-config
         kubescape.io/infra: config
@@ -6077,8 +6069,8 @@ minimal capabilities:
     data:
       capabilities: |
         {
-          "capabilities":{"autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","networkPolicyService":"enable","nodeScan":"enable","relevancy":"enable","runtimeObservability":"enable","vexGeneration":"disable","vulnerabilityScan":"enable"},
-          "components":{"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
+          "capabilities":{"autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","networkPolicyService":"disable","nodeScan":"enable","relevancy":"enable","runtimeObservability":"disable","vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "components":{"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":false},"hostScanner":{"enabled":true},"kollector":{"enabled":false},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":false},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":false},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
           "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable"}
         }
     kind: ConfigMap
@@ -6101,398 +6093,6 @@ minimal capabilities:
       name: cs-matching-rules
       namespace: kubescape
   6: |
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      labels:
-        app: gateway
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: gateway
-        helm.sh/chart: kubescape-operator-1.17.0
-        tier: ks-control-plane
-      name: gateway
-      namespace: kubescape
-    spec:
-      replicas: 1
-      revisionHistoryLimit: 2
-      selector:
-        matchLabels:
-          app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: gateway
-          tier: ks-control-plane
-      strategy:
-        rollingUpdate:
-          maxSurge: 0%
-          maxUnavailable: 100%
-        type: RollingUpdate
-      template:
-        metadata:
-          annotations:
-            checksum/cloud-config: 6f0138a894063347b064cada3e9ae5025ccd2db588a6fea697e94b2481bb75fd
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
-          labels:
-            app: gateway
-            app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: gateway
-            tier: ks-control-plane
-        spec:
-          affinity: null
-          automountServiceAccountToken: false
-          containers:
-            - args:
-                - -alsologtostderr
-                - -v=4
-                - 2>&1
-              env:
-                - name: GOMEMLIMIT
-                  value: 30MiB
-                - name: KS_LOGGER_LEVEL
-                  value: info
-                - name: KS_LOGGER_NAME
-                  value: zap
-                - name: WEBSOCKET_PORT
-                  value: "8001"
-                - name: HTTP_PORT
-                  value: "8002"
-                - name: ACCOUNT_ID
-                  valueFrom:
-                    secretKeyRef:
-                      key: account
-                      name: cloud-secret
-                - name: OTEL_COLLECTOR_SVC
-                  value: otel-collector:4317
-              image: quay.io/kubescape/gateway:v0.1.20
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /v1/liveness
-                  port: readiness-port
-                initialDelaySeconds: 3
-                periodSeconds: 3
-              name: gateway
-              ports:
-                - containerPort: 8000
-                  name: readiness-port
-                  protocol: TCP
-                - containerPort: 8001
-                  name: websocket
-                  protocol: TCP
-                - containerPort: 8002
-                  name: rest-api
-                  protocol: TCP
-              readinessProbe:
-                httpGet:
-                  path: /v1/readiness
-                  port: readiness-port
-                initialDelaySeconds: 10
-                periodSeconds: 5
-              resources:
-                limits:
-                  cpu: 100m
-                  memory: 50Mi
-                requests:
-                  cpu: 10m
-                  memory: 30Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-              volumeMounts:
-                - mountPath: /etc/credentials
-                  name: cloud-secret
-                  readOnly: true
-                - mountPath: /etc/config
-                  name: ks-cloud-config
-                  readOnly: true
-          nodeSelector: null
-          securityContext:
-            fsGroup: 65532
-            runAsUser: 65532
-          tolerations: null
-          volumes:
-            - name: cloud-secret
-              secret:
-                secretName: cloud-secret
-            - configMap:
-                items:
-                  - key: clusterData
-                    path: clusterData.json
-                  - key: services
-                    path: services.json
-                name: ks-cloud-config
-              name: ks-cloud-config
-  7: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: gateway
-      name: gateway
-      namespace: kubescape
-    spec:
-      ports:
-        - name: websocket
-          port: 8001
-          protocol: TCP
-          targetPort: 8001
-        - name: http
-          port: 8002
-          protocol: TCP
-          targetPort: 8002
-      selector:
-        app: gateway
-      type: ClusterIP
-  8: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: kollector
-    rules:
-      - apiGroups:
-          - ""
-        resources:
-          - pods
-          - namespaces
-          - cronjobs
-          - secrets
-          - nodes
-          - services
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - apps
-        resources:
-          - deployments
-          - statefulsets
-          - daemonsets
-          - replicasets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - batch
-        resources:
-          - jobs
-          - cronjobs
-        verbs:
-          - get
-          - watch
-          - list
-  9: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: kollector
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: kollector
-    subjects:
-      - kind: ServiceAccount
-        name: kollector
-        namespace: kubescape
-  10: |
-    apiVersion: v1
-    automountServiceAccountToken: false
-    kind: ServiceAccount
-    metadata:
-      labels:
-        app: kollector
-      name: kollector
-      namespace: kubescape
-  11: |
-    apiVersion: apps/v1
-    kind: StatefulSet
-    metadata:
-      labels:
-        app: kollector
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: kollector
-        tier: ks-control-plane
-      name: kollector
-      namespace: kubescape
-    spec:
-      replicas: 1
-      selector:
-        matchLabels:
-          app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: kollector
-          tier: ks-control-plane
-      serviceName: ""
-      template:
-        metadata:
-          annotations:
-            checksum/cloud-config: 6f0138a894063347b064cada3e9ae5025ccd2db588a6fea697e94b2481bb75fd
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
-          labels:
-            app: kollector
-            app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: kollector
-            helm.sh/chart: kubescape-operator-1.17.0
-            tier: ks-control-plane
-        spec:
-          affinity: null
-          automountServiceAccountToken: true
-          containers:
-            - args:
-                - -alsologtostderr
-                - -v=4
-                - 2>&1
-              env:
-                - name: GOMEMLIMIT
-                  value: 100MiB
-                - name: KS_LOGGER_LEVEL
-                  value: info
-                - name: KS_LOGGER_NAME
-                  value: zap
-                - name: NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                - name: ACCOUNT_ID
-                  valueFrom:
-                    secretKeyRef:
-                      key: account
-                      name: cloud-secret
-                - name: OTEL_COLLECTOR_SVC
-                  value: otel-collector:4317
-                - name: PRINT_REPORT
-                  value: "false"
-                - name: WAIT_BEFORE_REPORT
-                  value: "0"
-              image: quay.io/kubescape/kollector:v0.1.33
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /v1/liveness
-                  port: readiness-port
-                initialDelaySeconds: 3
-                periodSeconds: 3
-              name: kollector
-              ports:
-                - containerPort: 8000
-                  name: readiness-port
-                  protocol: TCP
-              readinessProbe:
-                httpGet:
-                  path: /v1/readiness
-                  port: readiness-port
-                initialDelaySeconds: 10
-                periodSeconds: 5
-              resources:
-                limits:
-                  cpu: 500m
-                  memory: 500Mi
-                requests:
-                  cpu: 10m
-                  memory: 100Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-                runAsUser: 100
-              volumeMounts:
-                - mountPath: /etc/credentials
-                  name: cloud-secret
-                  readOnly: true
-                - mountPath: /tmp
-                  name: tmp-dir
-                - mountPath: /etc/config
-                  name: ks-cloud-config
-                  readOnly: true
-          nodeSelector: null
-          serviceAccountName: kollector
-          tolerations: null
-          volumes:
-            - name: cloud-secret
-              secret:
-                secretName: cloud-secret
-            - emptyDir: {}
-              name: tmp-dir
-            - configMap:
-                items:
-                  - key: clusterData
-                    path: clusterData.json
-                  - key: services
-                    path: services.json
-                name: ks-cloud-config
-              name: ks-cloud-config
-  12: |
-    apiVersion: v1
-    data:
-      request-body.json: '{"commands":[{"CommandName":"kubescapeScan","args":{"scanV1": {}}}]}'
-    kind: ConfigMap
-    metadata:
-      labels:
-        app: kubescape-scheduler
-        tier: ks-control-plane
-      name: kubescape-scheduler
-      namespace: kubescape
-  13: |
-    apiVersion: batch/v1
-    kind: CronJob
-    metadata:
-      labels:
-        app: kubescape-scheduler
-        app.kubernetes.io/name: kubescape-scheduler
-        armo.tier: kubescape-scan
-        tier: ks-control-plane
-      name: kubescape-scheduler
-      namespace: kubescape
-    spec:
-      failedJobsHistoryLimit: 1
-      jobTemplate:
-        spec:
-          template:
-            metadata:
-              labels:
-                app: kubescape-scheduler
-                app.kubernetes.io/name: kubescape-scheduler
-                armo.tier: kubescape-scan
-            spec:
-              affinity: null
-              automountServiceAccountToken: false
-              containers:
-                - args:
-                    - -method=post
-                    - -scheme=http
-                    - -host=operator:4002
-                    - -path=v1/triggerAction
-                    - -headers="Content-Type:application/json"
-                    - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.0.14
-                  imagePullPolicy: IfNotPresent
-                  name: kubescape-scheduler
-                  resources:
-                    limits:
-                      cpu: 10m
-                      memory: 20Mi
-                    requests:
-                      cpu: 1m
-                      memory: 10Mi
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    readOnlyRootFilesystem: true
-                    runAsNonRoot: true
-                    runAsUser: 100
-                  volumeMounts:
-                    - mountPath: /home/ks/request-body.json
-                      name: kubescape-scheduler
-                      readOnly: true
-                      subPath: request-body.json
-              nodeSelector: null
-              restartPolicy: Never
-              tolerations: null
-              volumes:
-                - configMap:
-                    name: kubescape-scheduler
-                  name: kubescape-scheduler
-      schedule: 1 2 3 4 5
-      successfulJobsHistoryLimit: 3
-  14: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -6670,7 +6270,7 @@ minimal capabilities:
           - create
           - update
           - patch
-  15: |
+  7: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -6683,7 +6283,7 @@ minimal capabilities:
       - kind: ServiceAccount
         name: kubescape
         namespace: kubescape
-  16: |
+  8: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -6691,7 +6291,7 @@ minimal capabilities:
         app: kubescape
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape
-        helm.sh/chart: kubescape-operator-1.17.0
+        helm.sh/chart: kubescape-operator-1.17.1
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -6711,14 +6311,14 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 6f0138a894063347b064cada3e9ae5025ccd2db588a6fea697e94b2481bb75fd
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-config: 95260ac6946b5771081a57105074148c915f2c581ad49cb97889ac0206e238f8
+            checksum/cloud-secret: 436faa29a74a6ab2b6ee2ae0faaa0576d663745a9780780fa53afa02a945dddb
             checksum/host-scanner-configmap: 2f2feb524edeabfcf23a0ded8294cb5169dbba6ad4251e9525564f3da04cae43
           labels:
             app: kubescape
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubescape
-            helm.sh/chart: kubescape-operator-1.17.0
+            helm.sh/chart: kubescape-operator-1.17.1
             otel: enabled
             tier: ks-control-plane
         spec:
@@ -6824,8 +6424,6 @@ minimal capabilities:
                 items:
                   - key: clusterData
                     path: clusterData.json
-                  - key: services
-                    path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
             - configMap:
@@ -6837,7 +6435,7 @@ minimal capabilities:
               name: results
             - emptyDir: {}
               name: failed
-  17: |
+  9: |
     apiVersion: v1
     data:
       host-scanner-yaml: |-
@@ -6933,7 +6531,7 @@ minimal capabilities:
         tier: ks-control-plane
       name: host-scanner-definition
       namespace: kubescape
-  18: |
+  10: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -6952,7 +6550,7 @@ minimal capabilities:
           - list
           - patch
           - delete
-  19: |
+  11: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -6966,7 +6564,7 @@ minimal capabilities:
       - kind: ServiceAccount
         name: kubescape
         namespace: kubescape
-  20: |
+  12: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -6983,7 +6581,7 @@ minimal capabilities:
       selector:
         app: kubescape
       type: ClusterIP
-  21: |
+  13: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -6992,79 +6590,7 @@ minimal capabilities:
         app: kubescape
       name: kubescape
       namespace: kubescape
-  22: |
-    apiVersion: v1
-    data:
-      request-body.json: '{"commands":[{"commandName":"scan","designators":[{"designatorType":"Attributes","attributes":{}}]}]}'
-    kind: ConfigMap
-    metadata:
-      labels:
-        app: kubevuln-scheduler
-        tier: ks-control-plane
-      name: kubevuln-scheduler
-      namespace: kubescape
-  23: |
-    apiVersion: batch/v1
-    kind: CronJob
-    metadata:
-      labels:
-        app: kubevuln-scheduler
-        app.kubernetes.io/name: kubevuln-scheduler
-        armo.tier: vuln-scan
-        tier: ks-control-plane
-      name: kubevuln-scheduler
-      namespace: kubescape
-    spec:
-      failedJobsHistoryLimit: 1
-      jobTemplate:
-        spec:
-          template:
-            metadata:
-              labels:
-                app: kubevuln-scheduler
-                app.kubernetes.io/name: kubevuln-scheduler
-                armo.tier: vuln-scan
-            spec:
-              affinity: null
-              automountServiceAccountToken: false
-              containers:
-                - args:
-                    - -method=post
-                    - -scheme=http
-                    - -host=operator:4002
-                    - -path=v1/triggerAction
-                    - -headers="Content-Type:application/json"
-                    - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.0.14
-                  imagePullPolicy: IfNotPresent
-                  name: kubevuln-scheduler
-                  resources:
-                    limits:
-                      cpu: 10m
-                      memory: 20Mi
-                    requests:
-                      cpu: 1m
-                      memory: 10Mi
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    readOnlyRootFilesystem: true
-                    runAsNonRoot: true
-                    runAsUser: 100
-                  volumeMounts:
-                    - mountPath: /home/ks/request-body.json
-                      name: kubevuln-scheduler
-                      readOnly: true
-                      subPath: request-body.json
-              nodeSelector: null
-              restartPolicy: Never
-              tolerations: null
-              volumes:
-                - configMap:
-                    name: kubevuln-scheduler
-                  name: kubevuln-scheduler
-      schedule: 1 2 3 4 5
-      successfulJobsHistoryLimit: 3
-  24: |
+  14: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -7093,7 +6619,7 @@ minimal capabilities:
           - get
           - watch
           - list
-  25: |
+  15: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -7106,7 +6632,7 @@ minimal capabilities:
       - kind: ServiceAccount
         name: kubevuln
         namespace: kubescape
-  26: |
+  16: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -7130,13 +6656,13 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 6f0138a894063347b064cada3e9ae5025ccd2db588a6fea697e94b2481bb75fd
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/cloud-config: 95260ac6946b5771081a57105074148c915f2c581ad49cb97889ac0206e238f8
+            checksum/cloud-secret: 436faa29a74a6ab2b6ee2ae0faaa0576d663745a9780780fa53afa02a945dddb
           labels:
             app: kubevuln
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubevuln
-            helm.sh/chart: kubescape-operator-1.17.0
+            helm.sh/chart: kubescape-operator-1.17.1
             otel: enabled
             tier: ks-control-plane
         spec:
@@ -7225,13 +6751,11 @@ minimal capabilities:
                 items:
                   - key: clusterData
                     path: clusterData.json
-                  - key: services
-                    path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
             - emptyDir: {}
               name: grype-db
-  27: |
+  17: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -7247,7 +6771,7 @@ minimal capabilities:
       selector:
         app: kubevuln
       type: ClusterIP
-  28: |
+  18: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -7256,7 +6780,7 @@ minimal capabilities:
         app: kubevuln
       name: kubevuln
       namespace: kubescape
-  29: |
+  19: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -7325,7 +6849,7 @@ minimal capabilities:
           - watch
           - list
           - patch
-  30: |
+  20: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -7338,23 +6862,23 @@ minimal capabilities:
       - kind: ServiceAccount
         name: node-agent
         namespace: kubescape
-  31: |
+  21: |
     apiVersion: v1
     data:
       config.json: |
         {
-            "applicationProfileServiceEnabled": true,
+            "applicationProfileServiceEnabled": false,
             "relevantCVEServiceEnabled": true,
             "InitialDelay": "2m",
             "updateDataPeriod": "10m",
             "maxSniffingTimePerContainer": "3h",
-            "networkServiceEnabled":  "true"
+            "networkServiceEnabled":  "false"
         }
     kind: ConfigMap
     metadata:
       name: node-agent
       namespace: kubescape
-  32: |
+  22: |
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
@@ -7374,16 +6898,16 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 6f0138a894063347b064cada3e9ae5025ccd2db588a6fea697e94b2481bb75fd
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
-            checksum/node-agent-config: 1f1ed354ec149975e60a35866c9b74c952b526adddf8fdc41ecb1ca64e0aafa5
+            checksum/cloud-config: 95260ac6946b5771081a57105074148c915f2c581ad49cb97889ac0206e238f8
+            checksum/cloud-secret: 436faa29a74a6ab2b6ee2ae0faaa0576d663745a9780780fa53afa02a945dddb
+            checksum/node-agent-config: 86b38ffc87a7df25c377369ecdf4cccf7d10f2c4fc1d29f3e220f39b74906de6
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             alt-name: node-agent
             app: node-agent
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: node-agent
-            helm.sh/chart: kubescape-operator-1.17.0
+            helm.sh/chart: kubescape-operator-1.17.1
             otel: enabled
             tier: ks-control-plane
         spec:
@@ -7501,8 +7025,6 @@ minimal capabilities:
                 items:
                   - key: clusterData
                     path: clusterData.json
-                  - key: services
-                    path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
             - configMap:
@@ -7511,13 +7033,13 @@ minimal capabilities:
                     path: config.json
                 name: node-agent
               name: config
-  33: |
+  23: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
       name: node-agent
       namespace: kubescape
-  34: |
+  24: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -7571,7 +7093,7 @@ minimal capabilities:
           - watch
           - list
           - delete
-  35: |
+  25: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -7584,7 +7106,7 @@ minimal capabilities:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  36: |
+  26: |
     apiVersion: v1
     data:
       config.json: |
@@ -7596,7 +7118,7 @@ minimal capabilities:
     metadata:
       name: operator
       namespace: kubescape
-  37: |
+  27: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -7623,16 +7145,16 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: bbb5ef64298b555653ccfba6f72882a866f6108952db91250471993045ee7d74
-            checksum/cloud-config: 6f0138a894063347b064cada3e9ae5025ccd2db588a6fea697e94b2481bb75fd
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
+            checksum/capabilities-config: c52025572b815c3339cfa6983574e8f3f61d8fba23d7cc543f1945d2ca364a33
+            checksum/cloud-config: 95260ac6946b5771081a57105074148c915f2c581ad49cb97889ac0206e238f8
+            checksum/cloud-secret: 436faa29a74a6ab2b6ee2ae0faaa0576d663745a9780780fa53afa02a945dddb
             checksum/matching-rules-config: 0fe866ff165ca62399198397c07ab2d49af3181c569b3d0cce4a4cb310796824
             checksum/operator-config: df99a2aba9854372143be03476352384d33d686923ae071dde264c8c7ffbc999
           labels:
             app: operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: operator
-            helm.sh/chart: kubescape-operator-1.17.0
+            helm.sh/chart: kubescape-operator-1.17.1
             otel: enabled
             tier: ks-control-plane
         spec:
@@ -7695,10 +7217,6 @@ minimal capabilities:
                   name: ks-cloud-config
                   readOnly: true
                   subPath: clusterData.json
-                - mountPath: /etc/config/services.json
-                  name: ks-cloud-config
-                  readOnly: true
-                  subPath: services.json
                 - mountPath: /etc/config/capabilities.json
                   name: ks-capabilities
                   readOnly: true
@@ -7727,8 +7245,6 @@ minimal capabilities:
                 items:
                   - key: clusterData
                     path: clusterData.json
-                  - key: services
-                    path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
             - configMap:
@@ -7749,7 +7265,7 @@ minimal capabilities:
                     path: matchingRules.json
                 name: cs-matching-rules
               name: cs-matching-rules
-  38: |
+  28: |
     apiVersion: v1
     data:
       cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
@@ -7760,7 +7276,7 @@ minimal capabilities:
         tier: ks-control-plane
       name: kubescape-cronjob-template
       namespace: kubescape
-  39: |
+  29: |
     apiVersion: v1
     data:
       cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
@@ -7771,7 +7287,7 @@ minimal capabilities:
         tier: ks-control-plane
       name: kubevuln-cronjob-template
       namespace: kubescape
-  40: |
+  30: |
     apiVersion: v1
     data:
       cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
@@ -7782,7 +7298,7 @@ minimal capabilities:
         tier: ks-control-plane
       name: registry-scan-cronjob-template
       namespace: kubescape
-  41: |
+  31: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -7814,7 +7330,7 @@ minimal capabilities:
           - list
           - patch
           - delete
-  42: |
+  32: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -7828,7 +7344,7 @@ minimal capabilities:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  43: |
+  33: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -7844,7 +7360,7 @@ minimal capabilities:
       selector:
         app: operator
       type: ClusterIP
-  44: |
+  34: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -7853,10 +7369,10 @@ minimal capabilities:
         app: operator
       name: operator
       namespace: kubescape
-  45: |
+  35: |
     apiVersion: v1
     data:
-      otel-collector-config.yaml: "\n# receivers configure how data gets into the Collector.\nreceivers:\n  otlp:\n    protocols:\n      grpc:\n      http:\n  hostmetrics:\n    collection_interval: 30s\n    scrapers:\n      cpu:\n      memory:\n\n# processors specify what happens with the received data.\nprocessors:\n  attributes/ksCloud:\n    actions:\n      - key: account_id\n        value: \"9e6c0c2c-6bd0-4919-815b-55030de7c9a0\"\n        action: upsert\n      - key: cluster_name\n        value: \"kind-kind\"\n        action: upsert\n  batch:\n    send_batch_size: 10000\n    timeout: 10s\n\n# exporters configure how to send processed data to one or more backends.\nexporters:\n  otlp/ksCloud:\n    endpoint: ${env:CLOUD_OTEL_COLLECTOR_URL}\n    tls:\n      insecure: false\n  otlp:\n    endpoint: \"otelCollector:4317\"\n    tls:\n      insecure: true\n    headers:\n      uptrace-dsn: \n\n# service pulls the configured receivers, processors, and exporters together into\n# processing pipelines. Unused receivers/processors/exporters are ignored.\nservice:\n  pipelines:\n    traces:\n      receivers: [otlp]\n      processors: [batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp\n    metrics/2:\n      receivers: [hostmetrics]\n      processors: [attributes/ksCloud, batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp\n    metrics:\n      receivers: [otlp]\n      processors: [attributes/ksCloud, batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp\n    logs:\n      receivers: [otlp]\n      processors: [attributes/ksCloud, batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp"
+      otel-collector-config.yaml: "\n# receivers configure how data gets into the Collector.\nreceivers:\n  otlp:\n    protocols:\n      grpc:\n      http:\n  hostmetrics:\n    collection_interval: 30s\n    scrapers:\n      cpu:\n      memory:\n\n# processors specify what happens with the received data.\nprocessors:\n  attributes/ksCloud:\n    actions:\n      - key: account_id\n        value: \"\"\n        action: upsert\n      - key: cluster_name\n        value: \"kind-kind\"\n        action: upsert\n  batch:\n    send_batch_size: 10000\n    timeout: 10s\n\n# exporters configure how to send processed data to one or more backends.\nexporters:\n  otlp/ksCloud:\n    endpoint: \"\"\n    tls:\n      insecure: false\n  otlp:\n    endpoint: \"otelCollector:4317\"\n    tls:\n      insecure: true\n    headers:\n      uptrace-dsn: \n\n# service pulls the configured receivers, processors, and exporters together into\n# processing pipelines. Unused receivers/processors/exporters are ignored.\nservice:\n  pipelines:\n    traces:\n      receivers: [otlp]\n      processors: [batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp\n    metrics/2:\n      receivers: [hostmetrics]\n      processors: [attributes/ksCloud, batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp\n    metrics:\n      receivers: [otlp]\n      processors: [attributes/ksCloud, batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp\n    logs:\n      receivers: [otlp]\n      processors: [attributes/ksCloud, batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp"
     kind: ConfigMap
     metadata:
       labels:
@@ -7864,7 +7380,7 @@ minimal capabilities:
         tier: ks-control-plane
       name: otel-collector-config
       namespace: kubescape
-  46: |
+  36: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -7872,7 +7388,7 @@ minimal capabilities:
         app: otel-collector
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: otel-collector
-        helm.sh/chart: kubescape-operator-1.17.0
+        helm.sh/chart: kubescape-operator-1.17.1
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -7892,7 +7408,7 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/otel-config: 50f39d2b201f211b8888a7e2cca3cfdebc768bcd17f2edb46a2316a67d662b1e
+            checksum/otel-config: d88df58b9cc02dce79750f71c91e974f73b768cc499d08a285517a4a4664e9ab
           labels:
             app: otel-collector
             app.kubernetes.io/instance: RELEASE-NAME
@@ -7942,7 +7458,7 @@ minimal capabilities:
             - configMap:
                 name: otel-collector-config
               name: otel-collector-config-volume
-  47: |
+  37: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -7959,132 +7475,7 @@ minimal capabilities:
       selector:
         app: otel-collector
       type: ClusterIP
-  48: |
-    apiVersion: batch/v1
-    kind: Job
-    metadata:
-      annotations:
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-        helm.sh/hook-weight: "1"
-      labels:
-        app: service-discovery
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: service-discovery
-        tier: ks-control-plane
-      name: service-discovery
-      namespace: kubescape
-    spec:
-      template:
-        metadata:
-          labels:
-            app: service-discovery
-            app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: service-discovery
-            helm.sh/chart: kubescape-operator-1.17.0
-            otel: enabled
-            tier: ks-control-plane
-          name: RELEASE-NAME
-        spec:
-          affinity: null
-          containers:
-            - args:
-                - |
-                  kubectl create configmap ks-cloud-config --from-literal=metrics=$(jq -r '.response.metrics' /data/services.json) --from-file=services=/data/services.json -n kubescape --dry-run=client -o yaml | kubectl patch configmap ks-cloud-config --patch "$(cat -)" -n kubescape
-              command:
-                - /bin/sh
-                - -c
-              image: docker.io/bitnami/kubectl:1.27.6
-              imagePullPolicy: IfNotPresent
-              name: update-configmap
-              resources:
-                limits:
-                  cpu: 100m
-                  memory: 50Mi
-                requests:
-                  cpu: 10m
-                  memory: 10Mi
-              volumeMounts:
-                - mountPath: /data
-                  name: shared-data
-          initContainers:
-            - args:
-                - -method=get
-                - -scheme=https
-                - -host=api.armosec.io
-                - -path=api/v2/servicediscovery
-                - -path-output=/data/services.json
-              env: null
-              image: quay.io/kubescape/http-request:v0.2.2
-              imagePullPolicy: IfNotPresent
-              name: url-discovery
-              resources:
-                limits:
-                  cpu: 100m
-                  memory: 50Mi
-                requests:
-                  cpu: 10m
-                  memory: 10Mi
-              volumeMounts:
-                - mountPath: /data
-                  name: shared-data
-          nodeSelector: null
-          restartPolicy: Never
-          serviceAccountName: service-discovery
-          tolerations: null
-          volumes:
-            - emptyDir: {}
-              name: shared-data
-  49: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-      annotations:
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-        helm.sh/hook-weight: "0"
-      name: service-discovery
-      namespace: kubescape
-    rules:
-      - apiGroups:
-          - ""
-        resources:
-          - configmaps
-        verbs:
-          - update
-          - create
-          - patch
-          - get
-          - list
-  50: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-      annotations:
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-        helm.sh/hook-weight: "0"
-      name: service-discovery
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: Role
-      name: service-discovery
-    subjects:
-      - kind: ServiceAccount
-        name: service-discovery
-        namespace: kubescape
-  51: |
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      annotations:
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-        helm.sh/hook-weight: "0"
-      name: service-discovery
-      namespace: kubescape
-  52: |
+  38: |
     apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
@@ -8098,7 +7489,7 @@ minimal capabilities:
         namespace: kubescape
       version: v1beta1
       versionPriority: 15
-  53: |
+  39: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -8130,7 +7521,7 @@ minimal capabilities:
           - get
           - watch
           - list
-  54: |
+  40: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -8143,7 +7534,7 @@ minimal capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  55: |
+  41: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -8156,7 +7547,7 @@ minimal capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  56: |
+  42: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -8200,7 +7591,7 @@ minimal capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/storage:v0.0.51
+              image: quay.io/kubescape/storage:v0.0.54
               imagePullPolicy: IfNotPresent
               name: apiserver
               resources:
@@ -8233,11 +7624,9 @@ minimal capabilities:
                 items:
                   - key: clusterData
                     path: clusterData.json
-                  - key: services
-                    path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  57: |
+  43: |
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
@@ -8253,7 +7642,7 @@ minimal capabilities:
       resources:
         requests:
           storage: 5Gi
-  58: |
+  44: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -8267,7 +7656,7 @@ minimal capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  59: |
+  45: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -8282,295 +7671,9 @@ minimal capabilities:
         app.kubernetes.io/component: apiserver
         app.kubernetes.io/name: storage
         app.kubernetes.io/part-of: kubescape-storage
-  60: |
+  46: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
       name: storage
-      namespace: kubescape
-  61: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: synchronizer
-    rules:
-      - apiGroups:
-          - ""
-        resources:
-          - pods
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - apps
-        resources:
-          - deployments
-          - statefulsets
-          - daemonsets
-          - replicasets
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - batch
-        resources:
-          - jobs
-          - cronjobs
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - networking.k8s.io
-        resources:
-          - networkpolicies
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationactivities
-          - applicationprofiles
-          - networkneighborses
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - knownservers
-        verbs:
-          - get
-          - watch
-          - list
-          - create
-          - update
-          - patch
-          - delete
-  62: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: synchronizer
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: synchronizer
-    subjects:
-      - kind: ServiceAccount
-        name: synchronizer
-        namespace: kubescape
-  63: |
-    apiVersion: v1
-    data:
-      config.json: |
-        {
-          "inCluster": {
-            "resources": [
-              {
-                "group": "apps",
-                "version": "v1",
-                "resource": "deployments",
-                "strategy": "patch"
-              },
-              {
-                "group": "apps",
-                "version": "v1",
-                "resource": "statefulsets",
-                "strategy": "patch"
-              },
-              {
-                "group": "apps",
-                "version": "v1",
-                "resource": "daemonsets",
-                "strategy": "patch"
-              },
-              {
-                "group": "apps",
-                "version": "v1",
-                "resource": "replicasets",
-                "strategy": "patch"
-              },
-              {
-                "group": "batch",
-                "version": "v1",
-                "resource": "jobs",
-                "strategy": "patch"
-              },
-              {
-                "group": "batch",
-                "version": "v1",
-                "resource": "cronjobs",
-                "strategy": "patch"
-              },
-              {
-                "group": "",
-                "version": "v1",
-                "resource": "pods",
-                "strategy": "patch"
-              },
-              {
-                "group": "networking.k8s.io",
-                "version": "v1",
-                "resource": "networkpolicies",
-                "strategy": "patch"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "applicationactivities",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborses",
-                "strategy": "copy"
-              }
-            ]
-          }
-        }
-    kind: ConfigMap
-    metadata:
-      name: synchronizer
-      namespace: kubescape
-  64: |
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      labels:
-        app: synchronizer
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: synchronizer
-        tier: ks-control-plane
-      name: synchronizer
-      namespace: kubescape
-    spec:
-      replicas: null
-      revisionHistoryLimit: 2
-      selector:
-        matchLabels:
-          app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: synchronizer
-          tier: ks-control-plane
-      strategy:
-        type: Recreate
-      template:
-        metadata:
-          annotations:
-            checksum/cloud-config: 6f0138a894063347b064cada3e9ae5025ccd2db588a6fea697e94b2481bb75fd
-            checksum/cloud-secret: 7a52a6a06abb711221729ad1ea112ce6b3d64144afde7ff807e46ed477fa2fe6
-            checksum/synchronizer-configmap: 848dd8561ee759e419b37415a20528258c55a5ece19bb07df5df328bd0378fa7
-          labels:
-            app: synchronizer
-            app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: synchronizer
-            helm.sh/chart: kubescape-operator-1.17.0
-            otel: enabled
-            tier: ks-control-plane
-        spec:
-          affinity: null
-          automountServiceAccountToken: true
-          containers:
-            - command:
-                - /usr/bin/client
-              env:
-                - name: GOMEMLIMIT
-                  value: 250MiB
-                - name: KS_LOGGER_LEVEL
-                  value: info
-                - name: KS_LOGGER_NAME
-                  value: zap
-                - name: ACCOUNT_ID
-                  valueFrom:
-                    secretKeyRef:
-                      key: account
-                      name: cloud-secret
-                - name: OTEL_COLLECTOR_SVC
-                  value: otel-collector:4317
-              image: quay.io/kubescape/synchronizer:v0.0.28
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /healthz
-                  port: 7888
-                initialDelaySeconds: 3
-                periodSeconds: 3
-              name: synchronizer
-              resources:
-                limits:
-                  cpu: 200m
-                  memory: 500Mi
-                requests:
-                  cpu: 100m
-                  memory: 250Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-              volumeMounts:
-                - mountPath: /etc/credentials
-                  name: cloud-secret
-                  readOnly: true
-                - mountPath: /etc/config/clusterData.json
-                  name: ks-cloud-config
-                  readOnly: true
-                  subPath: clusterData.json
-                - mountPath: /etc/config/services.json
-                  name: ks-cloud-config
-                  readOnly: true
-                  subPath: services.json
-                - mountPath: /etc/config/config.json
-                  name: config
-                  readOnly: true
-                  subPath: config.json
-          nodeSelector: null
-          securityContext:
-            fsGroup: 65532
-            runAsUser: 65532
-          serviceAccountName: synchronizer
-          tolerations: null
-          volumes:
-            - name: cloud-secret
-              secret:
-                secretName: cloud-secret
-            - configMap:
-                items:
-                  - key: clusterData
-                    path: clusterData.json
-                  - key: services
-                    path: services.json
-                name: ks-cloud-config
-              name: ks-cloud-config
-            - configMap:
-                items:
-                  - key: config.json
-                    path: config.json
-                name: synchronizer
-              name: config
-  65: |
-    apiVersion: v1
-    automountServiceAccountToken: false
-    kind: ServiceAccount
-    metadata:
-      labels:
-        app: synchronizer
-      name: synchronizer
       namespace: kubescape

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -8,6 +8,7 @@ tests:
         - batch/v1/CronJob
     set:
       account: 9e6c0c2c-6bd0-4919-815b-55030de7c9a0
+      accessKey: f304d73b-d43c-412b-82ea-e4c859493ce6
       capabilities:
         configurationScan: enable
         continuousScan: enable
@@ -37,8 +38,6 @@ tests:
       apiVersions:
         - batch/v1/CronJob
     set:
-      account: 9e6c0c2c-6bd0-4919-815b-55030de7c9a0
-      server: api.armosec.io
       configurations.otelUrl: "otelCollector:4317"
       clusterName: kind-kind
       kubescapeScheduler.scanSchedule: "1 2 3 4 5"
@@ -51,6 +50,7 @@ tests:
         - batch/v1/CronJob
     set:
       account: 9e6c0c2c-6bd0-4919-815b-55030de7c9a0
+      accessKey: f304d73b-d43c-412b-82ea-e4c859493ce6
       capabilities:
         configurationScan: enable
         continuousScan: disable


### PR DESCRIPTION
## User description
## Overview

When submit is enabled we only require value for account, however, a Kubescape-compatible backend should also require an access key. 
As part of this PR, installing the chart will fail if access key is not provided when working with submit is enabled (similar to account).


___

## Type
Enhancement


___

## Description
- The PR introduces a check to fail the installation if the `accessKey` is not provided when `submit` is enabled. This is similar to the existing check for the `account`.
- The `accessKey` has been added to the test configuration in `snapshot_test.yaml`.


___

## Changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_helpers.tpl&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/_helpers.tpl<br><br>

**Added a check to fail the installation if the `accessKey` is <br>not provided when `submit` is enabled. This is similar to <br>the existing check for the `account`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/371/files#diff-aa81f2ba9ca60237f5e62c64faf4e05f73d0f94f6ed0b9773aed5a84aedf993c"> +3/-0</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapshot_test.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/tests/snapshot_test.yaml<br><br>

**Added `accessKey` to the test configuration.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/371/files#diff-1914664e59de0998b316c82729e267ff27790dfecd5830bded0dc0ddedbffaad"> +1/-0</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
