### PR TITLE
fix prometheus config

### DIFF
--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -16,12 +16,6 @@ metadata:
     kubescape.io/ignore: "true"
     kubescape.io/tier: "core"
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-{{- if .Values.kubescape.prometheusAnnotation.enabled }}
-  annotations:
-    prometheus.io/path: /v1/metrics
-    prometheus.io/port: "8080"
-    prometheus.io/scrape: "true"
-{{- end }}
 spec:
   replicas: 1
   revisionHistoryLimit: 2
@@ -43,6 +37,11 @@ spec:
         checksum/cloud-config: {{ $checksums.cloudConfig }}
       {{- if ne .Values.global.proxySecretFile "" }}
         checksum/proxy-config: {{ $checksums.proxySecret }}
+      {{- end }}
+      {{- if eq .Values.configurations.prometheusAnnotations "enable" }}
+        prometheus.io/path: /v1/metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
       {{- end }}
       labels:
         kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/node-agent/configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/configmap.yaml
@@ -14,7 +14,7 @@ data:
     {
         "applicationProfileServiceEnabled": {{ $configurations.runtimeObservability }},
         "relevantCVEServiceEnabled": true,
-        "prometheusExporterEnabled": {{ .Values.nodeAgent.serviceMonitor.enabled }},
+        "prometheusExporterEnabled": {{ eq .Values.nodeAgent.config.prometheusExporter "enable" }},
         "runtimeDetectionEnabled": {{ eq .Values.capabilities.runtimeDetection "enable" }},
         "networkServiceEnabled": {{ eq .Values.capabilities.networkPolicyService "enable" }},
         "malwareDetectionEnabled": {{ eq .Values.capabilities.malwareDetection "enable" }},

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -30,6 +30,11 @@ spec:
         checksum/proxy-config: {{ $checksums.proxySecret }}
       {{- end }}
         container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
+      {{- if eq .Values.configurations.prometheusAnnotations "enable" }}
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      {{- end }}
       labels:
         kubescape.io/tier: "core"
         app.kubernetes.io/name: {{ .Values.nodeAgent.name }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -164,7 +164,7 @@ all capabilities:
         {
           "capabilities":{"autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","malwareDetection":"disable","networkPolicyService":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","vexGeneration":"enable","vulnerabilityScan":"enable"},
           "components":{"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
-          "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable"}
+          "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable","prometheusAnnotations":"disable"}
         }
     kind: ConfigMap
     metadata:
@@ -1772,7 +1772,7 @@ all capabilities:
         {
             "applicationProfileServiceEnabled": true,
             "relevantCVEServiceEnabled": true,
-            "prometheusExporterEnabled": false,
+            "prometheusExporterEnabled": true,
             "runtimeDetectionEnabled": false,
             "networkServiceEnabled": true,
             "malwareDetectionEnabled": false,
@@ -1814,7 +1814,7 @@ all capabilities:
           annotations:
             checksum/cloud-config: ca5984899e6bdff85ee9c762fd75f715483b862b4eea5990a107581e5f01e21a
             checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
-            checksum/node-agent-config: 2d17bedf65b554dc85e7d34b942015585364c08ec4c29a83c8da9b96afdcd95c
+            checksum/node-agent-config: 16b17a89cd015d4e27574c58b8c53ad6f344443bbd596d88ce098b890fd7507f
             checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -2110,7 +2110,7 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 74532b849b2278c9944227e4afb66be405ed684be5000cbc69fa8e7156783e49
+            checksum/capabilities-config: 6b44ee0d5bd17b565f09f23c6c183b808f8f76b732a092590978a9bad1e81da2
             checksum/cloud-config: ca5984899e6bdff85ee9c762fd75f715483b862b4eea5990a107581e5f01e21a
             checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
             checksum/matching-rules-config: 9282b3916f506ac98eccbdfe686271420ff520374de611f7efce8235dcdf8809
@@ -3467,7 +3467,7 @@ default capabilities:
         {
           "capabilities":{"autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","malwareDetection":"disable","networkPolicyService":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
-          "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable"}
+          "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable","prometheusAnnotations":"disable"}
         }
     kind: ConfigMap
     metadata:
@@ -5075,7 +5075,7 @@ default capabilities:
         {
             "applicationProfileServiceEnabled": true,
             "relevantCVEServiceEnabled": true,
-            "prometheusExporterEnabled": false,
+            "prometheusExporterEnabled": true,
             "runtimeDetectionEnabled": false,
             "networkServiceEnabled": true,
             "malwareDetectionEnabled": false,
@@ -5117,7 +5117,7 @@ default capabilities:
           annotations:
             checksum/cloud-config: fb124737ed448255a8e5c3fa8777f93da4ae931e5e7b2e98418924a2528a9230
             checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
-            checksum/node-agent-config: 2d17bedf65b554dc85e7d34b942015585364c08ec4c29a83c8da9b96afdcd95c
+            checksum/node-agent-config: 16b17a89cd015d4e27574c58b8c53ad6f344443bbd596d88ce098b890fd7507f
             checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -5413,7 +5413,7 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 441287945b80f3fc159c771a8c78b86733d0b5cfc618f7ebd92d3481c968ff4d
+            checksum/capabilities-config: e8dd2ce18f81f2a7692849f6f39350c11867c0c0ed053005ed9b9f2965dcb983
             checksum/cloud-config: fb124737ed448255a8e5c3fa8777f93da4ae931e5e7b2e98418924a2528a9230
             checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
             checksum/matching-rules-config: 9282b3916f506ac98eccbdfe686271420ff520374de611f7efce8235dcdf8809
@@ -6761,7 +6761,7 @@ minimal capabilities:
         {
           "capabilities":{"autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","malwareDetection":"disable","networkPolicyService":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":false},"hostScanner":{"enabled":true},"kollector":{"enabled":false},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":false},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":false},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
-          "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable"}
+          "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable","prometheusAnnotations":"disable"}
         }
     kind: ConfigMap
     metadata:
@@ -7609,7 +7609,7 @@ minimal capabilities:
         {
             "applicationProfileServiceEnabled": true,
             "relevantCVEServiceEnabled": true,
-            "prometheusExporterEnabled": false,
+            "prometheusExporterEnabled": true,
             "runtimeDetectionEnabled": false,
             "networkServiceEnabled": true,
             "malwareDetectionEnabled": false,
@@ -7651,7 +7651,7 @@ minimal capabilities:
           annotations:
             checksum/cloud-config: 9f53ca7bef8ac508eb3f7759668ef3db9ce194c142364e1f84151f1b8e538b1d
             checksum/cloud-secret: baefa7c2a6f06e1afdaffb0829d1caf36ff7428773197f1e5ca4731c132ecb78
-            checksum/node-agent-config: 2d17bedf65b554dc85e7d34b942015585364c08ec4c29a83c8da9b96afdcd95c
+            checksum/node-agent-config: 16b17a89cd015d4e27574c58b8c53ad6f344443bbd596d88ce098b890fd7507f
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             alt-name: node-agent
@@ -7938,7 +7938,7 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 59c778ddd81146731ba993e61c6f417ef52ca20c3112909997b3b2dc343f07e4
+            checksum/capabilities-config: f0bc225ba593679cb05105e7be07630cae79ae9b741b9ef47d33f591bb3e96e4
             checksum/cloud-config: 9f53ca7bef8ac508eb3f7759668ef3db9ce194c142364e1f84151f1b8e538b1d
             checksum/cloud-secret: baefa7c2a6f06e1afdaffb0829d1caf36ff7428773197f1e5ca4731c132ecb78
             checksum/matching-rules-config: 9282b3916f506ac98eccbdfe686271420ff520374de611f7efce8235dcdf8809

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -93,6 +93,9 @@ configurations:
   otelUrl: # default is empty
   persistence: enable
 
+  # Enable Prometheus annotations, to allow open-source Prometheus (not operator) to scrape metrics
+  prometheusAnnotations: disable
+
 # -----------------------------------------------------------------------------------------
 # ------------------------ Cloud Providers ------------------------------------------------
 # -----------------------------------------------------------------------------------------
@@ -188,10 +191,6 @@ kubescape:
     limits:
       cpu: 600m
       memory: 1Gi
-
-  # Enable prometheus pod annotations,to allow your opensource prometheus (not operator) to scrape metrics
-  prometheusAnnotation:
-    enabled: false
 
   # -- download policies every scan, we recommend it should remain true, you should change to 'false' when running in an air-gapped environment or when scanning with high frequency (when running with Prometheus)
   downloadArtifacts: true
@@ -460,10 +459,11 @@ nodeAgent:
     maxLearningPeriod: 12h # duration string
     learningPeriod: 2m # duration string
     updatePeriod: 10m # duration string
+    prometheusExporter: enable
     httpExporterConfig: 
       url: http://synchronizer.kubescape.svc.cluster.local:8089/apis/v1/kubescape.io/v1/runtimealerts
 
-  # enable prometheus exporter
+  # prometheus (operator) service monitor
   serviceMonitor:
     # -- enable/disable service monitor for prometheus 
     enabled: false


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced a new `prometheusAnnotations` configuration option to enable/disable Prometheus annotations globally, improving flexibility in metrics scraping setup.
- Removed the old `prometheusAnnotation` configuration block and replaced it with a more granular `prometheusExporter` option under `nodeAgent.config`.
- Refactored Prometheus annotations in Kubescape deployment and Node Agent DaemonSet to align with the new configuration approach.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml</strong><dd><code>Refactor Prometheus Annotations in Kubescape Deployment</code>&nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/kubescape/deployment.yaml
<li>Moved Prometheus annotations from a conditional block to a new <br>configuration option <code>prometheusAnnotations</code>.<br> <li> Annotations are now added based on the <code>prometheusAnnotations</code> value in <br><code>values.yaml</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/419/files#diff-b2d573694275628033f9c8251c96711107d99e5c1a189bdc54fc4bbfc8effd68">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>configmap.yaml</strong><dd><code>Update Prometheus Exporter Configuration in Node Agent ConfigMap</code></dd></summary>
<hr>

charts/kubescape-operator/templates/node-agent/configmap.yaml
<li>Changed the condition for enabling Prometheus exporter to check for a <br>new <code>prometheusExporter</code> configuration.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/419/files#diff-b8ccd25dcf7198d49ac143cb1ab55a34bc09894349c91c3d6767ba9ca210094d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>daemonset.yaml</strong><dd><code>Add Prometheus Annotations to Node Agent DaemonSet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/node-agent/daemonset.yaml
<li>Added Prometheus annotations to the DaemonSet based on the new <br><code>prometheusAnnotations</code> configuration.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/419/files#diff-87cf3c6035cbedc17bdc75a7055fa64e7e38d2e83f4b0a79654a4c37c94f4efd">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Introduce New Prometheus Configuration Options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/values.yaml
<li>Introduced <code>prometheusAnnotations</code> configuration to enable/disable <br>Prometheus annotations globally.<br> <li> Removed old <code>prometheusAnnotation</code> block under <code>kubescape</code>.<br> <li> Added <code>prometheusExporter</code> configuration under <code>nodeAgent.config</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/419/files#diff-2d5611f69251d498d71f52fa778f6ce1bc93e1e1f46951ede1c50d975bdcad02">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

