### PR TITLE
fix cron templates

### DIFF
--- a/charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml
+++ b/charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml
@@ -1,5 +1,5 @@
-{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
-  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- if not (.Capabilities.APIVersions.Has "batch/v1") }}
+  {{- fail "`batch/v1 not supported`" }}
 {{- end }}
 {{- $components := fromYaml (include "components" .) }}
 {{- if $components.kubescapeScheduler.enabled }}

--- a/charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml
+++ b/charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml
@@ -1,5 +1,5 @@
-{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
-  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- if not (.Capabilities.APIVersions.Has "batch/v1") }}
+  {{- fail "`batch/v1 not supported`" }}
 {{- end }}
 {{- $components := fromYaml (include "components" .) }}
 {{- if $components.kubevulnScheduler.enabled }}

--- a/charts/kubescape-operator/templates/operator/ks-recurring-cronjob-configmap.yaml
+++ b/charts/kubescape-operator/templates/operator/ks-recurring-cronjob-configmap.yaml
@@ -1,7 +1,7 @@
 {{- $components := fromYaml (include "components" .) }}
 {{- if $components.operator.enabled }}
-{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
-  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- if not (.Capabilities.APIVersions.Has "batch/v1") }}
+  {{- fail "`batch/v1 not supported`" }}
 {{- end }}
 kind: ConfigMap
 apiVersion: v1

--- a/charts/kubescape-operator/templates/operator/kv-recurring-cronjob-configmap.yaml
+++ b/charts/kubescape-operator/templates/operator/kv-recurring-cronjob-configmap.yaml
@@ -1,7 +1,7 @@
 {{- $components := fromYaml (include "components" .) }}
 {{- if $components.operator.enabled }}
-{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
-  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- if not (.Capabilities.APIVersions.Has "batch/v1") }}
+  {{- fail "`batch/v1 not supported`" }}
 {{- end }}
 kind: ConfigMap
 apiVersion: v1

--- a/charts/kubescape-operator/templates/operator/registry-scan-recurring-cronjob-configmap.yaml
+++ b/charts/kubescape-operator/templates/operator/registry-scan-recurring-cronjob-configmap.yaml
@@ -1,7 +1,7 @@
 {{- $components := fromYaml (include "components" .) }}
 {{- if $components.operator.enabled }}
-{{- if not (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
-  {{- fail "`batch/v1/CronJob not supported`" }}
+{{- if not (.Capabilities.APIVersions.Has "batch/v1") }}
+  {{- fail "`batch/v1 not supported`" }}
 {{- end }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -5,7 +5,7 @@ tests:
       - matchSnapshot: {}
     capabilities:
       apiVersions:
-        - batch/v1/CronJob
+        - batch/v1
     set:
       account: 9e6c0c2c-6bd0-4919-815b-55030de7c9a0
       accessKey: f304d73b-d43c-412b-82ea-e4c859493ce6
@@ -36,7 +36,7 @@ tests:
       - matchSnapshot: {}
     capabilities:
       apiVersions:
-        - batch/v1/CronJob
+        - batch/v1
     set:
       configurations.otelUrl: "otelCollector:4317"
       clusterName: kind-kind
@@ -47,7 +47,7 @@ tests:
       - matchSnapshot: {}
     capabilities:
       apiVersions:
-        - batch/v1/CronJob
+        - batch/v1
     set:
       account: 9e6c0c2c-6bd0-4919-815b-55030de7c9a0
       accessKey: f304d73b-d43c-412b-82ea-e4c859493ce6


### PR DESCRIPTION
## **User description**
## Overview

helm template and kustomize with helm no longer work unless you change:

`.Capabilities.APIVersions.Has "batch/v1/CronJob"`
to
`.Capabilities.APIVersions.Has "batch/v1"`

Otherwise it fails with the error: Error: execution error at (kubescape-operator/templates/operator/registry-scan-recurring-cronjob-configmap.yaml:4:6): `batch/v1/CronJob not supported`

using the latest version of helm and k8s 1.27.7.

## How to Test
Do a find and replace:
Find: `.Capabilities.APIVersions.Has "batch/v1/CronJob"`
Replace: `.Capabilities.APIVersions.Has "batch/v1"`

Run helm template or kustomize build --enable-helm

## Related issues/PRs:

Resolved #369 

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


___

## **Type**
Bug fix


___

## **Description**
This PR addresses a compatibility issue with the latest version of Helm and Kubernetes 1.27.7. The changes include:
- Updating the API version check in various cronjob and configmap templates from `batch/v1/CronJob` to `batch/v1`.
- This change ensures that helm template and kustomize with helm work without errors.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cronjob.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml<br><br>

**Updated the API version check from `batch/v1/CronJob` to <br>`batch/v1`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/373/files#diff-3b0bc577fe1782b485836dc0ac4bfdee71c366f129cb4b402b28ed83abecccb6"> +2/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cronjob.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml<br><br>

**Updated the API version check from `batch/v1/CronJob` to <br>`batch/v1`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/373/files#diff-ddff8e50d506d0a065ea3d72b011a7e3d8e84da8e9f3d47f02b2fba92cd45d79"> +2/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ks-recurring-cronjob-configmap.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/operator/ks-recurring-cronjob-configmap.yaml<br><br>

**Updated the API version check from `batch/v1/CronJob` to <br>`batch/v1`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/373/files#diff-7c08d4558261bb5005c0fea0c70b7c9daa2c8201c370f4ae1a137c5efc03e545"> +2/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kv-recurring-cronjob-configmap.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/operator/kv-recurring-cronjob-configmap.yaml<br><br>

**Updated the API version check from `batch/v1/CronJob` to <br>`batch/v1`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/373/files#diff-a5be87ec5cfb48f3e7aa6141f9fa2d3e22608477ca99f6c0408d13efa342dbbb"> +2/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>registry-scan-recurring-cronjob-configmap.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/templates/operator/registry-scan-recurring-cronjob-configmap.yaml<br><br>

**Updated the API version check from `batch/v1/CronJob` to <br>`batch/v1`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/373/files#diff-ca9370a77fd991d25a5c2a34e238c73d4690af7b5031f01aa0961ddc9ca3fa3b"> +2/-2</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
