### PR TITLE
mount hostpath /var to node-agent

### DIFF
--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2985,6 +2985,8 @@ all capabilities:
                   name: host
                 - mountPath: /run
                   name: run
+                - mountPath: /var
+                  name: var
                 - mountPath: /lib/modules
                   name: modules
                 - mountPath: /sys/kernel/debug
@@ -3030,6 +3032,9 @@ all capabilities:
             - hostPath:
                 path: /run
               name: run
+            - hostPath:
+                path: /var
+              name: var
             - hostPath:
                 path: /sys/fs/cgroup
               name: cgroup
@@ -8706,6 +8711,8 @@ default capabilities:
                   name: host
                 - mountPath: /run
                   name: run
+                - mountPath: /var
+                  name: var
                 - mountPath: /lib/modules
                   name: modules
                 - mountPath: /sys/kernel/debug
@@ -8746,6 +8753,9 @@ default capabilities:
             - hostPath:
                 path: /run
               name: run
+            - hostPath:
+                path: /var
+              name: var
             - hostPath:
                 path: /sys/fs/cgroup
               name: cgroup
@@ -13258,6 +13268,8 @@ disable otel:
                   name: host
                 - mountPath: /run
                   name: run
+                - mountPath: /var
+                  name: var
                 - mountPath: /lib/modules
                   name: modules
                 - mountPath: /sys/kernel/debug
@@ -13295,6 +13307,9 @@ disable otel:
             - hostPath:
                 path: /run
               name: run
+            - hostPath:
+                path: /var
+              name: var
             - hostPath:
                 path: /sys/fs/cgroup
               name: cgroup
@@ -16795,6 +16810,8 @@ minimal capabilities:
                   name: host
                 - mountPath: /run
                   name: run
+                - mountPath: /var
+                  name: var
                 - mountPath: /lib/modules
                   name: modules
                 - mountPath: /sys/kernel/debug
@@ -16832,6 +16849,9 @@ minimal capabilities:
             - hostPath:
                 path: /run
               name: run
+            - hostPath:
+                path: /var
+              name: var
             - hostPath:
                 path: /sys/fs/cgroup
               name: cgroup

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -555,6 +555,8 @@ nodeAgent:
       name: host
     - mountPath: /run
       name: run
+    - mountPath: /var
+      name: var
     - mountPath: /lib/modules
       name: modules
     - mountPath: /sys/kernel/debug
@@ -576,6 +578,9 @@ nodeAgent:
     - hostPath:
         path: /run
       name: run
+    - hostPath:
+        path: /var
+      name: var
     - hostPath:
         path: /sys/fs/cgroup
       name: cgroup


### PR DESCRIPTION
I still think we should rationalize our mounts, but at least now we look more like inspektor