### PR TITLE
Adding ignore label to all resources

### DIFF
--- a/ArgoCDApplication.yaml
+++ b/ArgoCDApplication.yaml
@@ -2,6 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: kubescape
+  namespace: argocd # change to the argocd namespace
 spec:
   destination:
     name: ''

--- a/charts/kubescape-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-operator/assets/host-scanner-definition.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        kubescape.io/ignore: "true"
         name: host-scanner
         {{- if $components.otelCollector.enabled }}
         otel: enabled

--- a/charts/kubescape-operator/assets/kubescape-cronjob-full.yaml
+++ b/charts/kubescape-operator/assets/kubescape-cronjob-full.yaml
@@ -6,6 +6,7 @@ apiVersion: batch/v1
       labels:
         app: {{ .Values.kubescapeScheduler.name }}
         tier: {{ .Values.global.namespaceTier }}
+        kubescape.io/ignore: "true"
         armo.tier: "kubescape-scan"
     spec:
       schedule: "{{ .Values.kubescapeScheduler.scanSchedule }}"

--- a/charts/kubescape-operator/assets/kubevuln-cronjob-full.yaml
+++ b/charts/kubescape-operator/assets/kubevuln-cronjob-full.yaml
@@ -5,6 +5,7 @@ apiVersion: batch/v1
       namespace: {{ .Values.ksNamespace }}
       labels:
         app: {{ .Values.kubevulnScheduler.name }}
+        kubescape.io/ignore: "true"
         tier: {{ .Values.global.namespaceTier }}
         armo.tier: "vuln-scan"
     spec:

--- a/charts/kubescape-operator/assets/registry-scan-cronjob-full.yaml
+++ b/charts/kubescape-operator/assets/registry-scan-cronjob-full.yaml
@@ -5,6 +5,7 @@ apiVersion: batch/v1
       namespace: {{ .Values.ksNamespace }}
       labels:
         app: {{ .Values.registryScanScheduler.name }}
+        kubescape.io/ignore: "true"
         tier: {{ .Values.global.namespaceTier }}
         armo.tier: "registry-scan"
     spec:

--- a/charts/kubescape-operator/templates/autoupdater/cronjob.yaml
+++ b/charts/kubescape-operator/templates/autoupdater/cronjob.yaml
@@ -4,6 +4,8 @@ kind: CronJob
 metadata:
   name: {{ .Values.helmReleaseUpgrader.name }}
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
   annotations:
     "helm.sh/resource-policy": keep
 spec:

--- a/charts/kubescape-operator/templates/autoupdater/rbac.yaml
+++ b/charts/kubescape-operator/templates/autoupdater/rbac.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Values.helmReleaseUpgrader.name }}
   annotations:
     "helm.sh/resource-policy": keep
+  labels:
+    kubescape.io/ignore: "true"
 rules:
 - apiGroups: ["*"]
   resources: ["*"]
@@ -16,6 +18,8 @@ metadata:
   name: {{ .Values.helmReleaseUpgrader.name }}
   annotations:
     "helm.sh/resource-policy": keep
+  labels:
+    kubescape.io/ignore: "true"
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.helmReleaseUpgrader.name }}

--- a/charts/kubescape-operator/templates/autoupdater/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/autoupdater/serviceaccount.yaml
@@ -6,4 +6,6 @@ metadata:
   name: {{ .Values.helmReleaseUpgrader.name }}
   annotations:
     "helm.sh/resource-policy": keep
+  labels:
+    kubescape.io/ignore: "true"
 {{ end }}

--- a/charts/kubescape-operator/templates/configs/cloud-secret.yaml
+++ b/charts/kubescape-operator/templates/configs/cloud-secret.yaml
@@ -9,6 +9,7 @@ metadata:
     app: {{ $components.cloudSecret.name }}
     tier: {{ .Values.global.namespaceTier }}
     kubescape.io/infra: credentials
+    kubescape.io/ignore: "true"
 type: Opaque
 data:
   account: "{{ .Values.account | default "" | b64enc }}"

--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: {{ .Values.global.cloudConfig }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
     kubescape.io/infra: config
   {{- if $components.serviceDiscovery.enabled }}
   annotations:

--- a/charts/kubescape-operator/templates/configs/components-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/components-configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: ks-capabilities
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 data:
   capabilities: |
     {

--- a/charts/kubescape-operator/templates/configs/matchingRules-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/matchingRules-configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: {{ .Values.ksLabel }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 data:
   matchingRules.json: |
     {{ mustToJson .Values.continuousScanning.matchingRules }}

--- a/charts/kubescape-operator/templates/configs/private-registries-creds-secret.yaml
+++ b/charts/kubescape-operator/templates/configs/private-registries-creds-secret.yaml
@@ -5,6 +5,8 @@ metadata:
   # Secret name must start with 'kubescape-registry-scan' for the operator to pick it up, change at your own risk
   name: kubescape-registry-scan-secrets 
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
 type: Opaque
 stringData:
   registriesAuth: |

--- a/charts/kubescape-operator/templates/gateway/deployment.yaml
+++ b/charts/kubescape-operator/templates/gateway/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
     app: {{ .Values.gateway.name }}
     tier: {{ .Values.global.namespaceTier }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    kubescape.io/ignore: "true"
 spec:
   replicas: 1
   revisionHistoryLimit: 2

--- a/charts/kubescape-operator/templates/gateway/service.yaml
+++ b/charts/kubescape-operator/templates/gateway/service.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   labels:
     app: {{ .Values.gateway.name }}
+    kubescape.io/ignore: "true"
 spec:
   type: {{ .Values.gateway.httpService.type }}
   ports:

--- a/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ .Values.grypeOfflineDB.name }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 spec:
   replicas: 1
   revisionHistoryLimit: 2

--- a/charts/kubescape-operator/templates/grype-offline-db/service.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   labels:
     app: {{ .Values.grypeOfflineDB.name }}
+    kubescape.io/ignore: "true"
 spec:
   type: ClusterIP
   ports:

--- a/charts/kubescape-operator/templates/kollector/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/kollector/clusterrole.yaml
@@ -4,6 +4,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kollector.name }}
+  labels:
+    kubescape.io/ignore: "true"
 rules:
 - apiGroups: [""]
   resources: ["pods", "namespaces", "cronjobs", "secrets", "nodes", "services"]

--- a/charts/kubescape-operator/templates/kollector/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/kollector/clusterrolebinding.yaml
@@ -4,6 +4,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kollector.name }}
+  labels:
+    kubescape.io/ignore: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kubescape-operator/templates/kollector/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/kollector/serviceaccount.yaml
@@ -12,6 +12,7 @@ metadata:
 {{- end }}
   labels:
     app: {{ .Values.kollector.name }}
+    kubescape.io/ignore: "true"
   name: {{ .Values.kollector.name }}
   namespace: {{ .Values.ksNamespace }}
 automountServiceAccountToken: false

--- a/charts/kubescape-operator/templates/kollector/statefulset.yaml
+++ b/charts/kubescape-operator/templates/kollector/statefulset.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.kollector.name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    kubescape.io/ignore: "true"
     app: {{ .Values.kollector.name }}
     tier: {{ .Values.global.namespaceTier }}
 spec:

--- a/charts/kubescape-operator/templates/kubescape-scheduler/configmap.yaml
+++ b/charts/kubescape-operator/templates/kubescape-scheduler/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app: {{ .Values.kubescapeScheduler.name }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 data:
   request-body.json: |-
     {"commands":[{"CommandName":"kubescapeScan","args":{"scanV1": {}}}]}

--- a/charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml
+++ b/charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml
@@ -14,6 +14,7 @@ metadata:
     app: {{ .Values.kubescapeScheduler.name }}
     tier: {{ .Values.global.namespaceTier }}
     armo.tier: "kubescape-scan"
+    kubescape.io/ignore: "true"
 spec:
   schedule: "{{ trimPrefix "\n" (trimSuffix  "\n" $kubescape_daily_scan_cron_tab) }}"
   successfulJobsHistoryLimit: {{ .Values.kubescapeScheduler.successfulJobsHistoryLimit }}

--- a/charts/kubescape-operator/templates/kubescape/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/kubescape/clusterrole.yaml
@@ -4,6 +4,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kubescape.name }}
+  labels:
+    kubescape.io/ignore: "true"
 rules:
 - apiGroups: [""]
   resources: ["pods", "pods/proxy", "namespaces", "secrets", "nodes", "configmaps", "services", "serviceaccounts", "endpoints", "persistentvolumeclaims", "persistentvolumes", "limitranges", "replicationcontrollers", "podtemplates", "resourcequotas", "events"]

--- a/charts/kubescape-operator/templates/kubescape/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/kubescape/clusterrolebinding.yaml
@@ -4,6 +4,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kubescape.name }}
+  labels:
+    kubescape.io/ignore: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ .Values.kubescape.name }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{- if .Values.kubescape.prometheusAnnotation.enabled }}
   annotations:

--- a/charts/kubescape-operator/templates/kubescape/host-scanner-definition-configmap.yaml
+++ b/charts/kubescape-operator/templates/kubescape/host-scanner-definition-configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app: {{ .Values.global.cloudConfig }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 data:
   host-scanner-yaml: |-
 {{ tpl (.Files.Get "assets/host-scanner-definition.yaml") . | indent 4 }}

--- a/charts/kubescape-operator/templates/kubescape/role.yaml
+++ b/charts/kubescape-operator/templates/kubescape/role.yaml
@@ -5,6 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kubescape.name }}
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
 rules:
   - apiGroups: ["apps"]
     resources: ["daemonsets"]

--- a/charts/kubescape-operator/templates/kubescape/rolebinding.yaml
+++ b/charts/kubescape-operator/templates/kubescape/rolebinding.yaml
@@ -5,6 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kubescape.name }}
   namespace: {{ .Values.ksNamespace }}
+  labels:    
+    kubescape.io/ignore: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/kubescape-operator/templates/kubescape/service.yaml
+++ b/charts/kubescape-operator/templates/kubescape/service.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   labels:
     app: {{ .Values.kubescape.name }}
+    kubescape.io/ignore: "true"
 spec:
   type: {{ .Values.kubescape.service.type }}
   ports:

--- a/charts/kubescape-operator/templates/kubescape/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/kubescape/serviceaccount.yaml
@@ -12,6 +12,7 @@ metadata:
 {{- end }}
   labels:
     app: {{ .Values.kubescape.name }}
+    kubescape.io/ignore: "true"
   name: {{ .Values.kubescape.name }}
   namespace: {{ .Values.ksNamespace }}
 automountServiceAccountToken: false

--- a/charts/kubescape-operator/templates/kubescape/servicemonitor.yaml
+++ b/charts/kubescape-operator/templates/kubescape/servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Values.kubescape.serviceMonitor.namespace | default .Values.ksNamespace }}
   labels:
     app: {{ .Values.kubescape.name }}
+    kubescape.io/ignore: "true"
     {{- with .Values.kubescape.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/kubescape-operator/templates/kubevuln-scheduler/configmap.yaml
+++ b/charts/kubescape-operator/templates/kubevuln-scheduler/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app: {{ .Values.kubevulnScheduler.name }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 data:
   request-body.json: |-
     {"commands":[{"commandName":"scan","designators":[{"designatorType":"Attributes","attributes":{}}]}]}

--- a/charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml
+++ b/charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml
@@ -14,6 +14,7 @@ metadata:
     app: {{ .Values.kubevulnScheduler.name }}
     tier: {{ .Values.global.namespaceTier }}
     armo.tier: "vuln-scan"
+    kubescape.io/ignore: "true"
 spec:
   schedule: "{{ trimPrefix "\n" (trimSuffix  "\n" $kubevuln_daily_scan_cron_tab) }}"
   successfulJobsHistoryLimit: {{ .Values.kubevulnScheduler.successfulJobsHistoryLimit }}

--- a/charts/kubescape-operator/templates/kubevuln/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/clusterrole.yaml
@@ -4,6 +4,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kubevuln.name }}
+  labels:
+    kubescape.io/ignore: "true"
 rules:
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
     resources: ["vulnerabilitymanifests", "vulnerabilitymanifestsummaries", "sbomsummaries", "sbomspdxv2p3s","openvulnerabilityexchangecontainers", "sbomsyftfiltereds", "sbomsyfts"]

--- a/charts/kubescape-operator/templates/kubevuln/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/clusterrolebinding.yaml
@@ -4,6 +4,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kubevuln.name }}
+  labels:
+    kubescape.io/ignore: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ .Values.kubevuln.name }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 spec:
   replicas: {{ .Values.kubevuln.replicaCount }}
   revisionHistoryLimit: 2

--- a/charts/kubescape-operator/templates/kubevuln/service.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/service.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   labels:
     app: {{ .Values.kubevuln.name }}
+    kubescape.io/ignore: "true"
 spec:
   type: {{ .Values.kubevuln.service.type }}
   ports:

--- a/charts/kubescape-operator/templates/kubevuln/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/serviceaccount.yaml
@@ -12,6 +12,7 @@ metadata:
 {{- end }}
   labels:
     app: {{ .Values.kubevuln.name }}
+    kubescape.io/ignore: "true"
   name: {{ .Values.kubevuln.name }}
   namespace: {{ .Values.ksNamespace }}
 automountServiceAccountToken: false

--- a/charts/kubescape-operator/templates/node-agent/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/node-agent/clusterrole.yaml
@@ -4,6 +4,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.nodeAgent.name }}
+  labels:
+    kubescape.io/ignore: "true"
 rules:
 - apiGroups: [""]
   resources: ["pods", "nodes", "services", "endpoints"]

--- a/charts/kubescape-operator/templates/node-agent/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/node-agent/clusterrolebinding.yaml
@@ -4,6 +4,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.nodeAgent.name }}
+  labels:
+    kubescape.io/ignore: "true"
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.nodeAgent.name }}

--- a/charts/kubescape-operator/templates/node-agent/configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/configmap.yaml
@@ -6,6 +6,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.nodeAgent.name }}
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
 data:
   config.json: |
     {

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -8,10 +8,11 @@ metadata:
   name: {{ .Values.nodeAgent.name }}
   namespace: {{ .Values.ksNamespace }}
   labels:
-      app.kubernetes.io/name: {{ .Values.nodeAgent.name }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app: {{ .Values.nodeAgent.name }}
-      tier: {{ .Values.global.namespaceTier }}
+    app.kubernetes.io/name: {{ .Values.nodeAgent.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app: {{ .Values.nodeAgent.name }}
+    tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 spec:
   selector:
     matchLabels:

--- a/charts/kubescape-operator/templates/node-agent/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/node-agent/serviceaccount.yaml
@@ -5,4 +5,6 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.nodeAgent.name }}
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
 {{- end }}

--- a/charts/kubescape-operator/templates/operator/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/operator/clusterrole.yaml
@@ -4,6 +4,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.operator.name }}
+  labels:
+    kubescape.io/ignore: "true"
 rules:
   - apiGroups: [""]
     resources: ["pods", "nodes", "namespaces", "configmaps", "secrets"]

--- a/charts/kubescape-operator/templates/operator/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/operator/clusterrolebinding.yaml
@@ -4,6 +4,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.operator.name }}
+  labels:
+    kubescape.io/ignore: "true"
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.operator.name }}

--- a/charts/kubescape-operator/templates/operator/configmap.yaml
+++ b/charts/kubescape-operator/templates/operator/configmap.yaml
@@ -5,6 +5,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.operator.name }}
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
 data:
   config.json: |
     {

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    kubescape.io/ignore: "true"
     app: {{ .Values.operator.name }}
     tier: {{ .Values.global.namespaceTier }}
 spec:

--- a/charts/kubescape-operator/templates/operator/ks-recurring-cronjob-configmap.yaml
+++ b/charts/kubescape-operator/templates/operator/ks-recurring-cronjob-configmap.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app: {{ .Values.global.cloudConfig }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 data:
   cronjobTemplate: |-
     {{ tpl (.Files.Get "assets/kubescape-cronjob-full.yaml") . }}

--- a/charts/kubescape-operator/templates/operator/kv-recurring-cronjob-configmap.yaml
+++ b/charts/kubescape-operator/templates/operator/kv-recurring-cronjob-configmap.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app: {{ .Values.global.cloudConfig }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 data:
   cronjobTemplate: |-
     {{ tpl (.Files.Get "assets/kubevuln-cronjob-full.yaml") . }}

--- a/charts/kubescape-operator/templates/operator/registry-scan-recurring-cronjob-configmap.yaml
+++ b/charts/kubescape-operator/templates/operator/registry-scan-recurring-cronjob-configmap.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     app: {{ .Values.global.cloudConfig }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
   name: registry-scan-cronjob-template
 data:
   cronjobTemplate: |-

--- a/charts/kubescape-operator/templates/operator/role.yaml
+++ b/charts/kubescape-operator/templates/operator/role.yaml
@@ -5,6 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.operator.name }}
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "secrets"]

--- a/charts/kubescape-operator/templates/operator/rolebinding.yaml
+++ b/charts/kubescape-operator/templates/operator/rolebinding.yaml
@@ -5,6 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.operator.name }}
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/kubescape-operator/templates/operator/service.yaml
+++ b/charts/kubescape-operator/templates/operator/service.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   labels:
     app: {{ .Values.operator.name }}
+    kubescape.io/ignore: "true"
 spec:
   type: {{ .Values.operator.service.type }}
   ports:

--- a/charts/kubescape-operator/templates/operator/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/operator/serviceaccount.yaml
@@ -12,6 +12,7 @@ metadata:
 {{- end }}
   labels:
     app: {{ .Values.operator.name }}
+    kubescape.io/ignore: "true"
   name: {{ .Values.operator.name }}
   namespace: {{ .Values.ksNamespace }}
 automountServiceAccountToken: false

--- a/charts/kubescape-operator/templates/otel-collector/configmap.yaml
+++ b/charts/kubescape-operator/templates/otel-collector/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app: {{ .Values.global.cloudConfig }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 data:
   otel-collector-config.yaml: |-
 {{ tpl (.Files.Get "assets/otel-collector-config.yaml") . | indent 4 }}

--- a/charts/kubescape-operator/templates/otel-collector/deployment.yaml
+++ b/charts/kubescape-operator/templates/otel-collector/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ .Values.otelCollector.name }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   replicas: 1

--- a/charts/kubescape-operator/templates/otel-collector/service.yaml
+++ b/charts/kubescape-operator/templates/otel-collector/service.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   labels:
     app: {{ .Values.otelCollector.name }}
+    kubescape.io/ignore: "true"
 spec:
   type: ClusterIP
   ports:

--- a/charts/kubescape-operator/templates/prometheus-exporter/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/clusterrole.yaml
@@ -4,6 +4,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.prometheusExporter.name }}
+  labels:
+    kubescape.io/ignore: "true"
 rules:
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
     resources: ["configurationscansummaries", "vulnerabilitysummaries"]

--- a/charts/kubescape-operator/templates/prometheus-exporter/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/clusterrolebinding.yaml
@@ -4,6 +4,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.prometheusExporter.name }}
+  labels:
+    kubescape.io/ignore: "true"
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.prometheusExporter.name }}

--- a/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ .Values.prometheusExporter.name }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 spec:
   replicas: 1
   revisionHistoryLimit: 2

--- a/charts/kubescape-operator/templates/prometheus-exporter/service.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/service.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   labels:
     app: {{ .Values.prometheusExporter.name }}
+    kubescape.io/ignore: "true"
 spec:
   type: {{ .Values.prometheusExporter.service.type }}
   ports:

--- a/charts/kubescape-operator/templates/prometheus-exporter/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/serviceaccount.yaml
@@ -12,6 +12,7 @@ metadata:
 {{- end }}
   labels:
     app: {{ .Values.prometheusExporter.name }}
+    kubescape.io/ignore: "true"
   name: {{ .Values.prometheusExporter.name }}
   namespace: {{ .Values.ksNamespace }}
 automountServiceAccountToken: false

--- a/charts/kubescape-operator/templates/proxy-support/proxy-secret.yaml
+++ b/charts/kubescape-operator/templates/proxy-support/proxy-secret.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   name: {{ .Values.global.proxySecretName }}
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
 type: Opaque
 data:
   proxy.crt: {{ .Values.global.proxySecretFile | quote }}

--- a/charts/kubescape-operator/templates/servicediscovery/job.yaml
+++ b/charts/kubescape-operator/templates/servicediscovery/job.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ .Values.serviceDiscovery.name }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/kubescape-operator/templates/servicediscovery/role.yaml
+++ b/charts/kubescape-operator/templates/servicediscovery/role.yaml
@@ -9,6 +9,8 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "0"
+  labels:
+    kubescape.io/ignore: "true"
 rules:
 - apiGroups: [""]
   resources: [ "configmaps"]

--- a/charts/kubescape-operator/templates/servicediscovery/rolebinding.yaml
+++ b/charts/kubescape-operator/templates/servicediscovery/rolebinding.yaml
@@ -8,6 +8,8 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "0"
+  labels:
+    kubescape.io/ignore: "true"
 subjects:
 - kind: ServiceAccount
   name: service-discovery

--- a/charts/kubescape-operator/templates/servicediscovery/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/servicediscovery/serviceaccount.yaml
@@ -5,6 +5,8 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceDiscovery.name }}
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/kubescape-operator/templates/storage/apiservice.yaml
+++ b/charts/kubescape-operator/templates/storage/apiservice.yaml
@@ -4,6 +4,8 @@ apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: "v1beta1.spdx.softwarecomposition.kubescape.io"
+  labels:
+    kubescape.io/ignore: "true"
 spec:
   insecureSkipTLSVerify: true
   group: "spdx.softwarecomposition.kubescape.io"

--- a/charts/kubescape-operator/templates/storage/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/storage/clusterrole.yaml
@@ -4,6 +4,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.storage.name }}
+  labels:
+    kubescape.io/ignore: "true"
 rules:
 - apiGroups: [""]
   resources: ["configmaps", "endpoints", "namespaces", "nodes", "persistentvolumeclaims", "persistentvolumes", "pods", "secrets", "serviceaccounts", "services"]

--- a/charts/kubescape-operator/templates/storage/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/storage/clusterrolebinding.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "storage.authDelegatorClusterRoleBindingName" . | quote }}
+  labels:
+    kubescape.io/ignore: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .Values.storage.name }}
   namespace: {{ .Values.ksNamespace }}
   labels:
+    kubescape.io/ignore: "true"
     {{ .Values.storage.labels | toYaml  | nindent 4 }}
 spec:
   replicas: 1

--- a/charts/kubescape-operator/templates/storage/pvc.yaml
+++ b/charts/kubescape-operator/templates/storage/pvc.yaml
@@ -6,6 +6,7 @@ metadata:
   name: kubescape-{{ .Values.storage.name }}
   namespace: {{ .Values.ksNamespace }}
   labels:
+    kubescape.io/ignore: "true"
     {{ .Values.storage.labels | toYaml  | nindent 4 }}
 spec:
   accessModes:

--- a/charts/kubescape-operator/templates/storage/rolebinding.yaml
+++ b/charts/kubescape-operator/templates/storage/rolebinding.yaml
@@ -5,6 +5,8 @@ kind: RoleBinding
 metadata:
   name: {{ include "storage.authReaderRoleBindingName" . | quote }}
   namespace: kube-system
+  labels:
+    kubescape.io/ignore: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/kubescape-operator/templates/storage/service.yaml
+++ b/charts/kubescape-operator/templates/storage/service.yaml
@@ -5,6 +5,8 @@ kind: Service
 metadata:
   name: {{ .Values.storage.name }}
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
 spec:
   ports:
   - port: 443

--- a/charts/kubescape-operator/templates/storage/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/storage/serviceaccount.yaml
@@ -5,4 +5,6 @@ apiVersion: v1
 metadata:
   name: {{ .Values.storage.name }}
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
 {{- end }}

--- a/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
@@ -4,6 +4,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.synchronizer.name }}
+  labels:
+    kubescape.io/ignore: "true"
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces"]

--- a/charts/kubescape-operator/templates/synchronizer/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/clusterrolebinding.yaml
@@ -4,6 +4,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.synchronizer.name }}
+  labels:
+    kubescape.io/ignore: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kubescape-operator/templates/synchronizer/configmap.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/configmap.yaml
@@ -6,6 +6,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.synchronizer.name }}
   namespace: {{ .Values.ksNamespace }}
+  labels:
+    kubescape.io/ignore: "true"
 data:
   config.json: |
     {

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ .Values.synchronizer.name }}
     tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/ignore: "true"
 spec:
   replicas: 1
   revisionHistoryLimit: 2

--- a/charts/kubescape-operator/templates/synchronizer/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/serviceaccount.yaml
@@ -12,6 +12,7 @@ metadata:
 {{- end }}
   labels:
     app: {{ .Values.synchronizer.name }}
+    kubescape.io/ignore: "true"
   name: {{ .Values.synchronizer.name }}
   namespace: {{ .Values.ksNamespace }}
 automountServiceAccountToken: false

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -7,6 +7,8 @@ all capabilities:
     metadata:
       annotations:
         helm.sh/resource-policy: keep
+      labels:
+        kubescape.io/ignore: "true"
       name: helm-release-upgrader
       namespace: kubescape
     spec:
@@ -58,6 +60,8 @@ all capabilities:
     metadata:
       annotations:
         helm.sh/resource-policy: keep
+      labels:
+        kubescape.io/ignore: "true"
       name: helm-release-upgrader
     rules:
       - apiGroups:
@@ -72,6 +76,8 @@ all capabilities:
     metadata:
       annotations:
         helm.sh/resource-policy: keep
+      labels:
+        kubescape.io/ignore: "true"
       name: helm-release-upgrader
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -87,6 +93,8 @@ all capabilities:
     metadata:
       annotations:
         helm.sh/resource-policy: keep
+      labels:
+        kubescape.io/ignore: "true"
       name: helm-release-upgrader
       namespace: kubescape
   6: |
@@ -98,6 +106,7 @@ all capabilities:
     metadata:
       labels:
         app: cloud-secret
+        kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
       name: cloud-secret
@@ -142,6 +151,7 @@ all capabilities:
         helm.sh/resource-policy: keep
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         kubescape.io/infra: config
         tier: ks-control-plane
       name: ks-cloud-config
@@ -159,6 +169,7 @@ all capabilities:
     metadata:
       labels:
         app: ks-capabilities
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: ks-capabilities
       namespace: kubescape
@@ -171,6 +182,7 @@ all capabilities:
     metadata:
       labels:
         app: kubescape
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: cs-matching-rules
       namespace: kubescape
@@ -183,6 +195,7 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: gateway
         helm.sh/chart: kubescape-operator-1.18.3
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: gateway
       namespace: kubescape
@@ -202,9 +215,9 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 65c94f1b291033884ce7997aa24d25e091c08b3bb6291960b4d1db7703fe6c75
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/cloud-config: 5c76d6ae3049caa8f1f6595e4e2d727b5c6e5c84ea60e83d4bb08cb813bc71ce
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
           labels:
             app: gateway
             app.kubernetes.io/instance: RELEASE-NAME
@@ -341,6 +354,7 @@ all capabilities:
     metadata:
       labels:
         app: gateway
+        kubescape.io/ignore: "true"
       name: gateway
       namespace: kubescape
     spec:
@@ -364,6 +378,7 @@ all capabilities:
         app: grype-offline-db
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: grype-offline-db
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
       namespace: kubescape
@@ -442,6 +457,7 @@ all capabilities:
     metadata:
       labels:
         app: grype-offline-db
+        kubescape.io/ignore: "true"
       name: grype-offline-db
       namespace: kubescape
     spec:
@@ -456,6 +472,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kollector
     rules:
       - apiGroups:
@@ -495,6 +513,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kollector
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -538,6 +558,7 @@ all capabilities:
     metadata:
       labels:
         app: kollector
+        kubescape.io/ignore: "true"
       name: kollector
       namespace: kubescape
   20: |
@@ -548,6 +569,7 @@ all capabilities:
         app: kollector
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kollector
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kollector
       namespace: kubescape
@@ -562,9 +584,9 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 65c94f1b291033884ce7997aa24d25e091c08b3bb6291960b4d1db7703fe6c75
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/cloud-config: 5c76d6ae3049caa8f1f6595e4e2d727b5c6e5c84ea60e83d4bb08cb813bc71ce
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
           labels:
             app: kollector
             app.kubernetes.io/instance: RELEASE-NAME
@@ -668,6 +690,7 @@ all capabilities:
     metadata:
       labels:
         app: kubescape-scheduler
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
       namespace: kubescape
@@ -679,6 +702,7 @@ all capabilities:
         app: kubescape-scheduler
         app.kubernetes.io/name: kubescape-scheduler
         armo.tier: kubescape-scan
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
       namespace: kubescape
@@ -736,6 +760,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape
     rules:
       - apiGroups:
@@ -927,6 +953,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -945,6 +973,7 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape
         helm.sh/chart: kubescape-operator-1.18.3
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -964,10 +993,10 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 65c94f1b291033884ce7997aa24d25e091c08b3bb6291960b4d1db7703fe6c75
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/host-scanner-configmap: 2f2feb524edeabfcf23a0ded8294cb5169dbba6ad4251e9525564f3da04cae43
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/cloud-config: 5c76d6ae3049caa8f1f6595e4e2d727b5c6e5c84ea60e83d4bb08cb813bc71ce
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/host-scanner-configmap: b6068eedcfa8521373ce4e38185dd66a6dda7dbf77f852e13e3f3662bc63d632
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
           labels:
             app: kubescape
             app.kubernetes.io/instance: RELEASE-NAME
@@ -1116,6 +1145,7 @@ all capabilities:
           template:
             metadata:
               labels:
+                kubescape.io/ignore: "true"
                 name: host-scanner
                 otel: enabled
             spec:
@@ -1190,6 +1220,7 @@ all capabilities:
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: host-scanner-definition
       namespace: kubescape
@@ -1230,6 +1261,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
     rules:
@@ -1249,6 +1282,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
     roleRef:
@@ -1265,6 +1300,7 @@ all capabilities:
     metadata:
       labels:
         app: kubescape
+        kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
     spec:
@@ -1283,6 +1319,7 @@ all capabilities:
     metadata:
       labels:
         app: kubescape
+        kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
   32: |
@@ -1291,6 +1328,7 @@ all capabilities:
     metadata:
       labels:
         app: kubescape
+        kubescape.io/ignore: "true"
       name: kubescape-monitor
       namespace: kubescape
     spec:
@@ -1313,6 +1351,7 @@ all capabilities:
     metadata:
       labels:
         app: kubevuln-scheduler
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
       namespace: kubescape
@@ -1324,6 +1363,7 @@ all capabilities:
         app: kubevuln-scheduler
         app.kubernetes.io/name: kubevuln-scheduler
         armo.tier: vuln-scan
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
       namespace: kubescape
@@ -1381,6 +1421,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubevuln
     rules:
       - apiGroups:
@@ -1412,6 +1454,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubevuln
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -1429,6 +1473,7 @@ all capabilities:
         app: kubevuln
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubevuln
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
       namespace: kubescape
@@ -1445,9 +1490,9 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 65c94f1b291033884ce7997aa24d25e091c08b3bb6291960b4d1db7703fe6c75
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/cloud-config: 5c76d6ae3049caa8f1f6595e4e2d727b5c6e5c84ea60e83d4bb08cb813bc71ce
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
           labels:
             app: kubevuln
             app.kubernetes.io/instance: RELEASE-NAME
@@ -1591,6 +1636,7 @@ all capabilities:
     metadata:
       labels:
         app: kubevuln
+        kubescape.io/ignore: "true"
       name: kubevuln
       namespace: kubescape
     spec:
@@ -1608,12 +1654,15 @@ all capabilities:
     metadata:
       labels:
         app: kubevuln
+        kubescape.io/ignore: "true"
       name: kubevuln
       namespace: kubescape
   41: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: node-agent
     rules:
       - apiGroups:
@@ -1685,6 +1734,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: node-agent
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -1708,6 +1759,8 @@ all capabilities:
         }
     kind: ConfigMap
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: node-agent
       namespace: kubescape
   44: |
@@ -1718,6 +1771,7 @@ all capabilities:
         app: node-agent
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: node-agent
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
@@ -1730,10 +1784,10 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 65c94f1b291033884ce7997aa24d25e091c08b3bb6291960b4d1db7703fe6c75
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/node-agent-config: 1f1ed354ec149975e60a35866c9b74c952b526adddf8fdc41ecb1ca64e0aafa5
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/cloud-config: 5c76d6ae3049caa8f1f6595e4e2d727b5c6e5c84ea60e83d4bb08cb813bc71ce
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/node-agent-config: fb53fadca13d78d5e01db68f6ee10efcefc9f19377867d9554fe07c449490244
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             alt-name: node-agent
@@ -1878,12 +1932,16 @@ all capabilities:
     apiVersion: v1
     kind: ServiceAccount
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: node-agent
       namespace: kubescape
   46: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
     rules:
       - apiGroups:
@@ -1940,6 +1998,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -1959,6 +2019,8 @@ all capabilities:
         }
     kind: ConfigMap
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
   49: |
@@ -1969,6 +2031,7 @@ all capabilities:
         app: operator
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: operator
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
       namespace: kubescape
@@ -1988,12 +2051,12 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 058141489d9220a4ece9fe4cef607bdbb201518834a470815c24667b9b1f68bc
-            checksum/cloud-config: 65c94f1b291033884ce7997aa24d25e091c08b3bb6291960b4d1db7703fe6c75
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/matching-rules-config: 0fe866ff165ca62399198397c07ab2d49af3181c569b3d0cce4a4cb310796824
-            checksum/operator-config: df99a2aba9854372143be03476352384d33d686923ae071dde264c8c7ffbc999
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/capabilities-config: ee39dc1a4fc363098f456364808d4596aa5796b77e551efac2fb913c6d3c79f7
+            checksum/cloud-config: 5c76d6ae3049caa8f1f6595e4e2d727b5c6e5c84ea60e83d4bb08cb813bc71ce
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/matching-rules-config: ac114ef46ae46b2ba220aadc68b8609734da30557e20aebf48182d201ba3d710
+            checksum/operator-config: 30dc27ad7f65bd501b52accfe50df5afc6dfa51e44ca618e3ec1fd3e68bca114
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
           labels:
             app: operator
             app.kubernetes.io/instance: RELEASE-NAME
@@ -2124,22 +2187,24 @@ all capabilities:
   50: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
     kind: ConfigMap
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-cronjob-template
       namespace: kubescape
   51: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    kubescape.io/ignore: \"true\"\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
     kind: ConfigMap
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-cronjob-template
       namespace: kubescape
@@ -2185,11 +2250,12 @@ all capabilities:
   53: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    kubescape.io/ignore: \"true\"\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
     kind: ConfigMap
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: registry-scan-cronjob-template
       namespace: kubescape
@@ -2197,6 +2263,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
     rules:
@@ -2229,6 +2297,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
     roleRef:
@@ -2245,6 +2315,7 @@ all capabilities:
     metadata:
       labels:
         app: operator
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
     spec:
@@ -2262,6 +2333,7 @@ all capabilities:
     metadata:
       labels:
         app: operator
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
   58: |
@@ -2272,6 +2344,7 @@ all capabilities:
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector-config
       namespace: kubescape
@@ -2284,6 +2357,7 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: otel-collector
         helm.sh/chart: kubescape-operator-1.18.3
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -2303,8 +2377,8 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/otel-config: 50f39d2b201f211b8888a7e2cca3cfdebc768bcd17f2edb46a2316a67d662b1e
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/otel-config: d811570ce0b1ec1e93e5199c48e975436129b185728903c041d2796b94beae6c
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
           labels:
             app: otel-collector
             app.kubernetes.io/instance: RELEASE-NAME
@@ -2399,6 +2473,7 @@ all capabilities:
     metadata:
       labels:
         app: otel-collector
+        kubescape.io/ignore: "true"
       name: otel-collector
       namespace: kubescape
     spec:
@@ -2416,6 +2491,8 @@ all capabilities:
       proxy.crt: foo
     kind: Secret
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape-proxy-certificate
       namespace: kubescape
     type: Opaque
@@ -2431,6 +2508,7 @@ all capabilities:
         app: service-discovery
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: service-discovery
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
       namespace: kubescape
@@ -2504,6 +2582,8 @@ all capabilities:
         helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
         helm.sh/hook-weight: "0"
+      labels:
+        kubescape.io/ignore: "true"
       name: service-discovery
       namespace: kubescape
     rules:
@@ -2525,6 +2605,8 @@ all capabilities:
         helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
         helm.sh/hook-weight: "0"
+      labels:
+        kubescape.io/ignore: "true"
       name: service-discovery
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -2542,12 +2624,16 @@ all capabilities:
         helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
         helm.sh/hook-weight: "0"
+      labels:
+        kubescape.io/ignore: "true"
       name: service-discovery
       namespace: kubescape
   67: |
     apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: v1beta1.spdx.softwarecomposition.kubescape.io
     spec:
       group: spdx.softwarecomposition.kubescape.io
@@ -2562,6 +2648,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage
     rules:
       - apiGroups:
@@ -2658,6 +2746,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage:system:auth-delegator
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -2688,6 +2778,7 @@ all capabilities:
         app.kubernetes.io/component: apiserver
         app.kubernetes.io/name: storage
         app.kubernetes.io/part-of: kubescape-storage
+        kubescape.io/ignore: "true"
       name: storage
       namespace: kubescape
     spec:
@@ -2771,6 +2862,7 @@ all capabilities:
         app.kubernetes.io/component: apiserver
         app.kubernetes.io/name: storage
         app.kubernetes.io/part-of: kubescape-storage
+        kubescape.io/ignore: "true"
       name: kubescape-storage
       namespace: kubescape
     spec:
@@ -2783,6 +2875,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage-auth-reader
       namespace: kube-system
     roleRef:
@@ -2797,6 +2891,8 @@ all capabilities:
     apiVersion: v1
     kind: Service
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage
       namespace: kubescape
     spec:
@@ -2812,12 +2908,16 @@ all capabilities:
     apiVersion: v1
     kind: ServiceAccount
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage
       namespace: kubescape
   76: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: synchronizer
     rules:
       - apiGroups:
@@ -2883,6 +2983,8 @@ all capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: synchronizer
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -2982,6 +3084,8 @@ all capabilities:
         }
     kind: ConfigMap
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: synchronizer
       namespace: kubescape
   79: |
@@ -2992,6 +3096,7 @@ all capabilities:
         app: synchronizer
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: synchronizer
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
       namespace: kubescape
@@ -3008,10 +3113,10 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 65c94f1b291033884ce7997aa24d25e091c08b3bb6291960b4d1db7703fe6c75
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
-            checksum/synchronizer-configmap: f0f418a871d983d273e6742863112c7fc6a62ee7706f6803bf6e8d5b696fb863
+            checksum/cloud-config: 5c76d6ae3049caa8f1f6595e4e2d727b5c6e5c84ea60e83d4bb08cb813bc71ce
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
+            checksum/synchronizer-configmap: 71f123b7422a49f4e8c3acba589211b0f5cb4a6e888a68aebda4c13a4bcbe571
           labels:
             app: synchronizer
             app.kubernetes.io/instance: RELEASE-NAME
@@ -3136,6 +3241,7 @@ all capabilities:
     metadata:
       labels:
         app: synchronizer
+        kubescape.io/ignore: "true"
       name: synchronizer
       namespace: kubescape
 default capabilities:
@@ -3150,6 +3256,7 @@ default capabilities:
     metadata:
       labels:
         app: cloud-secret
+        kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
       name: cloud-secret
@@ -3194,6 +3301,7 @@ default capabilities:
         helm.sh/resource-policy: keep
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         kubescape.io/infra: config
         tier: ks-control-plane
       name: ks-cloud-config
@@ -3211,6 +3319,7 @@ default capabilities:
     metadata:
       labels:
         app: ks-capabilities
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: ks-capabilities
       namespace: kubescape
@@ -3223,6 +3332,7 @@ default capabilities:
     metadata:
       labels:
         app: kubescape
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: cs-matching-rules
       namespace: kubescape
@@ -3235,6 +3345,7 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: gateway
         helm.sh/chart: kubescape-operator-1.18.3
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: gateway
       namespace: kubescape
@@ -3254,9 +3365,9 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 1c3c58b01798216ec94806b7e92c3fc7ad7ea90f092dbb953d4c1a3fbceb0e97
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/cloud-config: 2ffc8249817256ce7ff2500dbcd9a620252ec6d6c0e5eb96577f2045d3d1d7c4
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
           labels:
             app: gateway
             app.kubernetes.io/instance: RELEASE-NAME
@@ -3393,6 +3504,7 @@ default capabilities:
     metadata:
       labels:
         app: gateway
+        kubescape.io/ignore: "true"
       name: gateway
       namespace: kubescape
     spec:
@@ -3416,6 +3528,7 @@ default capabilities:
         app: grype-offline-db
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: grype-offline-db
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
       namespace: kubescape
@@ -3494,6 +3607,7 @@ default capabilities:
     metadata:
       labels:
         app: grype-offline-db
+        kubescape.io/ignore: "true"
       name: grype-offline-db
       namespace: kubescape
     spec:
@@ -3508,6 +3622,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kollector
     rules:
       - apiGroups:
@@ -3547,6 +3663,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kollector
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -3590,6 +3708,7 @@ default capabilities:
     metadata:
       labels:
         app: kollector
+        kubescape.io/ignore: "true"
       name: kollector
       namespace: kubescape
   16: |
@@ -3600,6 +3719,7 @@ default capabilities:
         app: kollector
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kollector
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kollector
       namespace: kubescape
@@ -3614,9 +3734,9 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 1c3c58b01798216ec94806b7e92c3fc7ad7ea90f092dbb953d4c1a3fbceb0e97
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/cloud-config: 2ffc8249817256ce7ff2500dbcd9a620252ec6d6c0e5eb96577f2045d3d1d7c4
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
           labels:
             app: kollector
             app.kubernetes.io/instance: RELEASE-NAME
@@ -3720,6 +3840,7 @@ default capabilities:
     metadata:
       labels:
         app: kubescape-scheduler
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
       namespace: kubescape
@@ -3731,6 +3852,7 @@ default capabilities:
         app: kubescape-scheduler
         app.kubernetes.io/name: kubescape-scheduler
         armo.tier: kubescape-scan
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
       namespace: kubescape
@@ -3788,6 +3910,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape
     rules:
       - apiGroups:
@@ -3979,6 +4103,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -3997,6 +4123,7 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape
         helm.sh/chart: kubescape-operator-1.18.3
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -4016,10 +4143,10 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 1c3c58b01798216ec94806b7e92c3fc7ad7ea90f092dbb953d4c1a3fbceb0e97
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/host-scanner-configmap: 2f2feb524edeabfcf23a0ded8294cb5169dbba6ad4251e9525564f3da04cae43
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/cloud-config: 2ffc8249817256ce7ff2500dbcd9a620252ec6d6c0e5eb96577f2045d3d1d7c4
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/host-scanner-configmap: b6068eedcfa8521373ce4e38185dd66a6dda7dbf77f852e13e3f3662bc63d632
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
           labels:
             app: kubescape
             app.kubernetes.io/instance: RELEASE-NAME
@@ -4168,6 +4295,7 @@ default capabilities:
           template:
             metadata:
               labels:
+                kubescape.io/ignore: "true"
                 name: host-scanner
                 otel: enabled
             spec:
@@ -4242,6 +4370,7 @@ default capabilities:
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: host-scanner-definition
       namespace: kubescape
@@ -4282,6 +4411,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
     rules:
@@ -4301,6 +4432,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
     roleRef:
@@ -4317,6 +4450,7 @@ default capabilities:
     metadata:
       labels:
         app: kubescape
+        kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
     spec:
@@ -4335,6 +4469,7 @@ default capabilities:
     metadata:
       labels:
         app: kubescape
+        kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
   28: |
@@ -4343,6 +4478,7 @@ default capabilities:
     metadata:
       labels:
         app: kubescape
+        kubescape.io/ignore: "true"
       name: kubescape-monitor
       namespace: kubescape
     spec:
@@ -4365,6 +4501,7 @@ default capabilities:
     metadata:
       labels:
         app: kubevuln-scheduler
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
       namespace: kubescape
@@ -4376,6 +4513,7 @@ default capabilities:
         app: kubevuln-scheduler
         app.kubernetes.io/name: kubevuln-scheduler
         armo.tier: vuln-scan
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
       namespace: kubescape
@@ -4433,6 +4571,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubevuln
     rules:
       - apiGroups:
@@ -4464,6 +4604,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubevuln
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -4481,6 +4623,7 @@ default capabilities:
         app: kubevuln
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubevuln
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
       namespace: kubescape
@@ -4497,9 +4640,9 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 1c3c58b01798216ec94806b7e92c3fc7ad7ea90f092dbb953d4c1a3fbceb0e97
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/cloud-config: 2ffc8249817256ce7ff2500dbcd9a620252ec6d6c0e5eb96577f2045d3d1d7c4
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
           labels:
             app: kubevuln
             app.kubernetes.io/instance: RELEASE-NAME
@@ -4643,6 +4786,7 @@ default capabilities:
     metadata:
       labels:
         app: kubevuln
+        kubescape.io/ignore: "true"
       name: kubevuln
       namespace: kubescape
     spec:
@@ -4660,12 +4804,15 @@ default capabilities:
     metadata:
       labels:
         app: kubevuln
+        kubescape.io/ignore: "true"
       name: kubevuln
       namespace: kubescape
   37: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: node-agent
     rules:
       - apiGroups:
@@ -4737,6 +4884,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: node-agent
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -4760,6 +4909,8 @@ default capabilities:
         }
     kind: ConfigMap
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: node-agent
       namespace: kubescape
   40: |
@@ -4770,6 +4921,7 @@ default capabilities:
         app: node-agent
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: node-agent
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
@@ -4782,10 +4934,10 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 1c3c58b01798216ec94806b7e92c3fc7ad7ea90f092dbb953d4c1a3fbceb0e97
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/node-agent-config: 1f1ed354ec149975e60a35866c9b74c952b526adddf8fdc41ecb1ca64e0aafa5
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/cloud-config: 2ffc8249817256ce7ff2500dbcd9a620252ec6d6c0e5eb96577f2045d3d1d7c4
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/node-agent-config: fb53fadca13d78d5e01db68f6ee10efcefc9f19377867d9554fe07c449490244
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             alt-name: node-agent
@@ -4930,12 +5082,16 @@ default capabilities:
     apiVersion: v1
     kind: ServiceAccount
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: node-agent
       namespace: kubescape
   42: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
     rules:
       - apiGroups:
@@ -4992,6 +5148,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -5011,6 +5169,8 @@ default capabilities:
         }
     kind: ConfigMap
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
   45: |
@@ -5021,6 +5181,7 @@ default capabilities:
         app: operator
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: operator
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
       namespace: kubescape
@@ -5040,12 +5201,12 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: c5ce8d3e19bb269915b259a78c796881abf315ff19b3f38fdc7d3b1ebe95b969
-            checksum/cloud-config: 1c3c58b01798216ec94806b7e92c3fc7ad7ea90f092dbb953d4c1a3fbceb0e97
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/matching-rules-config: 0fe866ff165ca62399198397c07ab2d49af3181c569b3d0cce4a4cb310796824
-            checksum/operator-config: df99a2aba9854372143be03476352384d33d686923ae071dde264c8c7ffbc999
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/capabilities-config: 2e40ef041a9ec6e423d23cfcb1157599f4264e41a329c5b939d84552c3a0d62f
+            checksum/cloud-config: 2ffc8249817256ce7ff2500dbcd9a620252ec6d6c0e5eb96577f2045d3d1d7c4
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/matching-rules-config: ac114ef46ae46b2ba220aadc68b8609734da30557e20aebf48182d201ba3d710
+            checksum/operator-config: 30dc27ad7f65bd501b52accfe50df5afc6dfa51e44ca618e3ec1fd3e68bca114
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
           labels:
             app: operator
             app.kubernetes.io/instance: RELEASE-NAME
@@ -5176,22 +5337,24 @@ default capabilities:
   46: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
     kind: ConfigMap
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-cronjob-template
       namespace: kubescape
   47: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    kubescape.io/ignore: \"true\"\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
     kind: ConfigMap
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-cronjob-template
       namespace: kubescape
@@ -5237,11 +5400,12 @@ default capabilities:
   49: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    kubescape.io/ignore: \"true\"\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
     kind: ConfigMap
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: registry-scan-cronjob-template
       namespace: kubescape
@@ -5249,6 +5413,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
     rules:
@@ -5281,6 +5447,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
     roleRef:
@@ -5297,6 +5465,7 @@ default capabilities:
     metadata:
       labels:
         app: operator
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
     spec:
@@ -5314,6 +5483,7 @@ default capabilities:
     metadata:
       labels:
         app: operator
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
   54: |
@@ -5324,6 +5494,7 @@ default capabilities:
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector-config
       namespace: kubescape
@@ -5336,6 +5507,7 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: otel-collector
         helm.sh/chart: kubescape-operator-1.18.3
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -5355,8 +5527,8 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/otel-config: 50f39d2b201f211b8888a7e2cca3cfdebc768bcd17f2edb46a2316a67d662b1e
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
+            checksum/otel-config: d811570ce0b1ec1e93e5199c48e975436129b185728903c041d2796b94beae6c
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
           labels:
             app: otel-collector
             app.kubernetes.io/instance: RELEASE-NAME
@@ -5451,6 +5623,7 @@ default capabilities:
     metadata:
       labels:
         app: otel-collector
+        kubescape.io/ignore: "true"
       name: otel-collector
       namespace: kubescape
     spec:
@@ -5468,6 +5641,8 @@ default capabilities:
       proxy.crt: foo
     kind: Secret
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape-proxy-certificate
       namespace: kubescape
     type: Opaque
@@ -5483,6 +5658,7 @@ default capabilities:
         app: service-discovery
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: service-discovery
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
       namespace: kubescape
@@ -5556,6 +5732,8 @@ default capabilities:
         helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
         helm.sh/hook-weight: "0"
+      labels:
+        kubescape.io/ignore: "true"
       name: service-discovery
       namespace: kubescape
     rules:
@@ -5577,6 +5755,8 @@ default capabilities:
         helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
         helm.sh/hook-weight: "0"
+      labels:
+        kubescape.io/ignore: "true"
       name: service-discovery
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -5594,12 +5774,16 @@ default capabilities:
         helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
         helm.sh/hook-weight: "0"
+      labels:
+        kubescape.io/ignore: "true"
       name: service-discovery
       namespace: kubescape
   63: |
     apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: v1beta1.spdx.softwarecomposition.kubescape.io
     spec:
       group: spdx.softwarecomposition.kubescape.io
@@ -5614,6 +5798,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage
     rules:
       - apiGroups:
@@ -5710,6 +5896,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage:system:auth-delegator
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -5740,6 +5928,7 @@ default capabilities:
         app.kubernetes.io/component: apiserver
         app.kubernetes.io/name: storage
         app.kubernetes.io/part-of: kubescape-storage
+        kubescape.io/ignore: "true"
       name: storage
       namespace: kubescape
     spec:
@@ -5823,6 +6012,7 @@ default capabilities:
         app.kubernetes.io/component: apiserver
         app.kubernetes.io/name: storage
         app.kubernetes.io/part-of: kubescape-storage
+        kubescape.io/ignore: "true"
       name: kubescape-storage
       namespace: kubescape
     spec:
@@ -5835,6 +6025,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage-auth-reader
       namespace: kube-system
     roleRef:
@@ -5849,6 +6041,8 @@ default capabilities:
     apiVersion: v1
     kind: Service
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage
       namespace: kubescape
     spec:
@@ -5864,12 +6058,16 @@ default capabilities:
     apiVersion: v1
     kind: ServiceAccount
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage
       namespace: kubescape
   72: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: synchronizer
     rules:
       - apiGroups:
@@ -5935,6 +6133,8 @@ default capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: synchronizer
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -6034,6 +6234,8 @@ default capabilities:
         }
     kind: ConfigMap
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: synchronizer
       namespace: kubescape
   75: |
@@ -6044,6 +6246,7 @@ default capabilities:
         app: synchronizer
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: synchronizer
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
       namespace: kubescape
@@ -6060,10 +6263,10 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 1c3c58b01798216ec94806b7e92c3fc7ad7ea90f092dbb953d4c1a3fbceb0e97
-            checksum/cloud-secret: 093281e88f6ece2531917b0c620b783a589c4a118521d94e375905522f55b523
-            checksum/proxy-config: f2071cad863e27de0eec2175d24d505135c28d48c11a520ad04a9f4f8a5ac0b7
-            checksum/synchronizer-configmap: f0f418a871d983d273e6742863112c7fc6a62ee7706f6803bf6e8d5b696fb863
+            checksum/cloud-config: 2ffc8249817256ce7ff2500dbcd9a620252ec6d6c0e5eb96577f2045d3d1d7c4
+            checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
+            checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
+            checksum/synchronizer-configmap: 71f123b7422a49f4e8c3acba589211b0f5cb4a6e888a68aebda4c13a4bcbe571
           labels:
             app: synchronizer
             app.kubernetes.io/instance: RELEASE-NAME
@@ -6188,6 +6391,7 @@ default capabilities:
     metadata:
       labels:
         app: synchronizer
+        kubescape.io/ignore: "true"
       name: synchronizer
       namespace: kubescape
 minimal capabilities:
@@ -6202,6 +6406,7 @@ minimal capabilities:
     metadata:
       labels:
         app: cloud-secret
+        kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
       name: cloud-secret
@@ -6237,6 +6442,7 @@ minimal capabilities:
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         kubescape.io/infra: config
         tier: ks-control-plane
       name: ks-cloud-config
@@ -6254,6 +6460,7 @@ minimal capabilities:
     metadata:
       labels:
         app: ks-capabilities
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: ks-capabilities
       namespace: kubescape
@@ -6266,6 +6473,7 @@ minimal capabilities:
     metadata:
       labels:
         app: kubescape
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: cs-matching-rules
       namespace: kubescape
@@ -6273,6 +6481,8 @@ minimal capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape
     rules:
       - apiGroups:
@@ -6464,6 +6674,8 @@ minimal capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -6482,6 +6694,7 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape
         helm.sh/chart: kubescape-operator-1.18.3
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -6501,9 +6714,9 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: b5d4bf3f25dc44c377f477cbc47e1d0d4e55959eef61038df057515fcec2160f
-            checksum/cloud-secret: 436faa29a74a6ab2b6ee2ae0faaa0576d663745a9780780fa53afa02a945dddb
-            checksum/host-scanner-configmap: 2f2feb524edeabfcf23a0ded8294cb5169dbba6ad4251e9525564f3da04cae43
+            checksum/cloud-config: 52e150fa6ba81b760a262c34545c5f1defc8c2a23d1b4ffd4fc57743dc3cbc5a
+            checksum/cloud-secret: baefa7c2a6f06e1afdaffb0829d1caf36ff7428773197f1e5ca4731c132ecb78
+            checksum/host-scanner-configmap: b6068eedcfa8521373ce4e38185dd66a6dda7dbf77f852e13e3f3662bc63d632
           labels:
             app: kubescape
             app.kubernetes.io/instance: RELEASE-NAME
@@ -6644,6 +6857,7 @@ minimal capabilities:
           template:
             metadata:
               labels:
+                kubescape.io/ignore: "true"
                 name: host-scanner
                 otel: enabled
             spec:
@@ -6718,6 +6932,7 @@ minimal capabilities:
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: host-scanner-definition
       namespace: kubescape
@@ -6725,6 +6940,8 @@ minimal capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
     rules:
@@ -6744,6 +6961,8 @@ minimal capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
     roleRef:
@@ -6760,6 +6979,7 @@ minimal capabilities:
     metadata:
       labels:
         app: kubescape
+        kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
     spec:
@@ -6778,12 +6998,15 @@ minimal capabilities:
     metadata:
       labels:
         app: kubescape
+        kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
   14: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubevuln
     rules:
       - apiGroups:
@@ -6815,6 +7038,8 @@ minimal capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubevuln
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -6832,6 +7057,7 @@ minimal capabilities:
         app: kubevuln
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubevuln
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
       namespace: kubescape
@@ -6848,8 +7074,8 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: b5d4bf3f25dc44c377f477cbc47e1d0d4e55959eef61038df057515fcec2160f
-            checksum/cloud-secret: 436faa29a74a6ab2b6ee2ae0faaa0576d663745a9780780fa53afa02a945dddb
+            checksum/cloud-config: 52e150fa6ba81b760a262c34545c5f1defc8c2a23d1b4ffd4fc57743dc3cbc5a
+            checksum/cloud-secret: baefa7c2a6f06e1afdaffb0829d1caf36ff7428773197f1e5ca4731c132ecb78
           labels:
             app: kubevuln
             app.kubernetes.io/instance: RELEASE-NAME
@@ -6953,6 +7179,7 @@ minimal capabilities:
     metadata:
       labels:
         app: kubevuln
+        kubescape.io/ignore: "true"
       name: kubevuln
       namespace: kubescape
     spec:
@@ -6970,12 +7197,15 @@ minimal capabilities:
     metadata:
       labels:
         app: kubevuln
+        kubescape.io/ignore: "true"
       name: kubevuln
       namespace: kubescape
   19: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: node-agent
     rules:
       - apiGroups:
@@ -7047,6 +7277,8 @@ minimal capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: node-agent
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -7070,6 +7302,8 @@ minimal capabilities:
         }
     kind: ConfigMap
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: node-agent
       namespace: kubescape
   22: |
@@ -7080,6 +7314,7 @@ minimal capabilities:
         app: node-agent
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: node-agent
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
@@ -7092,9 +7327,9 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: b5d4bf3f25dc44c377f477cbc47e1d0d4e55959eef61038df057515fcec2160f
-            checksum/cloud-secret: 436faa29a74a6ab2b6ee2ae0faaa0576d663745a9780780fa53afa02a945dddb
-            checksum/node-agent-config: 86b38ffc87a7df25c377369ecdf4cccf7d10f2c4fc1d29f3e220f39b74906de6
+            checksum/cloud-config: 52e150fa6ba81b760a262c34545c5f1defc8c2a23d1b4ffd4fc57743dc3cbc5a
+            checksum/cloud-secret: baefa7c2a6f06e1afdaffb0829d1caf36ff7428773197f1e5ca4731c132ecb78
+            checksum/node-agent-config: 8ac85abd1cd0207e37423eb94bceade527d71c17685de5b01c7da9def2703ff3
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             alt-name: node-agent
@@ -7231,12 +7466,16 @@ minimal capabilities:
     apiVersion: v1
     kind: ServiceAccount
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: node-agent
       namespace: kubescape
   24: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
     rules:
       - apiGroups:
@@ -7293,6 +7532,8 @@ minimal capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -7312,6 +7553,8 @@ minimal capabilities:
         }
     kind: ConfigMap
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
   27: |
@@ -7322,6 +7565,7 @@ minimal capabilities:
         app: operator
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: operator
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
       namespace: kubescape
@@ -7341,11 +7585,11 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: d63cbbc983883c4b6f372af3dc0d5ab6a07b84eb98ede271fe4a631f53c8cf31
-            checksum/cloud-config: b5d4bf3f25dc44c377f477cbc47e1d0d4e55959eef61038df057515fcec2160f
-            checksum/cloud-secret: 436faa29a74a6ab2b6ee2ae0faaa0576d663745a9780780fa53afa02a945dddb
-            checksum/matching-rules-config: 0fe866ff165ca62399198397c07ab2d49af3181c569b3d0cce4a4cb310796824
-            checksum/operator-config: df99a2aba9854372143be03476352384d33d686923ae071dde264c8c7ffbc999
+            checksum/capabilities-config: 67b2f519fbd103a96c737bdab94b8d023487b4dc17c5d0be0879bee010ff1b17
+            checksum/cloud-config: 52e150fa6ba81b760a262c34545c5f1defc8c2a23d1b4ffd4fc57743dc3cbc5a
+            checksum/cloud-secret: baefa7c2a6f06e1afdaffb0829d1caf36ff7428773197f1e5ca4731c132ecb78
+            checksum/matching-rules-config: ac114ef46ae46b2ba220aadc68b8609734da30557e20aebf48182d201ba3d710
+            checksum/operator-config: 30dc27ad7f65bd501b52accfe50df5afc6dfa51e44ca618e3ec1fd3e68bca114
           labels:
             app: operator
             app.kubernetes.io/instance: RELEASE-NAME
@@ -7464,33 +7708,36 @@ minimal capabilities:
   28: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
     kind: ConfigMap
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-cronjob-template
       namespace: kubescape
   29: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    kubescape.io/ignore: \"true\"\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
     kind: ConfigMap
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-cronjob-template
       namespace: kubescape
   30: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    kubescape.io/ignore: \"true\"\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.0.14\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
     kind: ConfigMap
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: registry-scan-cronjob-template
       namespace: kubescape
@@ -7498,6 +7745,8 @@ minimal capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
     rules:
@@ -7530,6 +7779,8 @@ minimal capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
     roleRef:
@@ -7546,6 +7797,7 @@ minimal capabilities:
     metadata:
       labels:
         app: operator
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
     spec:
@@ -7563,6 +7815,7 @@ minimal capabilities:
     metadata:
       labels:
         app: operator
+        kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
   35: |
@@ -7573,6 +7826,7 @@ minimal capabilities:
     metadata:
       labels:
         app: ks-cloud-config
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector-config
       namespace: kubescape
@@ -7585,6 +7839,7 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: otel-collector
         helm.sh/chart: kubescape-operator-1.18.3
+        kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -7604,7 +7859,7 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/otel-config: d88df58b9cc02dce79750f71c91e974f73b768cc499d08a285517a4a4664e9ab
+            checksum/otel-config: 4537b426465e475b469222caa0d53ff43e4956abd9eacb94cb69430937161b2e
           labels:
             app: otel-collector
             app.kubernetes.io/instance: RELEASE-NAME
@@ -7660,6 +7915,7 @@ minimal capabilities:
     metadata:
       labels:
         app: otel-collector
+        kubescape.io/ignore: "true"
       name: otel-collector
       namespace: kubescape
     spec:
@@ -7675,6 +7931,8 @@ minimal capabilities:
     apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: v1beta1.spdx.softwarecomposition.kubescape.io
     spec:
       group: spdx.softwarecomposition.kubescape.io
@@ -7689,6 +7947,8 @@ minimal capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage
     rules:
       - apiGroups:
@@ -7785,6 +8045,8 @@ minimal capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage:system:auth-delegator
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -7815,6 +8077,7 @@ minimal capabilities:
         app.kubernetes.io/component: apiserver
         app.kubernetes.io/name: storage
         app.kubernetes.io/part-of: kubescape-storage
+        kubescape.io/ignore: "true"
       name: storage
       namespace: kubescape
     spec:
@@ -7896,6 +8159,7 @@ minimal capabilities:
         app.kubernetes.io/component: apiserver
         app.kubernetes.io/name: storage
         app.kubernetes.io/part-of: kubescape-storage
+        kubescape.io/ignore: "true"
       name: kubescape-storage
       namespace: kubescape
     spec:
@@ -7908,6 +8172,8 @@ minimal capabilities:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage-auth-reader
       namespace: kube-system
     roleRef:
@@ -7922,6 +8188,8 @@ minimal capabilities:
     apiVersion: v1
     kind: Service
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage
       namespace: kubescape
     spec:
@@ -7937,6 +8205,8 @@ minimal capabilities:
     apiVersion: v1
     kind: ServiceAccount
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: storage
       namespace: kubescape
 with multiple private registry credentials:
@@ -7944,6 +8214,8 @@ with multiple private registry credentials:
     apiVersion: v1
     kind: Secret
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape-registry-scan-secrets
       namespace: kubescape
     stringData:
@@ -7968,6 +8240,8 @@ with single private registry credentials:
     apiVersion: v1
     kind: Secret
     metadata:
+      labels:
+        kubescape.io/ignore: "true"
       name: kubescape-registry-scan-secrets
       namespace: kubescape
     stringData:


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement


___

## **Description**
- Added `kubescape.io/ignore: "true"` label to various resources including deployments, services, ConfigMaps, secrets, and RBAC resources across the kubescape-operator charts.
- This change is aimed at marking these resources to be ignored by Kubescape scans, enhancing the security posture by excluding them from vulnerability scans.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ArgoCDApplication.yaml</strong><dd><code>Add Namespace to ArgoCD Application Metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ArgoCDApplication.yaml
- Namespace added to the metadata section.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-7f7d85a125659cb48cd2fe3dc28504a474c03b41e82f02e3c7dd68c995afb13a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>host-scanner-definition.yaml</strong><dd><code>Add Ignore Label to Host Scanner Definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/assets/host-scanner-definition.yaml
<li>Added <code>kubescape.io/ignore: "true"</code> label to the template metadata.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-88152015cf1e3581505b2f76d7aa94865377739b68a0bf2cb83579b1f15cd7f9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kubescape-cronjob-full.yaml</strong><dd><code>Add Ignore Label to Kubescape Cronjob</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/assets/kubescape-cronjob-full.yaml
- Added `kubescape.io/ignore: "true"` label to the cronjob metadata.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-eff376bb4ed26da80ea2c541feba5a682792a562b5ae071ea12272f14497c7cb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kubevuln-cronjob-full.yaml</strong><dd><code>Add Ignore Label to KubeVuln Cronjob</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/assets/kubevuln-cronjob-full.yaml
- Added `kubescape.io/ignore: "true"` label to the cronjob metadata.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-a6c71225bcec775a304738cdcfc01ac0feb870555f0fa2297b0aaca4bc62cdd6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>registry-scan-cronjob-full.yaml</strong><dd><code>Add Ignore Label to Registry Scan Cronjob</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/assets/registry-scan-cronjob-full.yaml
- Added `kubescape.io/ignore: "true"` label to the cronjob metadata.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-efdcc6e194c517f765750120607f404139ecab11aa8612674cd3281f8355f96f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cronjob.yaml</strong><dd><code>Add Ignore Label to AutoUpdater Cronjob</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/autoupdater/cronjob.yaml
- Added `kubescape.io/ignore: "true"` label to the cronjob metadata.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-e0f712732b9b8f719a5ad8a80d0503811c4b82d23ec42d4aab8a849faab6fcb8">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rbac.yaml</strong><dd><code>Add Ignore Label to AutoUpdater RBAC Resources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/autoupdater/rbac.yaml
- Added `kubescape.io/ignore: "true"` label to RBAC resources.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-b46e38ad80691141d4e735d6280ea65bab982aafcc043cfc6c32632d444d071a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>serviceaccount.yaml</strong><dd><code>Add Ignore Label to AutoUpdater Service Account</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/autoupdater/serviceaccount.yaml
- Added `kubescape.io/ignore: "true"` label to the service account.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-f8c2b7419dca6b7a42bd941b55a7169f716f2c6f772f624d7b2e68940499e95a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cloud-secret.yaml</strong><dd><code>Add Ignore Label to Cloud Secret</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/configs/cloud-secret.yaml
- Added `kubescape.io/ignore: "true"` label to the secret.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-f22c39347903120f4e9dd584c170b364614893d28d72c019fe09603da71f39e7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cloudapi-configmap.yaml</strong><dd><code>Add Ignore Label to CloudAPI ConfigMap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
- Added `kubescape.io/ignore: "true"` label to the ConfigMap.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-d67b5e77ec52f1651c868cf77a343661ac8a570cdcfc8b27d8cbb14e4c0e0052">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>components-configmap.yaml</strong><dd><code>Add Ignore Label to Components ConfigMap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/configs/components-configmap.yaml
- Added `kubescape.io/ignore: "true"` label to the ConfigMap.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-d88eb2cf5c168a01daf11225292baaf9b7f000811c85e4774e5a01349f3f7349">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>matchingRules-configmap.yaml</strong><dd><code>Add Ignore Label to Matching Rules ConfigMap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/configs/matchingRules-configmap.yaml
- Added `kubescape.io/ignore: "true"` label to the ConfigMap.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-c53c33d4ec1374f12cf4559b3b1607fea1df261ffaf607fd71ea6f5c9009f6c2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>private-registries-creds-secret.yaml</strong><dd><code>Add Ignore Label to Private Registries Credentials Secret</code></dd></summary>
<hr>

charts/kubescape-operator/templates/configs/private-registries-creds-secret.yaml
- Added `kubescape.io/ignore: "true"` label to the secret.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-4beab6e16477b86421d0f84f6093886e69f056382479b407cb4eeb6c8077aad6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml</strong><dd><code>Add Ignore Label to Gateway Deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/gateway/deployment.yaml
- Added `kubescape.io/ignore: "true"` label to the deployment.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-6bd270405e95dd0258489bb9e98181292b47be2e77423dd4086b756f6c7618d3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>service.yaml</strong><dd><code>Add Ignore Label to Gateway Service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/gateway/service.yaml
- Added `kubescape.io/ignore: "true"` label to the service.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/395/files#diff-3245647805b30959c731845734e98f2ad0e97bc1963411cd989aac20ee913946">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
