### PR TITLE
revert merge mess

### DIFF
--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -152,8 +152,8 @@ all capabilities:
     data:
       capabilities: |
         {
-          "capabilities":{"autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","networkPolicyService":"enable","nodeScan":"enable","relevancy":"enable","runtimeObservability":"enable","vexGeneration":"enable","vulnerabilityScan":"enable"},
-          "components":{"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
+          "capabilities":{"autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","networkPolicyService":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeObservability":"enable","vexGeneration":"enable","vulnerabilityScan":"enable"},
+          "components":{"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable"}
         }
     kind: ConfigMap
@@ -1974,7 +1974,7 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 1805053085011dffd5ad88e6a8be1aaa7416d06688e1244b3cdfb857325cf957
+            checksum/capabilities-config: 058141489d9220a4ece9fe4cef607bdbb201518834a470815c24667b9b1f68bc
             checksum/cloud-config: 253f0c05e8d2915ab3627479c2f810d8cf3d40b03c0807ec6af34da0e1d1e049
             checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/matching-rules-config: 0fe866ff165ca62399198397c07ab2d49af3181c569b3d0cce4a4cb310796824
@@ -2397,177 +2397,6 @@ all capabilities:
         app: otel-collector
       type: ClusterIP
   62: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: prometheus-exporter
-    rules:
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - configurationscansummaries
-          - vulnerabilitysummaries
-        verbs:
-          - get
-          - watch
-          - list
-  63: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: prometheus-exporter
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: prometheus-exporter
-    subjects:
-      - kind: ServiceAccount
-        name: prometheus-exporter
-        namespace: kubescape
-  64: |
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      labels:
-        app: prometheus-exporter
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: prometheus-exporter
-        tier: ks-control-plane
-      name: prometheus-exporter
-      namespace: kubescape
-    spec:
-      replicas: null
-      revisionHistoryLimit: 2
-      selector:
-        matchLabels:
-          app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: prometheus-exporter
-          tier: ks-control-plane
-      strategy:
-        type: Recreate
-      template:
-        metadata:
-          labels:
-            app: prometheus-exporter
-            app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: prometheus-exporter
-            tier: ks-control-plane
-        spec:
-          affinity: null
-          automountServiceAccountToken: true
-          containers:
-            - env:
-                - name: GOMEMLIMIT
-                  value: 10MiB
-                - name: KS_LOGGER_LEVEL
-                  value: info
-                - name: KS_LOGGER_NAME
-                  value: zap
-              image: quay.io/kubescape/prometheus-exporter:v0.0.6
-              imagePullPolicy: Always
-              livenessProbe:
-                initialDelaySeconds: 3
-                periodSeconds: 3
-                tcpSocket:
-                  port: 8080
-              name: prometheus-exporter
-              ports:
-                - containerPort: 8080
-                  name: metrics
-                  protocol: TCP
-              readinessProbe:
-                tcpSocket:
-                  port: 8080
-              resources:
-                limits:
-                  cpu: 50m
-                  memory: 100Mi
-                requests:
-                  cpu: 10m
-                  memory: 10Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-              volumeMounts:
-                - mountPath: /etc/config
-                  name: ks-cloud-config
-                  readOnly: true
-          nodeSelector: null
-          securityContext:
-            fsGroup: 65532
-            runAsUser: 65532
-          serviceAccountName: prometheus-exporter
-          tolerations: null
-          volumes:
-            - configMap:
-                items:
-                  - key: clusterData
-                    path: clusterData.json
-                name: ks-cloud-config
-              name: ks-cloud-config
-  65: |
-    apiVersion: networking.k8s.io/v1
-    kind: NetworkPolicy
-    metadata:
-      labels:
-        app: prometheus-exporter
-        tier: ks-control-plane
-      name: prometheus-exporter
-      namespace: kubescape
-    spec:
-      ingress:
-        - ports:
-            - port: 8080
-              protocol: TCP
-      podSelector:
-        matchLabels:
-          app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: prometheus-exporter
-          tier: ks-control-plane
-      policyTypes:
-        - Ingress
-  66: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: prometheus-exporter
-      name: prometheus-exporter
-      namespace: kubescape
-    spec:
-      ports:
-        - port: 8080
-          protocol: TCP
-          targetPort: 8080
-      selector:
-        app: prometheus-exporter
-      type: null
-  67: |
-    apiVersion: v1
-    automountServiceAccountToken: false
-    kind: ServiceAccount
-    metadata:
-      labels:
-        app: prometheus-exporter
-      name: prometheus-exporter
-      namespace: kubescape
-  68: |
-    apiVersion: monitoring.coreos.com/v1
-    kind: ServiceMonitor
-    metadata:
-      labels:
-        app: prometheus-exporter
-      name: prometheus-exporter
-      namespace: kubescape
-    spec:
-      namespaceSelector:
-        matchNames:
-          - kubescape
-      selector:
-        matchLabels:
-          app: prometheus-exporter
-  69: |
     apiVersion: v1
     data:
       proxy.crt: foo
@@ -2576,7 +2405,7 @@ all capabilities:
       name: kubescape-proxy-certificate
       namespace: kubescape
     type: Opaque
-  70: |
+  63: |
     apiVersion: batch/v1
     kind: Job
     metadata:
@@ -2653,7 +2482,7 @@ all capabilities:
           volumes:
             - emptyDir: {}
               name: shared-data
-  71: |
+  64: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -2674,7 +2503,7 @@ all capabilities:
           - patch
           - get
           - list
-  72: |
+  65: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -2691,7 +2520,7 @@ all capabilities:
       - kind: ServiceAccount
         name: service-discovery
         namespace: kubescape
-  73: |
+  66: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -2701,7 +2530,7 @@ all capabilities:
         helm.sh/hook-weight: "0"
       name: service-discovery
       namespace: kubescape
-  74: |
+  67: |
     apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
@@ -2715,7 +2544,7 @@ all capabilities:
         namespace: kubescape
       version: v1beta1
       versionPriority: 15
-  75: |
+  68: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -2824,7 +2653,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  77: |
+  70: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2837,7 +2666,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  78: |
+  71: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -2920,7 +2749,7 @@ all capabilities:
                     path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  79: |
+  72: |
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
@@ -2936,7 +2765,7 @@ all capabilities:
       resources:
         requests:
           storage: 5Gi
-  80: |
+  73: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -2950,7 +2779,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  81: |
+  74: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -2965,13 +2794,13 @@ all capabilities:
         app.kubernetes.io/component: apiserver
         app.kubernetes.io/name: storage
         app.kubernetes.io/part-of: kubescape-storage
-  82: |
+  75: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
       name: storage
       namespace: kubescape
-  83: |
+  76: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -3035,7 +2864,7 @@ all capabilities:
           - update
           - patch
           - delete
-  84: |
+  77: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -3048,7 +2877,7 @@ all capabilities:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  85: |
+  78: |
     apiVersion: v1
     data:
       config.json: |
@@ -3134,7 +2963,7 @@ all capabilities:
     metadata:
       name: synchronizer
       namespace: kubescape
-  86: |
+  79: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -3255,7 +3084,7 @@ all capabilities:
                     path: config.json
                 name: synchronizer
               name: config
-  87: |
+  80: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -3277,7 +3106,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  88: |
+  81: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -3352,8 +3181,8 @@ default capabilities:
     data:
       capabilities: |
         {
-          "capabilities":{"autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","networkPolicyService":"enable","nodeScan":"enable","relevancy":"enable","runtimeObservability":"enable","vexGeneration":"disable","vulnerabilityScan":"enable"},
-          "components":{"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
+          "capabilities":{"autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","networkPolicyService":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeObservability":"enable","vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "components":{"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable"}
         }
     kind: ConfigMap
@@ -5174,7 +5003,7 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: bbb5ef64298b555653ccfba6f72882a866f6108952db91250471993045ee7d74
+            checksum/capabilities-config: c5ce8d3e19bb269915b259a78c796881abf315ff19b3f38fdc7d3b1ebe95b969
             checksum/cloud-config: bc11c557570531f1993ebd8a8d6ee8174a1dd9f35c00e7640181b82eab213945
             checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
             checksum/matching-rules-config: 0fe866ff165ca62399198397c07ab2d49af3181c569b3d0cce4a4cb310796824
@@ -6372,8 +6201,8 @@ minimal capabilities:
     data:
       capabilities: |
         {
-          "capabilities":{"autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","networkPolicyService":"enable","nodeScan":"enable","relevancy":"enable","runtimeObservability":"enable","vexGeneration":"disable","vulnerabilityScan":"enable"},
-          "components":{"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":false},"hostScanner":{"enabled":true},"kollector":{"enabled":false},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":false},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":false},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
+          "capabilities":{"autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","networkPolicyService":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeObservability":"enable","vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "components":{"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":false},"hostScanner":{"enabled":true},"kollector":{"enabled":false},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":false},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":false},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
           "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable"}
         }
     kind: ConfigMap
@@ -7448,7 +7277,7 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: f0ce88839916da46001275e246af6ca1290eb2c2a8a0d687e5ea947219deda76
+            checksum/capabilities-config: 0c442325975e8630c7b6cae4e4e570e4ab5721c1603f79f51bc77567f1384039
             checksum/cloud-config: 95260ac6946b5771081a57105074148c915f2c581ad49cb97889ac0206e238f8
             checksum/cloud-secret: 436faa29a74a6ab2b6ee2ae0faaa0576d663745a9780780fa53afa02a945dddb
             checksum/matching-rules-config: 0fe866ff165ca62399198397c07ab2d49af3181c569b3d0cce4a4cb310796824

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -19,7 +19,50 @@ tests:
         runtimeObservability: enable
         networkPolicyService: enable
         autoUpgrading: enable
-        prometheusExporter: enable
+        prometheusExporter: disable
+      server: api.armosec.io
+      configurations.otelUrl: "otelCollector:4317"
+      clusterName: kind-kind
+      global:
+        networkPolicy:
+          createEgressRules: true
+          enabled: true
+        proxySecretFile: foo
+      grypeOfflineDB.enabled: true
+      kubescape.serviceMonitor.enabled: true
+      kubescapeScheduler.scanSchedule: "1 2 3 4 5"
+      kubevulnScheduler.scanSchedule: "1 2 3 4 5"
+  - it: minimal capabilities
+    asserts:
+      - matchSnapshot: {}
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      configurations.otelUrl: "otelCollector:4317"
+      clusterName: kind-kind
+      kubescapeScheduler.scanSchedule: "1 2 3 4 5"
+      kubevulnScheduler.scanSchedule: "1 2 3 4 5"
+  - it: default capabilities
+    asserts:
+      - matchSnapshot: {}
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      account: 9e6c0c2c-6bd0-4919-815b-55030de7c9a0
+      accessKey: f304d73b-d43c-412b-82ea-e4c859493ce6
+      capabilities:
+        configurationScan: enable
+        continuousScan: disable
+        nodeScan: enable
+        vulnerabilityScan: enable
+        relevancy: enable
+        vexGeneration: disable
+        runtimeObservability: enable
+        networkPolicyService: enable
+        autoUpgrading: disable
+        prometheusExporter: disable
       server: api.armosec.io
       configurations.otelUrl: "otelCollector:4317"
       clusterName: kind-kind


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
Enhancement


___

## **Description**
This PR introduces several enhancements to the kubescape operator configurations. The main changes include:
- Addition of new configurations for enabling/disabling various capabilities.
- New settings for server, otelUrl, clusterName, and others.
- Switching the `prometheusExporter` from `enable` to `disable`.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapshot_test.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        charts/kubescape-operator/tests/snapshot_test.yaml<br><br>

**The changes in this file include the addition of new <br>configurations for the kubescape operator. These <br>configurations include enabling/disabling various <br>capabilities such as `configurationScan`, `continuousScan`, <br>`nodeScan`, `vulnerabilityScan`, `relevancy`, <br>`vexGeneration`, `runtimeObservability`, <br>`networkPolicyService`, `autoUpgrading`, and <br>`prometheusExporter`. Also, new settings for `server`, <br>`configurations.otelUrl`, `clusterName`, <br>`global.networkPolicy.createEgressRules`, <br>`grypeOfflineDB.enabled`, <br>`kubescape.serviceMonitor.enabled`, <br>`kubescapeScheduler.scanSchedule`, and <br>`kubevulnScheduler.scanSchedule` have been added. The <br>`prometheusExporter` has been switched from `enable` to <br>`disable`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/377/files#diff-1914664e59de0998b316c82729e267ff27790dfecd5830bded0dc0ddedbffaad"> +44/-1</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
