### PR TITLE
add warning on upgrading releases with manual changes

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -723,6 +723,10 @@ The Helm chart provides a capability to automatically fetch the latest chart ver
 
 To enable this capability, simply simply set the `capabilities.autoUpgrading` to `enable` and configure how often you would like to check for updates by adjusting the cron schedule:
 
+> [!WARNING]
+> The Auto Upgrading capability works the same way as a regular Helm upgrade.
+> Therefore, it [won't update Kubernetes resources after manual changes](https://github.com/helm/helm/issues/11040#issuecomment-1154700942).
+
 ```yaml
 capabilities:
   autoUpgrading: enable


### PR DESCRIPTION
## **Type**
documentation


___

## **Description**
- Added a warning in the `kubescape-operator` chart README to inform users that the Auto Upgrading capability does not update Kubernetes resources if they have been manually changed. This is to prevent unexpected behavior and align with Helm's limitations.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add Warning to Auto Upgrading Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/README.md
<li>Added a warning about the Auto Upgrading capability not updating <br>Kubernetes resources after manual changes.<br>


</details>
    

  </td>
  <td><a href="https:/kubescape/helm-charts/pull/399/files#diff-29301ee79c4acf85dcfdaa8326521bc7676bd383dff72b2e41a08c86b6727327">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

