### PR TITLE
prepare hotfix release

### DIFF
--- a/.github/workflows/02-e2e-test.yaml
+++ b/.github/workflows/02-e2e-test.yaml
@@ -64,7 +64,7 @@ jobs:
               relevancy_java_and_python,
               relevancy_golang_dynamic,
               relevancy_multiple_containers,
-              vulnerability_scanning, 
+              vuln_scan,
               vuln_scan_proxy,
               vuln_scan_trigger_scan_public_registry,
               vuln_scan_trigger_scan_public_registry_excluded,

--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.18.8
+version: 1.18.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.18.8
+appVersion: 1.18.9
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -1,6 +1,6 @@
 # Kubescape Operator
 
-![Version: 1.18.8](https://img.shields.io/badge/Version-1.18.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.18.8](https://img.shields.io/badge/AppVersion-v1.18.8-informational?style=flat-square)
+![Version: 1.18.9](https://img.shields.io/badge/Version-1.18.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.18.9](https://img.shields.io/badge/AppVersion-v1.18.9-informational?style=flat-square)
 
 [Kubescape operator documentation](https://kubescape.io/docs/install-operator/)
 [Troubleshooting guide](https://hub.armosec.io/docs/installation-troubleshooting#3-the-kubescape-pod-restarted)

--- a/charts/kubescape-operator/assets/kubescape-cronjob-full.yaml
+++ b/charts/kubescape-operator/assets/kubescape-cronjob-full.yaml
@@ -41,7 +41,7 @@ apiVersion: batch/v1
                   - -scheme=http
                   - -host={{ .Values.operator.name }}:{{ .Values.operator.service.port }}
                   - -path=v1/triggerAction
-                  - -headers="Content-Type:application/json"
+                  - -headers=Content-Type:application/json
                   - -path-body=/home/ks/request-body.json
                 volumeMounts:
                   - name: "request-body-volume"

--- a/charts/kubescape-operator/assets/kubevuln-cronjob-full.yaml
+++ b/charts/kubescape-operator/assets/kubevuln-cronjob-full.yaml
@@ -41,7 +41,7 @@ apiVersion: batch/v1
                   - -scheme=http
                   - -host={{ .Values.operator.name }}:{{ .Values.operator.service.port }}
                   - -path=v1/triggerAction
-                  - -headers="Content-Type:application/json"
+                  - -headers=Content-Type:application/json
                   - -path-body=/home/ks/request-body.json
                 volumeMounts:
                   - name: "request-body-volume"

--- a/charts/kubescape-operator/assets/registry-scan-cronjob-full.yaml
+++ b/charts/kubescape-operator/assets/registry-scan-cronjob-full.yaml
@@ -41,7 +41,7 @@ apiVersion: batch/v1
                   - -scheme=http
                   - -host={{ .Values.operator.name }}:{{ .Values.operator.service.port }}
                   - -path=v1/triggerAction
-                  - -headers="Content-Type:application/json"
+                  - -headers=Content-Type:application/json
                   - -path-body=/home/ks/request-body.json
                 volumeMounts:
                   - name: "request-body-volume"

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,6 +1,6 @@
 all capabilities:
   1: |
-    raw: "Thank you for installing kubescape-operator version 1.18.8.\nView your cluster's configuration scanning schedule:  \n> kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'\n\nTo change the schedule, set `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubescape-scheduler\nView your cluster's image scanning schedule:  \n> kubectl -n kubescape get cj kubevuln-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'  \n\nTo change the schedule, edit `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubevuln-scheduler\nView your configuration scan summaries:\n> kubectl get workloadconfigurationscansummaries -A\n\nDetailed reports are also available:\n> kubectl get workloadconfigurationscans -A\n\nView your image vulnerabilities scan summaries:\n> kubectl get vulnerabilitymanifestsummaries -A\n\nDetailed reports are also available:\n> kubectl get vulnerabilitymanifests -A\n\nkubescape-operator generates suggested network policies. To view them:  \n> kubectl get generatednetworkpolicies -n <namespace>\n\n"
+    raw: "Thank you for installing kubescape-operator version 1.18.9.\nView your cluster's configuration scanning schedule:  \n> kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'\n\nTo change the schedule, set `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubescape-scheduler\nView your cluster's image scanning schedule:  \n> kubectl -n kubescape get cj kubevuln-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'  \n\nTo change the schedule, edit `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubevuln-scheduler\nView your configuration scan summaries:\n> kubectl get workloadconfigurationscansummaries -A\n\nDetailed reports are also available:\n> kubectl get workloadconfigurationscans -A\n\nView your image vulnerabilities scan summaries:\n> kubectl get vulnerabilitymanifestsummaries -A\n\nDetailed reports are also available:\n> kubectl get vulnerabilitymanifests -A\n\nkubescape-operator generates suggested network policies. To view them:  \n> kubectl get generatednetworkpolicies -n <namespace>\n\n"
   2: |
     apiVersion: batch/v1
     kind: CronJob
@@ -197,7 +197,7 @@ all capabilities:
         app: gateway
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: gateway
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -326,7 +326,7 @@ all capabilities:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         tier: ks-control-plane
       name: gateway
       namespace: kubescape
@@ -407,7 +407,7 @@ all capabilities:
             app: grype-offline-db
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: grype-offline-db
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             tier: ks-control-plane
         spec:
@@ -599,7 +599,7 @@ all capabilities:
             app: kollector
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kollector
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             tier: ks-control-plane
         spec:
@@ -739,7 +739,7 @@ all capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.5
+                  image: quay.io/kubescape/http-request:v0.2.6
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -984,7 +984,7 @@ all capabilities:
         app: kubescape
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1014,7 +1014,7 @@ all capabilities:
             app: kubescape
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubescape
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -1246,7 +1246,7 @@ all capabilities:
     metadata:
       labels:
         app: kubescape
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -1407,7 +1407,7 @@ all capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.5
+                  image: quay.io/kubescape/http-request:v0.2.6
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -1514,7 +1514,7 @@ all capabilities:
             app: kubevuln
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubevuln
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -1810,7 +1810,7 @@ all capabilities:
             app: node-agent
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: node-agent
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -2078,7 +2078,7 @@ all capabilities:
             app: operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: operator
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -2092,7 +2092,7 @@ all capabilities:
                 - 2>&1
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.18.8
+                  value: kubescape-operator-1.18.9
                 - name: GOMEMLIMIT
                   value: 100MiB
                 - name: KS_LOGGER_LEVEL
@@ -2101,7 +2101,7 @@ all capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/operator:v0.2.7
+              image: quay.io/kubescape/operator:v0.2.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -2207,7 +2207,7 @@ all capabilities:
   50: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.5\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.6\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=Content-Type:application/json\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
     kind: ConfigMap
     metadata:
       labels:
@@ -2220,7 +2220,7 @@ all capabilities:
   51: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.5\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.6\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=Content-Type:application/json\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
     kind: ConfigMap
     metadata:
       labels:
@@ -2272,7 +2272,7 @@ all capabilities:
   53: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.5\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.6\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=Content-Type:application/json\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
     kind: ConfigMap
     metadata:
       labels:
@@ -2380,7 +2380,7 @@ all capabilities:
         app: otel-collector
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: otel-collector
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2466,7 +2466,7 @@ all capabilities:
     metadata:
       labels:
         app: otel-collector
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -2547,7 +2547,7 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: service-discovery
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             otel: enabled
             tier: ks-control-plane
           name: RELEASE-NAME
@@ -2581,7 +2581,7 @@ all capabilities:
                 - -path=api/v2/servicediscovery
                 - -path-output=/data/services.json
               env: null
-              image: quay.io/kubescape/http-request:v0.2.5
+              image: quay.io/kubescape/http-request:v0.2.6
               imagePullPolicy: IfNotPresent
               name: url-discovery
               resources:
@@ -3205,7 +3205,7 @@ all capabilities:
             app: synchronizer
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: synchronizer
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -3217,7 +3217,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.18.8
+                  value: kubescape-operator-1.18.9
                 - name: GOMEMLIMIT
                   value: 250MiB
                 - name: KS_LOGGER_LEVEL
@@ -3357,7 +3357,7 @@ all capabilities:
       namespace: kubescape
 default capabilities:
   1: |
-    raw: "Thank you for installing kubescape-operator version 1.18.8.\nView your cluster's configuration scanning schedule:  \n> kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'\n\nTo change the schedule, set `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubescape-scheduler\nView your cluster's image scanning schedule:  \n> kubectl -n kubescape get cj kubevuln-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'  \n\nTo change the schedule, edit `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubevuln-scheduler\n\n\nView your image vulnerabilities scan summaries:\n> kubectl get vulnerabilitymanifestsummaries -A\n\nDetailed reports are also available:\n> kubectl get vulnerabilitymanifests -A\n\nkubescape-operator generates suggested network policies. To view them:  \n> kubectl get generatednetworkpolicies -n <namespace>\n\n"
+    raw: "Thank you for installing kubescape-operator version 1.18.9.\nView your cluster's configuration scanning schedule:  \n> kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'\n\nTo change the schedule, set `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubescape-scheduler\nView your cluster's image scanning schedule:  \n> kubectl -n kubescape get cj kubevuln-scheduler -o=jsonpath='{.metadata.name}{\"\\t\"}{.spec.schedule}{\"\\n\"}'  \n\nTo change the schedule, edit `.spec.schedule`:  \n> kubectl -n kubescape edit cj kubevuln-scheduler\n\n\nView your image vulnerabilities scan summaries:\n> kubectl get vulnerabilitymanifestsummaries -A\n\nDetailed reports are also available:\n> kubectl get vulnerabilitymanifests -A\n\nkubescape-operator generates suggested network policies. To view them:  \n> kubectl get generatednetworkpolicies -n <namespace>\n\n"
   2: |
     apiVersion: v1
     data:
@@ -3458,7 +3458,7 @@ default capabilities:
         app: gateway
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: gateway
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3587,7 +3587,7 @@ default capabilities:
     metadata:
       labels:
         app: gateway
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         tier: ks-control-plane
       name: gateway
       namespace: kubescape
@@ -3668,7 +3668,7 @@ default capabilities:
             app: grype-offline-db
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: grype-offline-db
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             tier: ks-control-plane
         spec:
@@ -3860,7 +3860,7 @@ default capabilities:
             app: kollector
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kollector
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             tier: ks-control-plane
         spec:
@@ -4000,7 +4000,7 @@ default capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.5
+                  image: quay.io/kubescape/http-request:v0.2.6
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -4245,7 +4245,7 @@ default capabilities:
         app: kubescape
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4275,7 +4275,7 @@ default capabilities:
             app: kubescape
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubescape
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -4507,7 +4507,7 @@ default capabilities:
     metadata:
       labels:
         app: kubescape
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         tier: ks-control-plane
       name: kubescape
       namespace: kubescape
@@ -4668,7 +4668,7 @@ default capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.5
+                  image: quay.io/kubescape/http-request:v0.2.6
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -4775,7 +4775,7 @@ default capabilities:
             app: kubevuln
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubevuln
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -5071,7 +5071,7 @@ default capabilities:
             app: node-agent
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: node-agent
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -5339,7 +5339,7 @@ default capabilities:
             app: operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: operator
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -5353,7 +5353,7 @@ default capabilities:
                 - 2>&1
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.18.8
+                  value: kubescape-operator-1.18.9
                 - name: GOMEMLIMIT
                   value: 100MiB
                 - name: KS_LOGGER_LEVEL
@@ -5362,7 +5362,7 @@ default capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/operator:v0.2.7
+              image: quay.io/kubescape/operator:v0.2.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -5468,7 +5468,7 @@ default capabilities:
   46: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.5\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.6\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=Content-Type:application/json\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
     kind: ConfigMap
     metadata:
       labels:
@@ -5481,7 +5481,7 @@ default capabilities:
   47: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.5\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.6\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=Content-Type:application/json\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
     kind: ConfigMap
     metadata:
       labels:
@@ -5533,7 +5533,7 @@ default capabilities:
   49: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.5\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.6\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=Content-Type:application/json\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
     kind: ConfigMap
     metadata:
       labels:
@@ -5641,7 +5641,7 @@ default capabilities:
         app: otel-collector
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: otel-collector
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5727,7 +5727,7 @@ default capabilities:
     metadata:
       labels:
         app: otel-collector
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         tier: ks-control-plane
       name: otel-collector
       namespace: kubescape
@@ -5808,7 +5808,7 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: service-discovery
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             otel: enabled
             tier: ks-control-plane
           name: RELEASE-NAME
@@ -5842,7 +5842,7 @@ default capabilities:
                 - -path=api/v2/servicediscovery
                 - -path-output=/data/services.json
               env: null
-              image: quay.io/kubescape/http-request:v0.2.5
+              image: quay.io/kubescape/http-request:v0.2.6
               imagePullPolicy: IfNotPresent
               name: url-discovery
               resources:
@@ -6466,7 +6466,7 @@ default capabilities:
             app: synchronizer
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: synchronizer
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -6478,7 +6478,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.18.8
+                  value: kubescape-operator-1.18.9
                 - name: GOMEMLIMIT
                   value: 250MiB
                 - name: KS_LOGGER_LEVEL
@@ -6618,7 +6618,7 @@ default capabilities:
       namespace: kubescape
 minimal capabilities:
   1: |
-    raw: "Thank you for installing kubescape-operator version 1.18.8.\n\n\n\n\nView your image vulnerabilities scan summaries:\n> kubectl get vulnerabilitymanifestsummaries -A\n\nDetailed reports are also available:\n> kubectl get vulnerabilitymanifests -A\n\nkubescape-operator generates suggested network policies. To view them:  \n> kubectl get generatednetworkpolicies -n <namespace>\n\n"
+    raw: "Thank you for installing kubescape-operator version 1.18.9.\n\n\n\n\nView your image vulnerabilities scan summaries:\n> kubectl get vulnerabilitymanifestsummaries -A\n\nDetailed reports are also available:\n> kubectl get vulnerabilitymanifests -A\n\nkubescape-operator generates suggested network policies. To view them:  \n> kubectl get generatednetworkpolicies -n <namespace>\n\n"
   2: |
     apiVersion: v1
     data:
@@ -6918,7 +6918,7 @@ minimal capabilities:
         app: kubescape
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6947,7 +6947,7 @@ minimal capabilities:
             app: kubescape
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubescape
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -7307,7 +7307,7 @@ minimal capabilities:
             app: kubevuln
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubevuln
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -7562,7 +7562,7 @@ minimal capabilities:
             app: node-agent
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: node-agent
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -7821,7 +7821,7 @@ minimal capabilities:
             app: operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: operator
-            helm.sh/chart: kubescape-operator-1.18.8
+            helm.sh/chart: kubescape-operator-1.18.9
             kubescape.io/tier: core
             otel: enabled
             tier: ks-control-plane
@@ -7835,7 +7835,7 @@ minimal capabilities:
                 - 2>&1
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.18.8
+                  value: kubescape-operator-1.18.9
                 - name: GOMEMLIMIT
                   value: 100MiB
                 - name: KS_LOGGER_LEVEL
@@ -7844,7 +7844,7 @@ minimal capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/operator:v0.2.7
+              image: quay.io/kubescape/operator:v0.2.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -7938,7 +7938,7 @@ minimal capabilities:
   28: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.5\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.6\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=Content-Type:application/json\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
     kind: ConfigMap
     metadata:
       labels:
@@ -7951,7 +7951,7 @@ minimal capabilities:
   29: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.5\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.6\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=Content-Type:application/json\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
     kind: ConfigMap
     metadata:
       labels:
@@ -7964,7 +7964,7 @@ minimal capabilities:
   30: |
     apiVersion: v1
     data:
-      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.5\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=\"Content-Type:application/json\"\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
+      cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.6\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=Content-Type:application/json\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
     kind: ConfigMap
     metadata:
       labels:
@@ -8072,7 +8072,7 @@ minimal capabilities:
         app: otel-collector
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: otel-collector
-        helm.sh/chart: kubescape-operator-1.18.8
+        helm.sh/chart: kubescape-operator-1.18.9
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -233,7 +233,7 @@ operator:
   image:
     # -- source code: https://github.com/kubescape/operator
     repository: quay.io/kubescape/operator
-    tag: v0.2.7
+    tag: v0.2.9
     pullPolicy: IfNotPresent
 
   service:
@@ -616,7 +616,7 @@ serviceDiscovery:
     name: url-discovery
     image:
       repository: quay.io/kubescape/http-request
-      tag: v0.2.5
+      tag: v0.2.6
       pullPolicy: IfNotPresent
 
   configMapCheck:
@@ -724,7 +724,7 @@ kubescapeScheduler:
   image:
     # -- source code: https://github.com/kubescape/http-request (public repo)
     repository: quay.io/kubescape/http-request
-    tag: v0.2.5
+    tag: v0.2.6
     pullPolicy: IfNotPresent
 
   # Additional volumes to be mounted on the scan scheduler
@@ -764,7 +764,7 @@ kubevulnScheduler:
   image:
     # source code - https://github.com/kubescape/http-request
     repository: quay.io/kubescape/http-request
-    tag: v0.2.5
+    tag: v0.2.6
     pullPolicy: IfNotPresent
 
   # Additional volumes to be mounted on the vuln scan scheduler
@@ -806,7 +806,7 @@ registryScanScheduler:
   image:
     # -- source code: https://github.com/kubescape/http-request (public repo)
     repository: quay.io/kubescape/http-request
-    tag: v0.2.5
+    tag: v0.2.6
     pullPolicy: IfNotPresent
 
   # Additional volumes to be mounted on the scan scheduler


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Incremented chart and app version to `1.18.9` in Chart.yaml and README.md.
- Fixed header format for content type in cronjob configurations.
- Updated various image tags in values.yaml to newer versions.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Version update</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Increment Chart and App Version for Kubescape Operator</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/Chart.yaml
<li>Incremented chart version from <code>1.18.8</code> to <code>1.18.9</code>.<br> <li> Incremented app version from <code>1.18.8</code> to <code>1.18.9</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/415/files#diff-a982fcb5ed73d5e096917432336870e77884084d3ceb0ac3914489703a7fb1b7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README Version Badges to 1.18.9</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/README.md
- Updated version badges to reflect new version `1.18.9`.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/415/files#diff-29301ee79c4acf85dcfdaa8326521bc7676bd383dff72b2e41a08c86b6727327">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kubescape-cronjob-full.yaml</strong><dd><code>Fix Header Format in Kubescape Cronjob Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/assets/kubescape-cronjob-full.yaml
- Corrected header format for content type in cronjob configuration.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/415/files#diff-eff376bb4ed26da80ea2c541feba5a682792a562b5ae071ea12272f14497c7cb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>kubevuln-cronjob-full.yaml</strong><dd><code>Fix Header Format in Kubevuln Cronjob Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/assets/kubevuln-cronjob-full.yaml
<li>Corrected header format for content type in kubevuln cronjob <br>configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/415/files#diff-a6c71225bcec775a304738cdcfc01ac0feb870555f0fa2297b0aaca4bc62cdd6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>registry-scan-cronjob-full.yaml</strong><dd><code>Fix Header Format in Registry Scan Cronjob Configuration</code>&nbsp; </dd></summary>
<hr>

charts/kubescape-operator/assets/registry-scan-cronjob-full.yaml
<li>Corrected header format for content type in registry scan cronjob <br>configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/415/files#diff-efdcc6e194c517f765750120607f404139ecab11aa8612674cd3281f8355f96f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Update Image Tags in Values Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/values.yaml
<li>Updated <code>operator</code> image tag from <code>v0.2.7</code> to <code>v0.2.9</code>.<br> <li> Updated <code>urlDiscovery</code>, <code>kubescapeScheduler</code>, <code>kubevulnScheduler</code>, and <br><code>registryScanScheduler</code> image tags from <code>v0.2.5</code> to <code>v0.2.6</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/415/files#diff-2d5611f69251d498d71f52fa778f6ce1bc93e1e1f46951ede1c50d975bdcad02">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

