### PR TITLE
The selector on the node-agent svc was not working.

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/service.yaml
+++ b/charts/kubescape-operator/templates/node-agent/service.yaml
@@ -14,5 +14,5 @@ spec:
     targetPort: 8080
     protocol: TCP
   selector:
-    app.kubernetes.io/name: {{ .Values.nodeAgent.name }}
+    {{- include "kubescape-operator.selectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name) | nindent 4 }}
 {{- end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -3210,7 +3210,9 @@ all capabilities:
           protocol: TCP
           targetPort: 8080
       selector:
-        app.kubernetes.io/name: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
   60: |
     apiVersion: v1
     kind: ServiceAccount
@@ -8875,7 +8877,9 @@ default capabilities:
           protocol: TCP
           targetPort: 8080
       selector:
-        app.kubernetes.io/name: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
   48: |
     apiVersion: v1
     kind: ServiceAccount
@@ -13287,7 +13291,9 @@ disable otel:
           protocol: TCP
           targetPort: 8080
       selector:
-        app.kubernetes.io/name: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
   36: |
     apiVersion: v1
     kind: ServiceAccount
@@ -16804,7 +16810,9 @@ minimal capabilities:
           protocol: TCP
           targetPort: 8080
       selector:
-        app.kubernetes.io/name: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
   25: |
     apiVersion: v1
     kind: ServiceAccount


### PR DESCRIPTION
No Pods was wrapped by the selector. This commit migrates the node-agent Service template to use kubescape-operator.selectorLabels defined in the `_helpers.tpl` file.

## How to Test

Add:

```yaml
....
....
    selector:
      app.kubernetes.io/component: node-agent
      app.kubernetes.io/instance: kubescape
      app.kubernetes.io/name: kubescape-operator
....
....
```

To the `node-agent Kubernetes Service`.

If the above selector filter is _not_ on the service one will see:

![image](https://github.com/user-attachments/assets/f4e9179f-f9ec-4271-99b6-6d6daf8b2f01)

When added ... you'll see:

![image](https://github.com/user-attachments/assets/cdd67394-0ac2-4eb1-af9b-56eaeb6553dd)

---

- [NOT_RELEVANT] My code follows the style guidelines of this project ( changing a Service YAML template here )
- [NOT_RELEVANT] I have commented on my code, particularly in hard-to-understand areas
- [X] I have performed a self-review of my code
- [NOT_RELEVANT] If it is a core feature, I have added thorough tests.
- [NOT_RELEVANT] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)** < I can't see any dev branch. Please guide me here if there's another branch to create the PR on. Checked other `PR's` and they seem to use the `main branch`.