### PR TITLE
Changing KDR defaults to include installation of CRD

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/configmap.yaml
@@ -1,6 +1,12 @@
 {{- $components := fromYaml (include "components" .) }}
 {{- $configurations := fromYaml (include "configurations" .) }}
 {{- if $components.nodeAgent.enabled }}
+{{/* validate that either alertCRD.scopeClustered or alertCRD.scopeNamespaced defined when the capability enabled */}}
+{{- if eq .Values.capabilities.runtimeDetection "enable" }}
+{{- if and (not .Values.alertCRD.scopeNamespaced) (not .Values.alertCRD.scopeClustered) }}
+{{- fail "Runtime detection is enabled, but the Runtime rule alert binding CRD is not configured to be created neither in the cluster scope nor namespace scope (set alertCRD.scopeClustered or alertCRD.scopeNamepaced)" }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -105,7 +105,7 @@ configurations:
 # installation of the alertCRD chart
 alertCRD:
   installDefault: false # install the default CRD
-  scopeClustered: false # it is better to have the CRDs in the cluster scope
+  scopeClustered: true # it is better to have the CRDs in the cluster scope
   scopeNamespaced: false # enable scopeNamespaced when there are no permissions for creating cluster scoped CRDs
 
 # -----------------------------------------------------------------------------------------
@@ -501,7 +501,7 @@ nodeAgent:
     limits:
       cpu: 500m
       memory: 700Mi
-  
+
   # GOMEMLIMIT should be lower than the memory limit
   gomemlimit: 600MiB
 


### PR DESCRIPTION
## Overview

1. Making the installation of runtime detection rule CRD the default behavior
2. Adding check that if the runtime detection enabled, at least one of the CRD types has to be installed