### PR TITLE
Adding the option to override the Grype DB URL

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -130,6 +130,7 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | kubevuln.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) |
 | kubevuln.volumes | object | `[]` | Additional volumes for the image vulnerability scanning |
 | kubevuln.volumeMounts | object | `[]` | Additional volumeMounts for the image vulnerability scanning |
+| kubevuln.config.grypeDbListingURL | string | `""` | Parameter to override the default Grype vulnerability database URL (listings.json format) |
 | kubevulnScheduler.enabled | bool | `true` | enable/disable an image vulnerability scheduled scan using a CronJob |
 | kubevulnScheduler.image.repository | string | `"quay.io/kubescape/http_request"` | [source code](https://github.com/kubescape/http-request) (public repo) |
 | kubevulnScheduler.scanSchedule | string | `"0 0 * * *"` | scan schedule frequency |

--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -46,6 +46,9 @@ data:
       "scanTimeout": "{{ .Values.kubevuln.config.scanTimeout }}",
       "vexGeneration": {{ eq .Values.capabilities.vexGeneration "enable" }},
       "continuousPostureScan": {{ $configurations.continuousScan }},
+{{- if not (empty .Values.kubevuln.config.grypeDbListingURL) }}
+      "listingURL": "{{ .Values.kubevuln.config.grypeDbListingURL }}",
+{{- end }}
 {{- if .Values.grypeOfflineDB.enabled }}
       "listingURL": "http://{{ .Values.grypeOfflineDB.name }}:80/listing.json",
 {{- end }}

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -331,6 +331,7 @@ kubevuln:
     maxImageSize: 5368709120 # set the maximum image size for scanning. This refers to the size of the zipped image. If the size of the non-zipped image is larger, increase the ephemeral-storage limits. It is recommended to use the same size as the requested ephemeral-storage
     maxSBOMSize: 20971520
     scanTimeout: 5m # set timeout for scanning an image
+    grypeDbListingURL: "" # set the URL for the grype db listing, if empty the default URL will be used
 
   env:
     - name: CA_MAX_VULN_SCAN_ROUTINES # TODO update the kubevuln


### PR DESCRIPTION
## Overview

Enabling the user to use an alternative URL with Kubevuln/Grype
 