### PR TITLE
Add support for custom CA certificates in KS containers

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -45,7 +45,7 @@ You can uninstall this helm chart by running the following command:
 helm uninstall kubescape -n kubescape
 ```
 Then, delete the kubescape namespace:
-```shell  
+```shell
 kubectl delete ns kubescape
 ```
 
@@ -92,6 +92,8 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | global.kubescapePsp.enabled | bool | `false` | Enable all privileges in Pod Security Policies for Kubescape namespace |
 | global.httpsProxy | string | `""` | Set https egress proxy for all components. Must supply also port.  |
 | global.proxySecretFile | string | `""` | Set proxy certificate / RootCA file content (not the file path) for all components to be used for proxy configured in global.httpsProxy |
+| global.overrideDefaultCaCertificates.enabled | bool | `false` | Use to enable custom CA Certificates |
+| global.overrideDefaultCaCertificates.caCertificates | string | `""` | Set the custom CA Certificates file in all container |
 | customScheduling.affinity | yaml |  | Use the `affinity` sub-section to define affinity rules that will apply to all of the workloads managed by the kubescape-operator |
 | customScheduling.nodeSelector | yaml | | Configure `nodeSelector` rules under the nodeSelector sub-section that will apply to all of the workloads managed by the kubescape-operator |
 | customScheduling.tolerations | yaml | | Define `tolerations` in the tolerations sub-section that will apply to all of the workloads managed by the kubescape-operator |
@@ -188,14 +190,14 @@ graph TB
     operator --> k8sApi
     ks --> k8sApi
   end;
-  
+
 subgraph Backend
     er(CloudEndpoint)
-    dashboard(Dashboard) --> masterGw("Master Gateway") 
+    dashboard(Dashboard) --> masterGw("Master Gateway")
     ks --> er
     kubevuln --> er
   end;
-  
+
   classDef k8s fill:#326ce5,stroke:#fff,stroke-width:1px,color:#fff;
   classDef plain fill:#ddd,stroke:#fff,stroke-width:1px,color:#000;
   class k8sApi k8s
@@ -220,7 +222,7 @@ subgraph Backend
 graph TB
   subgraph Backend
    dashboard(Dashboard)
-    masterGw("Gateway (Master)") 
+    masterGw("Gateway (Master)")
   end
    subgraph Cluster N
     gw3("Gateway (In-cluster)")
@@ -230,7 +232,7 @@ graph TB
     gw2("Gateway (In-cluster)")
     operator2(Operator)
   end;
-   
+
 subgraph Cluster 1
     gw1("Gateway (In-cluster)")
     operator1(Operator)
@@ -278,7 +280,7 @@ graph TB
     operator --> k8sApi
     operator --- urlCm
     operator --- recurringTempCm
-  
+
   classDef k8s fill:#326ce5,stroke:#fff,stroke-width:1px,color:#fff;
   classDef plain fill:#ddd,stroke:#fff,stroke-width:1px,color:#000;
   class k8sApi k8s
@@ -297,7 +299,7 @@ graph TB
 graph TB
 
 subgraph Cluster
-    kubevuln(Kubevuln)  
+    kubevuln(Kubevuln)
     k8sApi(Kubernetes API)
     operator(Operator)
     gateway(Gateway)
@@ -309,18 +311,18 @@ subgraph Cluster
 end
 
 masterGateway .- gateway
-gateway .-|Scan Notification| operator 
+gateway .-|Scan Notification| operator
 operator -->|Collect NS, Images|k8sApi
 operator -->|Start Scan| kubevuln
 operator --- urlCm
-urlCm --- kubevuln 
+urlCm --- kubevuln
 recurringTempCm --- operator
 recurringScanCj -->|Scan Notification| operator
 recurringScanCm --- recurringScanCj
 
 subgraph Backend
     er(CloudEndpoint)
-    masterGateway("Master Gateway") 
+    masterGateway("Master Gateway")
     kubevuln -->|Scan Results| er
 end;
 
@@ -356,16 +358,16 @@ subgraph Cluster
 end
 
 masterGateway .- gateway
-gateway .-|Scan Notification| operator 
+gateway .-|Scan Notification| operator
 operator -->|Start Scan| ks
 ks-->|Collect Cluster Info|k8sApi
-ksCm --- ks 
+ksCm --- ks
 recurringTempCm --- operator
 recurringScanCj -->|Scan Notification| operator
 recurringScanCm --- recurringScanCj
 subgraph Backend
     er(CloudEndpoint)
-    masterGateway("Master Gateway") 
+    masterGateway("Master Gateway")
     ks -->|Scan Results| er
 end;
 
@@ -389,11 +391,11 @@ class ksCm,recurringScanCm,operator,er,gateway,masterGateway,recurringScanCj,rec
 graph TD
 subgraph Backend
     er(CloudEndpoint)
-    masterGw("Master Gateway") 
+    masterGw("Master Gateway")
 end;
 
 subgraph Cluster
-    kollector(Kollector) 
+    kollector(Kollector)
     k8sApi(Kubernetes API);
     gw(Gateway)
 end;
@@ -522,13 +524,13 @@ sequenceDiagram
     participant clusterGw as Cluster<br><br>In-Cluster Gateway
     participant operator as Cluster<br><br>Operator
     participant k8sApi as Cluster<br><br>Kubernetes API
-    
+
     user->>dashboard: 1. create scan schedule
     dashboard->>masterGw: 2. build schedule notification
     masterGw->>clusterGw: 3. broadcast notification
     clusterGw->>operator: 4. create recurring scan
     operator->>k8sApi: 5. get namespaces, workloads
-    k8sApi-->>operator: 
+    k8sApi-->>operator:
     operator->>k8sApi: 6. Create cronjob & ConfigMap
 ```
 </details>
@@ -546,7 +548,7 @@ sequenceDiagram
       cronJob->>operator: 1. run image scan
    end
    operator->>k8sApi: 2. list NS, container images
-   k8sApi-->>operator: 
+   k8sApi-->>operator:
    operator->>kubeVuln: 3. scan images
    kubeVuln ->> er: 4. send scan results
 ```
@@ -565,9 +567,9 @@ sequenceDiagram
   loop
       cronJob->>operator: 1. run configuration scan
   end
-  operator->>ks: 2. kubescape scan 
-  ks->>k8sApi: 3. list NS, workloads, RBAC 
-  k8sApi->>ks: 
+  operator->>ks: 2. kubescape scan
+  ks->>k8sApi: 3. list NS, workloads, RBAC
+  k8sApi->>ks:
   ks ->> er: 4. send scan results
 ```
 

--- a/charts/kubescape-operator/templates/_helpers.tpl
+++ b/charts/kubescape-operator/templates/_helpers.tpl
@@ -76,5 +76,7 @@ synchronizer:
   enabled: {{ or (and $configurations.submit (eq .Values.capabilities.networkPolicyService "enable")) (and $configurations.submit (eq .Values.capabilities.runtimeObservability "enable")) }}
 clamAV:
   enabled: {{ eq .Values.capabilities.malwareDetection "enable" }}
+customCaCertificates:
+  name: custom-ca-certificates
 
 {{- end -}}

--- a/charts/kubescape-operator/templates/configs/custom-ca-certificates.yaml
+++ b/charts/kubescape-operator/templates/configs/custom-ca-certificates.yaml
@@ -1,0 +1,16 @@
+{{- $components := fromYaml (include "components" .) }}
+{{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ $components.customCaCertificates.name }}
+  namespace: {{ .Values.ksNamespace }}
+  labels:
+    app: {{ $components.customCaCertificates.name }}
+    tier: {{ .Values.global.namespaceTier }}
+    kubescape.io/infra: credentials
+    kubescape.io/ignore: "true"
+type: Opaque
+data:
+  ca-certificates.crt: "{{ .Values.global.overrideDefaultCaCertificates.caCertificates | default "" | b64enc }}"
+{{- end }}

--- a/charts/kubescape-operator/templates/gateway/deployment.yaml
+++ b/charts/kubescape-operator/templates/gateway/deployment.yaml
@@ -134,6 +134,11 @@ spec:
             mountPath: /etc/ssl/certs/proxy.crt
             subPath: proxy.crt
           {{- end }}
+          {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+          - name: custom-ca-certificates
+            mountPath: /etc/ssl/certs/ca-certificates.crt
+            subPath: ca-certificates.crt
+          {{- end }}
       volumes:
         - name: {{ $components.cloudSecret.name }}
           secret:
@@ -142,6 +147,11 @@ spec:
         - name: proxy-secret
           secret:
             secretName: {{ .Values.global.proxySecretName }}
+      {{- end }}
+      {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+        - name: custom-ca-certificates
+          secret:
+            secretName: {{ $components.customCaCertificates.name }}
       {{- end }}
         - name: {{ .Values.global.cloudConfig }}
           configMap:

--- a/charts/kubescape-operator/templates/kollector/statefulset.yaml
+++ b/charts/kubescape-operator/templates/kollector/statefulset.yaml
@@ -125,6 +125,11 @@ spec:
               mountPath: /etc/ssl/certs/proxy.crt
               subPath: proxy.crt
 {{- end }}
+{{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+            - name: custom-ca-certificates
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              subPath: ca-certificates.crt
+{{- end }}
       volumes:
         - name: {{ $components.cloudSecret.name }}
           secret:
@@ -133,6 +138,11 @@ spec:
         - name: proxy-secret
           secret:
             secretName: {{ .Values.global.proxySecretName }}
+      {{- end }}
+      {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+        - name: custom-ca-certificates
+          secret:
+            secretName: {{ $components.customCaCertificates.name }}
       {{- end }}
         - name: tmp-dir
           emptyDir: {}

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -193,6 +193,11 @@ spec:
           mountPath: /etc/ssl/certs/proxy.crt
           subPath: proxy.crt
 {{- end }}
+{{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+        - name: custom-ca-certificates
+          mountPath: /etc/ssl/certs/ca-certificates.crt
+          subPath: ca-certificates.crt
+{{- end }}
       volumes:
       - name: {{ $components.cloudSecret.name }}
         secret:
@@ -201,6 +206,11 @@ spec:
       - name: proxy-secret
         secret:
           secretName: {{ .Values.global.proxySecretName }}
+      {{- end }}
+      {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+      - name: custom-ca-certificates
+        secret:
+          secretName: {{ $components.customCaCertificates.name }}
       {{- end }}
       - name: {{ .Values.global.cloudConfig }}
         configMap:

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -129,6 +129,11 @@ spec:
               mountPath: /etc/ssl/certs/proxy.crt
               subPath: proxy.crt
 {{- end }}
+{{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+            - name: custom-ca-certificates
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              subPath: ca-certificates.crt
+{{- end }}
       volumes:
         - name: {{ $components.cloudSecret.name }}
           secret:
@@ -137,6 +142,11 @@ spec:
         - name: proxy-secret
           secret:
             secretName: {{ .Values.global.proxySecretName }}
+      {{- end }}
+      {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+        - name: custom-ca-certificates
+          secret:
+            secretName: {{ $components.customCaCertificates.name }}
       {{- end }}
         - name: tmp-dir
           emptyDir: {}

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -89,6 +89,11 @@ spec:
           secret:
             secretName: {{ .Values.global.proxySecretName }}
         {{- end }}
+        {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+        - name: custom-ca-certificates
+          secret:
+            secretName: {{ $components.customCaCertificates.name }}
+        {{- end }}
       containers:
         {{- if $components.clamAV.enabled }}
         - name: {{ .Values.clamav.name }}
@@ -192,6 +197,11 @@ spec:
           - name: proxy-secret
             mountPath: /etc/ssl/certs/proxy.crt
             subPath: proxy.crt
+          {{- end }}
+          {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+          - name: custom-ca-certificates
+            mountPath: /etc/ssl/certs/ca-certificates.crt
+            subPath: ca-certificates.crt
           {{- end }}
       nodeSelector:
       {{- if .Values.nodeAgent.nodeSelector }}

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -140,6 +140,11 @@ spec:
               mountPath: /etc/config/config.json
               readOnly: true
               subPath: "config.json"
+            {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+            - name: custom-ca-certificates
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              subPath: ca-certificates.crt
+            {{- end }}
 {{- if .Values.volumeMounts }}
 {{ toYaml .Values.volumeMounts | indent 12 }}
 {{- end }}
@@ -159,6 +164,11 @@ spec:
         - name: proxy-secret
           secret:
             secretName: {{ .Values.global.proxySecretName }}
+        {{- end }}
+        {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+        - name: custom-ca-certificates
+          secret:
+            secretName: {{ $components.customCaCertificates.name }}
         {{- end }}
         - name: tmp-dir
           emptyDir: {}

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -110,6 +110,11 @@ spec:
               readOnly: true
               subPath: "services.json"
             {{- end }}
+            {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+            - name: custom-ca-certificates
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              subPath: ca-certificates.crt
+            {{- end }}
             - name: config
               mountPath: /etc/config/config.json
               readOnly: true
@@ -133,6 +138,11 @@ spec:
         - name: proxy-secret
           secret:
             secretName: {{ .Values.global.proxySecretName }}
+      {{- end }}
+      {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+        - name: custom-ca-certificates
+          secret:
+            secretName: {{ $components.customCaCertificates.name }}
       {{- end }}
         - name: {{ .Values.global.cloudConfig }}
           configMap:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -179,6 +179,20 @@ all capabilities:
   9: |
     apiVersion: v1
     data:
+      ca-certificates.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSTd6WnozWjYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    kind: Secret
+    metadata:
+      labels:
+        app: custom-ca-certificates
+        kubescape.io/ignore: "true"
+        kubescape.io/infra: credentials
+        tier: ks-control-plane
+      name: custom-ca-certificates
+      namespace: kubescape
+    type: Opaque
+  10: |
+    apiVersion: v1
+    data:
       matchingRules.json: |
         {"match":[{"apiGroups":["apps"],"apiVersions":["v1"],"resources":["deployments"]}],"namespaces":["default"]}
     kind: ConfigMap
@@ -190,7 +204,7 @@ all capabilities:
         tier: ks-control-plane
       name: cs-matching-rules
       namespace: kubescape
-  10: |
+  11: |
     apiVersion: scheduling.k8s.io/v1
     description: This priority class is for node-agent daemonset pods
     globalDefault: false
@@ -198,7 +212,7 @@ all capabilities:
     metadata:
       name: kubescape-critical
     value: 1.000001e+08
-  11: |
+  12: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -309,6 +323,9 @@ all capabilities:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+                - mountPath: /etc/ssl/certs/ca-certificates.crt
+                  name: custom-ca-certificates
+                  subPath: ca-certificates.crt
           nodeSelector: null
           securityContext:
             fsGroup: 65532
@@ -321,6 +338,9 @@ all capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
+            - name: custom-ca-certificates
+              secret:
+                secretName: custom-ca-certificates
             - configMap:
                 items:
                   - key: clusterData
@@ -329,7 +349,7 @@ all capabilities:
                     path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  12: |
+  13: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -362,7 +382,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  13: |
+  14: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -384,7 +404,7 @@ all capabilities:
       selector:
         app: gateway
       type: ClusterIP
-  14: |
+  15: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -440,7 +460,7 @@ all capabilities:
                 runAsNonRoot: true
           nodeSelector: null
           tolerations: null
-  15: |
+  16: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -467,7 +487,7 @@ all capabilities:
           tier: ks-control-plane
       policyTypes:
         - Ingress
-  16: |
+  17: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -484,7 +504,7 @@ all capabilities:
       selector:
         app: grype-offline-db
       type: ClusterIP
-  17: |
+  18: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -525,7 +545,7 @@ all capabilities:
           - get
           - watch
           - list
-  18: |
+  19: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -540,7 +560,7 @@ all capabilities:
       - kind: ServiceAccount
         name: kollector
         namespace: kubescape
-  19: |
+  20: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -567,7 +587,7 @@ all capabilities:
           tier: ks-control-plane
       policyTypes:
         - Egress
-  20: |
+  21: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -577,7 +597,7 @@ all capabilities:
         kubescape.io/ignore: "true"
       name: kollector
       namespace: kubescape
-  21: |
+  22: |
     apiVersion: apps/v1
     kind: StatefulSet
     metadata:
@@ -680,6 +700,9 @@ all capabilities:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+                - mountPath: /etc/ssl/certs/ca-certificates.crt
+                  name: custom-ca-certificates
+                  subPath: ca-certificates.crt
           nodeSelector: null
           serviceAccountName: kollector
           tolerations: null
@@ -690,6 +713,9 @@ all capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
+            - name: custom-ca-certificates
+              secret:
+                secretName: custom-ca-certificates
             - emptyDir: {}
               name: tmp-dir
             - configMap:
@@ -700,7 +726,7 @@ all capabilities:
                     path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  22: |
+  23: |
     apiVersion: v1
     data:
       request-body.json: '{"commands":[{"CommandName":"kubescapeScan","args":{"scanV1": {}}}]}'
@@ -713,7 +739,7 @@ all capabilities:
         tier: ks-control-plane
       name: kubescape-scheduler
       namespace: kubescape
-  23: |
+  24: |
     apiVersion: batch/v1
     kind: CronJob
     metadata:
@@ -777,7 +803,7 @@ all capabilities:
                   name: kubescape-scheduler
       schedule: 1 2 3 4 5
       successfulJobsHistoryLimit: 3
-  24: |
+  25: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -970,7 +996,7 @@ all capabilities:
           - create
           - update
           - patch
-  25: |
+  26: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -985,7 +1011,7 @@ all capabilities:
       - kind: ServiceAccount
         name: kubescape
         namespace: kubescape
-  26: |
+  27: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -1119,6 +1145,9 @@ all capabilities:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+                - mountPath: /etc/ssl/certs/ca-certificates.crt
+                  name: custom-ca-certificates
+                  subPath: ca-certificates.crt
           nodeSelector: null
           securityContext:
             fsGroup: 65532
@@ -1132,6 +1161,9 @@ all capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
+            - name: custom-ca-certificates
+              secret:
+                secretName: custom-ca-certificates
             - configMap:
                 items:
                   - key: clusterData
@@ -1149,7 +1181,7 @@ all capabilities:
               name: results
             - emptyDir: {}
               name: failed
-  27: |
+  28: |
     apiVersion: v1
     data:
       host-scanner-yaml: |-
@@ -1249,7 +1281,7 @@ all capabilities:
         tier: ks-control-plane
       name: host-scanner-definition
       namespace: kubescape
-  28: |
+  29: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -1282,7 +1314,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  29: |
+  30: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -1303,7 +1335,7 @@ all capabilities:
           - list
           - patch
           - delete
-  30: |
+  31: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -1319,7 +1351,7 @@ all capabilities:
       - kind: ServiceAccount
         name: kubescape
         namespace: kubescape
-  31: |
+  32: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -1337,7 +1369,7 @@ all capabilities:
       selector:
         app: kubescape
       type: ClusterIP
-  32: |
+  33: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -1347,7 +1379,7 @@ all capabilities:
         kubescape.io/ignore: "true"
       name: kubescape
       namespace: kubescape
-  33: |
+  34: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -1368,7 +1400,7 @@ all capabilities:
       selector:
         matchLabels:
           app: kubescape
-  34: |
+  35: |
     apiVersion: v1
     data:
       request-body.json: '{"commands":[{"commandName":"scan","designators":[{"designatorType":"Attributes","attributes":{}}]}]}'
@@ -1381,7 +1413,7 @@ all capabilities:
         tier: ks-control-plane
       name: kubevuln-scheduler
       namespace: kubescape
-  35: |
+  36: |
     apiVersion: batch/v1
     kind: CronJob
     metadata:
@@ -1445,7 +1477,7 @@ all capabilities:
                   name: kubevuln-scheduler
       schedule: 1 2 3 4 5
       successfulJobsHistoryLimit: 3
-  36: |
+  37: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -1475,7 +1507,7 @@ all capabilities:
           - get
           - watch
           - list
-  37: |
+  38: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -1490,7 +1522,7 @@ all capabilities:
       - kind: ServiceAccount
         name: kubevuln
         namespace: kubescape
-  38: |
+  39: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -1598,6 +1630,9 @@ all capabilities:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+                - mountPath: /etc/ssl/certs/ca-certificates.crt
+                  name: custom-ca-certificates
+                  subPath: ca-certificates.crt
           nodeSelector: null
           securityContext:
             fsGroup: 65532
@@ -1611,6 +1646,9 @@ all capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
+            - name: custom-ca-certificates
+              secret:
+                secretName: custom-ca-certificates
             - emptyDir: {}
               name: tmp-dir
             - emptyDir: {}
@@ -1625,7 +1663,7 @@ all capabilities:
               name: ks-cloud-config
             - emptyDir: {}
               name: grype-db
-  39: |
+  40: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -1657,7 +1695,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  40: |
+  41: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -1674,7 +1712,7 @@ all capabilities:
       selector:
         app: kubevuln
       type: ClusterIP
-  41: |
+  42: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -1684,7 +1722,7 @@ all capabilities:
         kubescape.io/ignore: "true"
       name: kubevuln
       namespace: kubescape
-  42: |
+  43: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -1762,7 +1800,7 @@ all capabilities:
         verbs:
           - list
           - watch
-  43: |
+  44: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -1777,7 +1815,7 @@ all capabilities:
       - kind: ServiceAccount
         name: node-agent
         namespace: kubescape
-  44: |
+  45: |
     apiVersion: v1
     data:
       config.json: |
@@ -1807,7 +1845,7 @@ all capabilities:
         kubescape.io/tier: core
       name: node-agent
       namespace: kubescape
-  45: |
+  46: |
     apiVersion: v1
     data:
       clamd.conf: |-
@@ -1843,7 +1881,7 @@ all capabilities:
     metadata:
       name: clamav
       namespace: kubescape
-  46: |
+  47: |
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
@@ -1998,6 +2036,9 @@ all capabilities:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+                - mountPath: /etc/ssl/certs/ca-certificates.crt
+                  name: custom-ca-certificates
+                  subPath: ca-certificates.crt
           hostPID: true
           nodeSelector:
             kubernetes.io/os: linux
@@ -2057,7 +2098,10 @@ all capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
-  47: |
+            - name: custom-ca-certificates
+              secret:
+                secretName: custom-ca-certificates
+  48: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -2075,7 +2119,7 @@ all capabilities:
           targetPort: 8080
       selector:
         app.kubernetes.io/name: node-agent
-  48: |
+  49: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -2083,7 +2127,7 @@ all capabilities:
         kubescape.io/ignore: "true"
       name: node-agent
       namespace: kubescape
-  49: |
+  50: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -2139,7 +2183,7 @@ all capabilities:
           - watch
           - list
           - delete
-  50: |
+  51: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2154,7 +2198,7 @@ all capabilities:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  51: |
+  52: |
     apiVersion: v1
     data:
       config.json: |
@@ -2169,7 +2213,7 @@ all capabilities:
         kubescape.io/tier: core
       name: operator
       namespace: kubescape
-  52: |
+  53: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -2290,6 +2334,9 @@ all capabilities:
                   name: config
                   readOnly: true
                   subPath: config.json
+                - mountPath: /etc/ssl/certs/ca-certificates.crt
+                  name: custom-ca-certificates
+                  subPath: ca-certificates.crt
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
@@ -2306,6 +2353,9 @@ all capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
+            - name: custom-ca-certificates
+              secret:
+                secretName: custom-ca-certificates
             - emptyDir: {}
               name: tmp-dir
             - configMap:
@@ -2334,7 +2384,7 @@ all capabilities:
                     path: matchingRules.json
                 name: cs-matching-rules
               name: cs-matching-rules
-  53: |
+  54: |
     apiVersion: v1
     data:
       cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubescape-scheduler\n  namespace: kubescape\n  labels:\n    app: kubescape-scheduler\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    armo.tier: \"kubescape-scan\"\nspec:\n  schedule: \"1 2 3 4 5\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"kubescape-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubescape-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.6\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=Content-Type:application/json\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubescape-scheduler"
@@ -2347,7 +2397,7 @@ all capabilities:
         tier: ks-control-plane
       name: kubescape-cronjob-template
       namespace: kubescape
-  54: |
+  55: |
     apiVersion: v1
     data:
       cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: kubevuln-scheduler\n  namespace: kubescape\n  labels:\n    app: kubevuln-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"vuln-scan\"\nspec:\n  schedule: \"1 2 3 4 5\" \n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"vuln-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: kubevuln-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.6\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=Content-Type:application/json\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: kubevuln-scheduler"
@@ -2360,7 +2410,7 @@ all capabilities:
         tier: ks-control-plane
       name: kubevuln-cronjob-template
       namespace: kubescape
-  55: |
+  56: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -2399,7 +2449,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  56: |
+  57: |
     apiVersion: v1
     data:
       cronjobTemplate: "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: registry-scheduler\n  namespace: kubescape\n  labels:\n    app: registry-scheduler\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    tier: ks-control-plane\n    armo.tier: \"registry-scan\"\nspec:\n  schedule: \"0 0 * * *\"\n  successfulJobsHistoryLimit: 3\n  failedJobsHistoryLimit: 1\n  jobTemplate:\n    spec:\n      template:\n        metadata:\n          labels:\n            armo.tier: \"registry-scan\"\n            kubescape.io/tier: \"core\"\n        spec:\n          containers:\n          - name: registry-scheduler\n            image: \"quay.io/kubescape/http-request:v0.2.6\"\n            imagePullPolicy: IfNotPresent\n            securityContext:\n              allowPrivilegeEscalation: false\n              readOnlyRootFilesystem: true\n              runAsNonRoot: true\n              runAsUser: 100\n            resources:\n              limits:\n                cpu: 10m\n                memory: 20Mi\n              requests:\n                cpu: 1m\n                memory: 10Mi\n            args: \n              - -method=post\n              - -scheme=http\n              - -host=operator:4002\n              - -path=v1/triggerAction\n              - -headers=Content-Type:application/json\n              - -path-body=/home/ks/request-body.json\n            volumeMounts:\n              - name: \"request-body-volume\"\n                mountPath: /home/ks/request-body.json\n                subPath: request-body.json\n                readOnly: true\n          restartPolicy: Never\n          automountServiceAccountToken: false\n          nodeSelector:\n          affinity:\n          tolerations:\n          volumes:\n            - name: \"request-body-volume\" # placeholder\n              configMap:\n                name: registry-scheduler"
@@ -2412,7 +2462,7 @@ all capabilities:
         tier: ks-control-plane
       name: registry-scan-cronjob-template
       namespace: kubescape
-  57: |
+  58: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -2446,7 +2496,7 @@ all capabilities:
           - list
           - patch
           - delete
-  58: |
+  59: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -2462,7 +2512,7 @@ all capabilities:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  59: |
+  60: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -2479,7 +2529,7 @@ all capabilities:
       selector:
         app: operator
       type: ClusterIP
-  60: |
+  61: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -2489,7 +2539,7 @@ all capabilities:
         kubescape.io/ignore: "true"
       name: operator
       namespace: kubescape
-  61: |
+  62: |
     apiVersion: v1
     data:
       otel-collector-config.yaml: "\n# receivers configure how data gets into the Collector.\nreceivers:\n  otlp:\n    protocols:\n      grpc:\n        endpoint: 0.0.0.0:4317\n      http:\n        endpoint: 0.0.0.0:4318\n  hostmetrics:\n    collection_interval: 30s\n    scrapers:\n      cpu:\n      memory:\n\n# processors specify what happens with the received data.\nprocessors:\n  attributes/ksCloud:\n    actions:\n      - key: account_id\n        value: \"9e6c0c2c-6bd0-4919-815b-55030de7c9a0\"\n        action: upsert\n      - key: cluster_name\n        value: \"kind-kind\"\n        action: upsert\n  batch:\n    send_batch_size: 10000\n    timeout: 10s\n\n# exporters configure how to send processed data to one or more backends.\nexporters:\n  otlp/ksCloud:\n    endpoint: ${env:CLOUD_OTEL_COLLECTOR_URL}\n    tls:\n      insecure: false\n  otlp:\n    endpoint: \"otelCollector:4317\"\n    tls:\n      insecure: true\n    headers:\n      uptrace-dsn: \n\n# service pulls the configured receivers, processors, and exporters together into\n# processing pipelines. Unused receivers/processors/exporters are ignored.\nservice:\n  pipelines:\n    traces:\n      receivers: [otlp]\n      processors: [batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp\n    metrics/2:\n      receivers: [hostmetrics]\n      processors: [attributes/ksCloud, batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp\n    metrics:\n      receivers: [otlp]\n      processors: [attributes/ksCloud, batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp\n    logs:\n      receivers: [otlp]\n      processors: [attributes/ksCloud, batch]\n      exporters:\n        - otlp/ksCloud\n        - otlp"
@@ -2502,7 +2552,7 @@ all capabilities:
         tier: ks-control-plane
       name: otel-collector-config
       namespace: kubescape
-  62: |
+  63: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -2599,7 +2649,7 @@ all capabilities:
             - configMap:
                 name: otel-collector-config
               name: otel-collector-config-volume
-  63: |
+  64: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -2632,7 +2682,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  64: |
+  65: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -2654,7 +2704,7 @@ all capabilities:
       selector:
         app: otel-collector
       type: ClusterIP
-  65: |
+  66: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -2671,7 +2721,7 @@ all capabilities:
           - get
           - watch
           - list
-  66: |
+  67: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2686,7 +2736,7 @@ all capabilities:
       - kind: ServiceAccount
         name: prometheus-exporter
         namespace: kubescape
-  67: |
+  68: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -2769,7 +2819,7 @@ all capabilities:
                     path: clusterData.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  68: |
+  69: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -2790,7 +2840,7 @@ all capabilities:
           tier: ks-control-plane
       policyTypes:
         - Ingress
-  69: |
+  70: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -2807,7 +2857,7 @@ all capabilities:
       selector:
         app: prometheus-exporter
       type: null
-  70: |
+  71: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -2817,7 +2867,7 @@ all capabilities:
         kubescape.io/ignore: "true"
       name: prometheus-exporter
       namespace: kubescape
-  71: |
+  72: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -2832,7 +2882,7 @@ all capabilities:
       selector:
         matchLabels:
           app: prometheus-exporter
-  72: |
+  73: |
     apiVersion: v1
     data:
       proxy.crt: foo
@@ -2847,7 +2897,7 @@ all capabilities:
       name: kubescape-proxy-certificate
       namespace: kubescape
     type: Opaque
-  73: |
+  74: |
     apiVersion: batch/v1
     kind: Job
     metadata:
@@ -2932,7 +2982,7 @@ all capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
-  74: |
+  75: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -2955,7 +3005,7 @@ all capabilities:
           - patch
           - get
           - list
-  75: |
+  76: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -2974,7 +3024,7 @@ all capabilities:
       - kind: ServiceAccount
         name: service-discovery
         namespace: kubescape
-  76: |
+  77: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -2986,7 +3036,7 @@ all capabilities:
         kubescape.io/ignore: "true"
       name: service-discovery
       namespace: kubescape
-  77: |
+  78: |
     apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
@@ -3002,7 +3052,7 @@ all capabilities:
         namespace: kubescape
       version: v1beta1
       versionPriority: 15
-  78: |
+  79: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -3100,7 +3150,7 @@ all capabilities:
           - get
           - watch
           - list
-  79: |
+  80: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -3115,7 +3165,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  80: |
+  81: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -3128,7 +3178,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  81: |
+  82: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -3214,7 +3264,7 @@ all capabilities:
                     path: services.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  82: |
+  83: |
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
@@ -3231,7 +3281,7 @@ all capabilities:
       resources:
         requests:
           storage: 5Gi
-  83: |
+  84: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -3247,7 +3297,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  84: |
+  85: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -3264,7 +3314,7 @@ all capabilities:
         app.kubernetes.io/component: apiserver
         app.kubernetes.io/name: storage
         app.kubernetes.io/part-of: kubescape-storage
-  85: |
+  86: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -3272,7 +3322,7 @@ all capabilities:
         kubescape.io/ignore: "true"
       name: storage
       namespace: kubescape
-  86: |
+  87: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -3388,7 +3438,7 @@ all capabilities:
           - get
           - list
           - watch
-  87: |
+  88: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -3403,7 +3453,7 @@ all capabilities:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  88: |
+  89: |
     apiVersion: v1
     data:
       config.json: |
@@ -3599,7 +3649,7 @@ all capabilities:
         kubescape.io/tier: core
       name: synchronizer
       namespace: kubescape
-  89: |
+  90: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -3691,6 +3741,9 @@ all capabilities:
                   name: ks-cloud-config
                   readOnly: true
                   subPath: services.json
+                - mountPath: /etc/ssl/certs/ca-certificates.crt
+                  name: custom-ca-certificates
+                  subPath: ca-certificates.crt
                 - mountPath: /etc/config/config.json
                   name: config
                   readOnly: true
@@ -3711,6 +3764,9 @@ all capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
+            - name: custom-ca-certificates
+              secret:
+                secretName: custom-ca-certificates
             - configMap:
                 items:
                   - key: clusterData
@@ -3725,7 +3781,7 @@ all capabilities:
                     path: config.json
                 name: synchronizer
               name: config
-  90: |
+  91: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -3756,7 +3812,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  91: |
+  92: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -3773,7 +3829,7 @@ all capabilities:
       selector:
         app: synchronizer
       type: ClusterIP
-  92: |
+  93: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -179,7 +179,7 @@ all capabilities:
   9: |
     apiVersion: v1
     data:
-      ca-certificates.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t
+      ca-certificates.crt: Zm9v
     kind: Secret
     metadata:
       labels:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -179,7 +179,7 @@ all capabilities:
   9: |
     apiVersion: v1
     data:
-      ca-certificates.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSTd6WnozWjYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
+      ca-certificates.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t
     kind: Secret
     metadata:
       labels:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -179,7 +179,7 @@ all capabilities:
   9: |
     apiVersion: v1
     data:
-      ca-certificates.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSTd6WnozWjYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      ca-certificates.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSTd6WnozWjYKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
     kind: Secret
     metadata:
       labels:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -164,7 +164,7 @@ all capabilities:
       capabilities: |
         {
           "capabilities":{"autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","malwareDetection":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeScan":"enable","prometheusExporter":"enable","relevancy":"enable","runtimeDetection":"enable","runtimeObservability":"enable","vexGeneration":"enable","vulnerabilityScan":"enable"},
-          "components":{"clamAV":{"enabled":true},"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":true},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
+          "components":{"clamAV":{"enabled":true},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":true},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"}
         }
     kind: ConfigMap
@@ -2198,7 +2198,7 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 9b2440aea07cc3d6976647cfaa3ae331467388cb70fde2ffa6227556ef29e007
+            checksum/capabilities-config: f3b50323bb773b2ec8697e87c955f27462c8273d3b5b74320a28bdb0306dc640
             checksum/cloud-config: c4dc912bbe62b0d5fd4734206c3cae52f56d766cbc20024182a2bcef09c0ae8e
             checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
             checksum/matching-rules-config: 9282b3916f506ac98eccbdfe686271420ff520374de611f7efce8235dcdf8809
@@ -3853,7 +3853,7 @@ default capabilities:
       capabilities: |
         {
           "capabilities":{"autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","malwareDetection":"disable","networkPolicyService":"enable","nodeProfileService":"disable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","vexGeneration":"disable","vulnerabilityScan":"enable"},
-          "components":{"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
+          "components":{"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"gateway":{"enabled":true},"hostScanner":{"enabled":true},"kollector":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"}
         }
     kind: ConfigMap
@@ -5824,7 +5824,7 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 5feb506d071526d4b7f4e0c6627cce9942eca2a3ef96a2b9b27b648b26792f2b
+            checksum/capabilities-config: ca76fce1c8ed0afd8812c20116e9658826cd3b9f09fd623c0e93cadcbd86dccb
             checksum/cloud-config: 98e72a3a1a24264d2cdebc86b61829ee5b941fb590d6ca717ebaa880922046c6
             checksum/cloud-secret: 8665d3f0f7282091716b5fbf7356972eb83a5a9e86eb064218d24e9f66612b99
             checksum/matching-rules-config: 9282b3916f506ac98eccbdfe686271420ff520374de611f7efce8235dcdf8809
@@ -7292,7 +7292,7 @@ minimal capabilities:
       capabilities: |
         {
           "capabilities":{"autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","malwareDetection":"disable","networkPolicyService":"enable","nodeProfileService":"disable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","vexGeneration":"disable","vulnerabilityScan":"enable"},
-          "components":{"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"gateway":{"enabled":false},"hostScanner":{"enabled":true},"kollector":{"enabled":false},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":false},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":false},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
+          "components":{"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"gateway":{"enabled":false},"hostScanner":{"enabled":true},"kollector":{"enabled":false},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":false},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":false},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
           "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"}
         }
     kind: ConfigMap
@@ -8494,7 +8494,7 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: a38f26706ee8de7094da30bbf12709e5ab6a8c267b0937cbeb629d61218f8cbd
+            checksum/capabilities-config: 8d8fdeab03d6a23cc4a3d132afe56c821554995659b948b30f8a1d736094fbbc
             checksum/cloud-config: c8580dbb81fa1c832dc787a966fc068feacfb2ee7f67fdd928c256f4094ad656
             checksum/cloud-secret: baefa7c2a6f06e1afdaffb0829d1caf36ff7428773197f1e5ca4731c132ecb78
             checksum/matching-rules-config: 9282b3916f506ac98eccbdfe686271420ff520374de611f7efce8235dcdf8809

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -33,7 +33,7 @@ tests:
         proxySecretFile: foo
         overrideDefaultCaCertificates:
           enabled: true
-          caCertificates: "-----BEGIN CERTIFICATE-----"
+          caCertificates: "foo"
       grypeOfflineDB.enabled: true
       kubescape.serviceMonitor.enabled: true
       kubescapeScheduler.scanSchedule: "1 2 3 4 5"

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -33,10 +33,7 @@ tests:
         proxySecretFile: foo
         overrideDefaultCaCertificates:
           enabled: true
-          caCertificates: |-
-            -----BEGIN CERTIFICATE-----
-            MIIDpDCCAoygAwIBAgIUI7zZz3Z6
-            -----END CERTIFICATE-----
+          caCertificates: "-----BEGIN CERTIFICATE-----"
       grypeOfflineDB.enabled: true
       kubescape.serviceMonitor.enabled: true
       kubescapeScheduler.scanSchedule: "1 2 3 4 5"

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -31,6 +31,12 @@ tests:
           createEgressRules: true
           enabled: true
         proxySecretFile: foo
+        overrideDefaultCaCertificates:
+          enabled: true
+          caCertificates: |
+            -----BEGIN CERTIFICATE-----
+            MIIDpDCCAoygAwIBAgIUI7zZz3Z6
+            -----END CERTIFICATE-----
       grypeOfflineDB.enabled: true
       kubescape.serviceMonitor.enabled: true
       kubescapeScheduler.scanSchedule: "1 2 3 4 5"

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -33,7 +33,7 @@ tests:
         proxySecretFile: foo
         overrideDefaultCaCertificates:
           enabled: true
-          caCertificates: |
+          caCertificates: |-
             -----BEGIN CERTIFICATE-----
             MIIDpDCCAoygAwIBAgIUI7zZz3Z6
             -----END CERTIFICATE-----

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -164,6 +164,9 @@ global:
     enabled: false
     createEgressRules: false
   overrideRuntimePath: ""
+  overrideDefaultCaCertificates:
+    enabled: false
+    caCertificates: ""
 
 # Image scanning configurations
 imageScanning:


### PR DESCRIPTION
## Overview

Add support for custom CA certificates in Kubescape-operator deployment.

```
global.overrideDefaultCaCertificates.enabled | bool | `false` | Use to enable custom CA Certificates
global.overrideDefaultCaCertificates.caCertificates | string | `""` | Set the custom CA Certificates file in all container
```
