### PR TITLE
add rbac and config for NetworkNeighborhood objects

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/node-agent/clusterrole.yaml
@@ -23,7 +23,7 @@ rules:
   resources: ["sbomsyfts"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
-  resources: ["applicationactivities", "applicationprofiles", "networkneighborses", "sbomsyftfiltereds"]
+  resources: ["applicationactivities", "applicationprofiles", "networkneighborses", "networkneighborhoods", "sbomsyftfiltereds"]
   verbs: ["create", "get", "update", "watch", "list", "patch"]
 - apiGroups: ["kubescape.io"]
   resources: ["runtimerulealertbindings"]

--- a/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
     resources: ["networkpolicies"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
-    resources: ["applicationactivities", "applicationprofiles", "networkneighborses"]
+    resources: ["applicationactivities", "applicationprofiles", "networkneighborses", "networkneighborhoods"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
     resources: ["knownservers"]

--- a/charts/kubescape-operator/templates/synchronizer/configmap.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/configmap.yaml
@@ -105,6 +105,12 @@ data:
             "strategy": "copy"
           },
           {
+            "group": "spdx.softwarecomposition.kubescape.io",
+            "version": "v1beta1",
+            "resource": "networkneighborhoods",
+            "strategy": "copy"
+          },
+          {
             "group": "cilium.io",
             "version": "v2",
             "resource": "ciliumnetworkpolicies",

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1737,6 +1737,7 @@ all capabilities:
           - applicationactivities
           - applicationprofiles
           - networkneighborses
+          - networkneighborhoods
           - sbomsyftfiltereds
         verbs:
           - create
@@ -3040,6 +3041,7 @@ all capabilities:
           - applicationactivities
           - applicationprofiles
           - networkneighborses
+          - networkneighborhoods
         verbs:
           - get
           - watch
@@ -3185,6 +3187,12 @@ all capabilities:
                 "strategy": "copy"
               },
               {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
+                "resource": "networkneighborhoods",
+                "strategy": "copy"
+              },
+              {
                 "group": "cilium.io",
                 "version": "v2",
                 "resource": "ciliumnetworkpolicies",
@@ -3246,7 +3254,7 @@ all capabilities:
             checksum/cloud-config: ca5984899e6bdff85ee9c762fd75f715483b862b4eea5990a107581e5f01e21a
             checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
             checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
-            checksum/synchronizer-configmap: d9520bb7119ab2c9fef396c8484697d4a0d705c3f5e1ebdf8906c85de98e1de0
+            checksum/synchronizer-configmap: 3a7db56d760d9a227368df8619c3f079637c74b613e589aba9fc2f05c92265f3
           labels:
             app: synchronizer
             app.kubernetes.io/instance: RELEASE-NAME
@@ -5044,6 +5052,7 @@ default capabilities:
           - applicationactivities
           - applicationprofiles
           - networkneighborses
+          - networkneighborhoods
           - sbomsyftfiltereds
         verbs:
           - create
@@ -6347,6 +6356,7 @@ default capabilities:
           - applicationactivities
           - applicationprofiles
           - networkneighborses
+          - networkneighborhoods
         verbs:
           - get
           - watch
@@ -6492,6 +6502,12 @@ default capabilities:
                 "strategy": "copy"
               },
               {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
+                "resource": "networkneighborhoods",
+                "strategy": "copy"
+              },
+              {
                 "group": "cilium.io",
                 "version": "v2",
                 "resource": "ciliumnetworkpolicies",
@@ -6553,7 +6569,7 @@ default capabilities:
             checksum/cloud-config: fb124737ed448255a8e5c3fa8777f93da4ae931e5e7b2e98418924a2528a9230
             checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
             checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
-            checksum/synchronizer-configmap: d9520bb7119ab2c9fef396c8484697d4a0d705c3f5e1ebdf8906c85de98e1de0
+            checksum/synchronizer-configmap: 3a7db56d760d9a227368df8619c3f079637c74b613e589aba9fc2f05c92265f3
           labels:
             app: synchronizer
             app.kubernetes.io/instance: RELEASE-NAME
@@ -7582,6 +7598,7 @@ minimal capabilities:
           - applicationactivities
           - applicationprofiles
           - networkneighborses
+          - networkneighborhoods
           - sbomsyftfiltereds
         verbs:
           - create


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added support for `networkneighborhoods` resource in ClusterRoles and ConfigMap.
- Updated ClusterRoles to include `networkneighborhoods` in the resources list for enhanced access control.
- Configured synchronization strategy for `networkneighborhoods` to ensure proper handling.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clusterrole.yaml</strong><dd><code>Add NetworkNeighborhoods Resource to ClusterRole</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/node-agent/clusterrole.yaml
<li>Added <code>networkneighborhoods</code> to the resources list for specific <br>apiGroups.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/425/files#diff-d1c6835d60d9da525a40c8bb19251208521160b7bf07a5f57baeaec508a97f8e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>clusterrole.yaml</strong><dd><code>Extend ClusterRole with NetworkNeighborhoods Resource</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
<li>Included <code>networkneighborhoods</code> in the resources list under certain <br>apiGroups.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/425/files#diff-291bef7ce7bc820ad64b88d073d5cd82450474744bd1a7753bc6c6b343bbbd4d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>configmap.yaml</strong><dd><code>Configure NetworkNeighborhoods Resource Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/synchronizer/configmap.yaml
<li>Introduced a new configuration for <code>networkneighborhoods</code> resource <br>handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/425/files#diff-dbee05c4ed5af6518fa52ee9d2ded91a6c73640791e1a098f2be22a1f9707a27">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

