### PR TITLE
Add permissions for storage classes and RBAC resources***

### DIFF
--- a/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
@@ -7,8 +7,14 @@ metadata:
   labels:
     kubescape.io/ignore: "true"
 rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings", "clusterrolebindings"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["pods", "namespaces", "nodes", "configmaps"]
+    resources: ["pods", "namespaces", "nodes", "configmaps", "persistentvolumes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]

--- a/charts/kubescape-operator/templates/synchronizer/configmap.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/configmap.yaml
@@ -15,6 +15,30 @@ data:
       "inCluster": {
         "resources": [
           {
+            "group": "rbac.authorization.k8s.io",
+            "version": "v1",
+            "resource": "rolebindings",
+            "strategy": "patch"
+          },
+          {
+            "group": "rbac.authorization.k8s.io",
+            "version": "v1",
+            "resource": "clusterrolebindings",
+            "strategy": "patch"
+          },
+          {
+            "group": "",
+            "version": "v1",
+            "resource": "persistentvolumes",
+            "strategy": "patch"
+          },
+          {
+            "group": "storage.k8s.io",
+            "version": "v1",
+            "resource": "storageclasses",
+            "strategy": "patch"
+          },
+          {
             "group": "apps",
             "version": "v1",
             "resource": "deployments",

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -3000,12 +3000,30 @@ all capabilities:
       name: synchronizer
     rules:
       - apiGroups:
+          - storage.k8s.io
+        resources:
+          - storageclasses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - rolebindings
+          - clusterrolebindings
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
           - ""
         resources:
           - pods
           - namespaces
           - nodes
           - configmaps
+          - persistentvolumes
         verbs:
           - get
           - list
@@ -3099,6 +3117,30 @@ all capabilities:
         {
           "inCluster": {
             "resources": [
+              {
+                "group": "rbac.authorization.k8s.io",
+                "version": "v1",
+                "resource": "rolebindings",
+                "strategy": "patch"
+              },
+              {
+                "group": "rbac.authorization.k8s.io",
+                "version": "v1",
+                "resource": "clusterrolebindings",
+                "strategy": "patch"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "resource": "persistentvolumes",
+                "strategy": "patch"
+              },
+              {
+                "group": "storage.k8s.io",
+                "version": "v1",
+                "resource": "storageclasses",
+                "strategy": "patch"
+              },
               {
                 "group": "apps",
                 "version": "v1",
@@ -3257,7 +3299,7 @@ all capabilities:
             checksum/cloud-config: ca5984899e6bdff85ee9c762fd75f715483b862b4eea5990a107581e5f01e21a
             checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
             checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
-            checksum/synchronizer-configmap: 3a7db56d760d9a227368df8619c3f079637c74b613e589aba9fc2f05c92265f3
+            checksum/synchronizer-configmap: 16d0d19f6475bf80c6cc2828090cf3be2d177bc8d366289bb5c72dcdf7de84ad
           labels:
             app: synchronizer
             app.kubernetes.io/instance: RELEASE-NAME
@@ -6318,12 +6360,30 @@ default capabilities:
       name: synchronizer
     rules:
       - apiGroups:
+          - storage.k8s.io
+        resources:
+          - storageclasses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - rolebindings
+          - clusterrolebindings
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
           - ""
         resources:
           - pods
           - namespaces
           - nodes
           - configmaps
+          - persistentvolumes
         verbs:
           - get
           - list
@@ -6417,6 +6477,30 @@ default capabilities:
         {
           "inCluster": {
             "resources": [
+              {
+                "group": "rbac.authorization.k8s.io",
+                "version": "v1",
+                "resource": "rolebindings",
+                "strategy": "patch"
+              },
+              {
+                "group": "rbac.authorization.k8s.io",
+                "version": "v1",
+                "resource": "clusterrolebindings",
+                "strategy": "patch"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "resource": "persistentvolumes",
+                "strategy": "patch"
+              },
+              {
+                "group": "storage.k8s.io",
+                "version": "v1",
+                "resource": "storageclasses",
+                "strategy": "patch"
+              },
               {
                 "group": "apps",
                 "version": "v1",
@@ -6575,7 +6659,7 @@ default capabilities:
             checksum/cloud-config: fb124737ed448255a8e5c3fa8777f93da4ae931e5e7b2e98418924a2528a9230
             checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
             checksum/proxy-config: 1899101b1e9e4f85d94e8f291c44fec0afd3ed60e569f831864d82bddd16d482
-            checksum/synchronizer-configmap: 3a7db56d760d9a227368df8619c3f079637c74b613e589aba9fc2f05c92265f3
+            checksum/synchronizer-configmap: 16d0d19f6475bf80c6cc2828090cf3be2d177bc8d366289bb5c72dcdf7de84ad
           labels:
             app: synchronizer
             app.kubernetes.io/instance: RELEASE-NAME


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement


___

## **Description**
- Added permissions for `storageclasses`, `rolebindings`, and `clusterrolebindings` to the ClusterRole to enhance access control.
- Updated the ConfigMap to include configurations for new resources with patch strategies, improving synchronization capabilities.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clusterrole.yaml</strong><dd><code>Extend ClusterRole Permissions for Storage and RBAC Resources</code></dd></summary>
<hr>

charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
<li>Added permissions for <code>storageclasses</code> in the <code>storage.k8s.io</code> API group.<br> <li> Added permissions for <code>rolebindings</code> and <code>clusterrolebindings</code> in the <br><code>rbac.authorization.k8s.io</code> API group.<br> <li> Extended existing permissions to include <code>persistentvolumes</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/430/files#diff-291bef7ce7bc820ad64b88d073d5cd82450474744bd1a7753bc6c6b343bbbd4d">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>configmap.yaml</strong><dd><code>Update ConfigMap with New Resource Configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/kubescape-operator/templates/synchronizer/configmap.yaml
<li>Added configuration for <code>rolebindings</code> and <code>clusterrolebindings</code> with <br>patch strategy in the <code>rbac.authorization.k8s.io</code> group.<br> <li> Added configuration for <code>persistentvolumes</code> with patch strategy.<br> <li> Added configuration for <code>storageclasses</code> with patch strategy in the <br><code>storage.k8s.io</code> group.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/helm-charts/pull/430/files#diff-dbee05c4ed5af6518fa52ee9d2ded91a6c73640791e1a098f2be22a1f9707a27">+24/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

