### PR TITLE
image pull secret generation using provided credentials

### DIFF
--- a/charts/kubescape-operator/templates/configs/image-pull-secret.yaml
+++ b/charts/kubescape-operator/templates/configs/image-pull-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.imagePullSecrets .Values.imagePullSecret.server }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.imagePullSecrets }}
+  namespace: {{ .Values.ksNamespace }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" 
+    .Values.imagePullSecret.server 
+    .Values.imagePullSecret.username 
+    .Values.imagePullSecret.password 
+    .Values.imagePullSecret.email 
+    (printf "%s:%s" .Values.imagePullSecret.username .Values.imagePullSecret.password | b64enc) | b64enc }}
+{{- end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -18102,6 +18102,16 @@ minimal capabilities:
         tier: ks-control-plane
       name: storage
       namespace: kubescape
+with image pull secret generated:
+  1: |
+    apiVersion: v1
+    data:
+      .dockerconfigjson: eyJhdXRocyI6eyJxdWF5LmlvIjp7InVzZXJuYW1lIjoiZm9vIiwicGFzc3dvcmQiOiJ4eHh4eHh4IiwiZW1haWwiOiIiLCJhdXRoIjoiWm05dk9uaDRlSGg0ZUhnPSJ9fX0=
+    kind: Secret
+    metadata:
+      name: quay-secret
+      namespace: kubescape
+    type: kubernetes.io/dockerconfigjson
 with multiple private registry credentials:
   1: |
     apiVersion: v1

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -176,3 +176,25 @@ tests:
               username: xxx
               password: yyy
               insecure: true
+  - it: with image pull secret generated
+    template: configs/image-pull-secret.yaml
+    documentSelector:
+      path: metadata.name
+      value: quay-secret
+    asserts:
+      - equal:
+          path: metadata.name
+          value: quay-secret
+      - matchSnapshot: {}
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      configurations.otelUrl: "otelCollector:4317"
+      clusterName: kind-kind
+      imagePullSecrets: quay-secret
+      imagePullSecret:
+        server: quay.io
+        username: foo
+        password: xxxxxxx

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -47,6 +47,13 @@ customScheduling:
 # -- set the image pull secrets for private registry support
 imagePullSecrets: ""
 
+# -- (optional) generate image pull secret with the provided credentials. Secret name must be provided in the imagePullSecrets field
+imagePullSecret:
+  server: ""
+  username: ""
+  password: ""
+  email: ""
+
 # -----------------------------------------------------------------------------------------
 # ----------------------------- Providers -------------------------------------------------
 # -----------------------------------------------------------------------------------------


### PR DESCRIPTION
## Overview

This update enhances the handling of `imagePullSecrets` by allowing users to generate an image pull secret dynamically based on provided credentials. Previously, the `imagePullSecrets` value was limited to referencing an existing secret. With this change, users can specify credentials and the chart will generate the required secret.