### PR TITLE
chore: Move host scanner resources configuration to values file

### DIFF
--- a/charts/kubescape-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-operator/assets/host-scanner-definition.yaml
@@ -73,12 +73,7 @@ spec:
             containerPort: 7888
             protocol: TCP
         resources:
-          limits:
-            cpu: 0.4m
-            memory: 400Mi
-          requests:
-            cpu: 0.1m
-            memory: 200Mi
+{{ toYaml .Values.hostScanner.resources | indent 10 }}
         volumeMounts:
         - mountPath: /host_fs
           name: host-filesystem

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -449,6 +449,15 @@ hostScanner:
     - key: node-role.kubernetes.io/master
       operator: Exists
       effect: NoSchedule
+   
+  resources:
+    limits:
+      cpu: 0.4m
+      memory: 400Mi
+    requests:
+      cpu: 0.1m
+      memory: 200Mi
+
 
 # +++++++++++++++++++++++++++++++ Storage ++++++++++++++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
## Overview
Moving the host-scanner resources definition to the values.yaml file.

Fixes #454 

Here is the configMap after the change:
```
% kgcm -n kubescape host-scanner-definition -o yaml
apiVersion: v1
data:
  host-scanner-yaml: |-
    apiVersion: apps/v1
    kind: DaemonSet
    metadata:
      name: host-scanner
      namespace: kubescape
      labels:
        app: host-scanner
        k8s-app: kubescape-host-scanner
    spec:
      selector:
        matchLabels:
          name: host-scanner
      template:
        metadata:
          labels:
            kubescape.io/ignore: "true"
            kubescape.io/tier: "core"
            name: host-scanner
        spec:
          nodeSelector:
          affinity:
          tolerations:
            - effect: NoSchedule
              key: node-role.kubernetes.io/control-plane
              operator: Exists
            - effect: NoSchedule
              key: node-role.kubernetes.io/master
              operator: Exists
          containers:
          - name: host-sensor
            image: "quay.io/kubescape/host-scanner:v1.0.66"
            imagePullPolicy: IfNotPresent
            securityContext:
              allowPrivilegeEscalation: true
              privileged: true
              readOnlyRootFilesystem: true
              procMount: Unmasked
            env:
            - name: KS_LOGGER_LEVEL
              value: "info"
            - name: KS_LOGGER_NAME
              value: "zap"
            ports:
              - name: scanner # Do not change port name
                containerPort: 7888
                protocol: TCP
            resources:
              limits:
                cpu: 0.4m
                memory: 400Mi
              requests:
                cpu: 0.1m
                memory: 200Mi
            volumeMounts:
            - mountPath: /host_fs
              name: host-filesystem
            startupProbe:
              httpGet:
                path: /readyz
                port: 7888
              failureThreshold: 30
              periodSeconds: 1
            livenessProbe:
              httpGet:
                path: /healthz
                port: 7888
              periodSeconds: 10
          terminationGracePeriodSeconds: 120
          dnsPolicy: ClusterFirstWithHostNet
          automountServiceAccountToken: false
          volumes:
          - hostPath:
              path: /
              type: Directory
            name: host-filesystem
          hostPID: true
          hostIPC: true
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: kubescape
    meta.helm.sh/release-namespace: kubescape
  creationTimestamp: "2024-08-18T20:18:53Z"
  labels:
    app: ks-cloud-config
    app.kubernetes.io/managed-by: Helm
    kubescape.io/ignore: "true"
    kubescape.io/tier: core
    tier: ks-control-plane
  name: host-scanner-definition
  namespace: kubescape
  resourceVersion: "1360"
  uid: f6a2888b-afdf-47c5-8aaf-e2807e17480b
```

 <!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 