### PR TITLE
Fixing bug where exporter config was set without synchronizer

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/configmap.yaml
@@ -37,7 +37,9 @@ data:
         "excludeNamespaces": "{{ .Values.excludeNamespaces }}",
         {{- end }}
         "exporters": {
+          {{- if $components.synchronizer.enabled }}
           "httpExporterConfig": {{- .Values.nodeAgent.config.httpExporterConfig | toJson }},
+          {{- end }}
           "alertManagerExporterUrls": {{- .Values.nodeAgent.config.alertManagerExporterUrls | toJson }},
           "stdoutExporter": {{- .Values.nodeAgent.config.stdoutExporter }},
           "syslogExporterURL": "{{- .Values.nodeAgent.config.syslogExporterURL }}"

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -144,8 +144,10 @@ spec:
             - name: KS_LOGGER_NAME
               value: "{{ .Values.logger.name }}"
             {{- if $components.otelCollector.enabled }}
+            {{- if $components.synchronizer.enabled }}
             - name: OTEL_COLLECTOR_SVC
               value: "otel-collector:4318"
+            {{- end }}
             {{- end }}
             {{- if $components.clamAV.enabled }}
             - name: CLAMAV_SOCKET

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -16652,7 +16652,6 @@ minimal capabilities:
             "nodeProfileInterval": "10m",
             "maxSniffingTimePerContainer": "24h",
             "exporters": {
-              "httpExporterConfig":{"maxAlertsPerMinute":1000,"method":"POST","url":"http://synchronizer:8089/apis/v1/kubescape.io"},
               "alertManagerExporterUrls":[],
               "stdoutExporter":true,
               "syslogExporterURL": ""
@@ -16701,7 +16700,7 @@ minimal capabilities:
           annotations:
             checksum/cloud-config: f5eda48aecb77a239b89ba75d2c49d92ad3c48f7f2b2951deca9e77052f7c00c
             checksum/cloud-secret: f1356b6dba8ba4a01197f4030346928c33c7dab7b123a2aecaffb0630352929c
-            checksum/node-agent-config: c210b0875265f4d1cc5217e0f754632e9c3ce74bec5ba28929706deddb3c425d
+            checksum/node-agent-config: 474bbbc94ee016e58c3cfd818115d54032b9329212108f2456f9d1acae80c949
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -16741,8 +16741,6 @@ minimal capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-                - name: OTEL_COLLECTOR_SVC
-                  value: otel-collector:4318
                 - name: NODE_NAME
                   valueFrom:
                     fieldRef:


### PR DESCRIPTION
This PR fixes: https://github.com/kubescape/node-agent/issues/412
