### PR TITLE
Fix prometheus-exporter missing endpoints

### DIFF
--- a/charts/kubescape-operator/templates/prometheus-exporter/servicemonitor.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/servicemonitor.yaml
@@ -8,6 +8,10 @@ metadata:
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.prometheusExporter.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:
+  endpoints:
+  - interval: 60s
+    path: /metrics
+    targetPort: 8080
   namespaceSelector:
     matchNames:
       -  {{ .Values.ksNamespace }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -4568,6 +4568,10 @@ all capabilities:
       name: prometheus-exporter
       namespace: kubescape
     spec:
+      endpoints:
+        - interval: 60s
+          path: /metrics
+          targetPort: 8080
       namespaceSelector:
         matchNames:
           - kubescape


### PR DESCRIPTION
## Overview

Fix the prometheus-exporter service monitor that misses the endpoint configuration

* Resolved #390
