### PR TITLE
prepare for next release

### DIFF
--- a/charts/kubescape-operator/templates/operator/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/operator/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     kubescape.io/ignore: "true"
 rules:
   - apiGroups: [""]
-    resources: ["pods", "nodes", "namespaces", "configmaps", "secrets"]
+    resources: ["pods", "nodes", "namespaces", "configmaps", "secrets", "services"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["batch"]
     resources: ["jobs", "cronjobs"]

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -84,6 +84,8 @@ spec:
           resources:
 {{ toYaml .Values.operator.resources | indent 12 }}
           env:
+            - name: HELM_RELEASE
+              value: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
             - name: GOMEMLIMIT
               value: "{{ .Values.operator.resources.requests.memory }}B"
             - name: KS_LOGGER_LEVEL

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1526,7 +1526,7 @@ all capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/kubevuln:v0.3.5
+              image: quay.io/kubescape/kubevuln:v0.3.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -1952,6 +1952,7 @@ all capabilities:
           - namespaces
           - configmaps
           - secrets
+          - services
         verbs:
           - get
           - watch
@@ -2073,6 +2074,8 @@ all capabilities:
                 - -v=4
                 - 2>&1
               env:
+                - name: HELM_RELEASE
+                  value: kubescape-operator-1.18.5
                 - name: GOMEMLIMIT
                   value: 100MiB
                 - name: KS_LOGGER_LEVEL
@@ -2081,7 +2084,7 @@ all capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/operator:v0.2.6
+              image: quay.io/kubescape/operator:v0.2.7
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -4720,7 +4723,7 @@ default capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/kubevuln:v0.3.5
+              image: quay.io/kubescape/kubevuln:v0.3.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -5146,6 +5149,7 @@ default capabilities:
           - namespaces
           - configmaps
           - secrets
+          - services
         verbs:
           - get
           - watch
@@ -5267,6 +5271,8 @@ default capabilities:
                 - -v=4
                 - 2>&1
               env:
+                - name: HELM_RELEASE
+                  value: kubescape-operator-1.18.5
                 - name: GOMEMLIMIT
                   value: 100MiB
                 - name: KS_LOGGER_LEVEL
@@ -5275,7 +5281,7 @@ default capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/operator:v0.2.6
+              image: quay.io/kubescape/operator:v0.2.7
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -7197,7 +7203,7 @@ minimal capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/kubevuln:v0.3.5
+              image: quay.io/kubescape/kubevuln:v0.3.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -7574,6 +7580,7 @@ minimal capabilities:
           - namespaces
           - configmaps
           - secrets
+          - services
         verbs:
           - get
           - watch
@@ -7694,6 +7701,8 @@ minimal capabilities:
                 - -v=4
                 - 2>&1
               env:
+                - name: HELM_RELEASE
+                  value: kubescape-operator-1.18.5
                 - name: GOMEMLIMIT
                   value: 100MiB
                 - name: KS_LOGGER_LEVEL
@@ -7702,7 +7711,7 @@ minimal capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/operator:v0.2.6
+              image: quay.io/kubescape/operator:v0.2.7
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -233,7 +233,7 @@ operator:
   image:
     # -- source code: https://github.com/kubescape/operator
     repository: quay.io/kubescape/operator
-    tag: v0.2.6
+    tag: v0.2.7
     pullPolicy: IfNotPresent
 
   service:
@@ -274,7 +274,7 @@ kubevuln:
   image:
     # -- source code: https://github.com/kubescape/kubevuln
     repository: quay.io/kubescape/kubevuln
-    tag: v0.3.5
+    tag: v0.3.6
     pullPolicy: IfNotPresent
 
   replicaCount: 1


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added "services" to the resources list in the cluster role to extend permissions.
- Introduced a new environment variable `HELM_RELEASE` in the deployment to track the Helm release version.
- Updated the operator and kubevuln image tags to v0.2.7 and v0.3.6 respectively, preparing for the next release.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clusterrole.yaml</strong><dd><code>Extend Cluster Role Resources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/operator/clusterrole.yaml
- Added "services" to the list of resources for the cluster role.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/405/files#diff-319db9f5c11e560155712379c80232e880c8bafae3f91b6a7ac8e1d2336eb42b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml</strong><dd><code>Add HELM_RELEASE Environment Variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/operator/deployment.yaml
<li>Introduced <code>HELM_RELEASE</code> environment variable with chart name and <br>version.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/405/files#diff-f64af5d3eb479f76bb827eefb0b345664e25457d016772051a4548e3d2840467">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Update Image Tags for Operator and Kubevuln</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/values.yaml
<li>Updated operator image tag to v0.2.7.<br> <li> Updated kubevuln image tag to v0.3.6.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/405/files#diff-2d5611f69251d498d71f52fa778f6ce1bc93e1e1f46951ede1c50d975bdcad02">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

