### PR TITLE
fixed copy paste mistake for Prometheus Exporter volumes

### DIFF
--- a/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
@@ -74,8 +74,8 @@ spec:
 {{- if .Values.volumeMounts }}
 {{ toYaml .Values.volumeMounts | indent 12 }}
 {{- end }}
-{{- if .Values.kubevuln.volumeMounts }}
-{{ toYaml .Values.kubevuln.volumeMounts | indent 12 }}
+{{- if .Values.prometheusExporter.volumeMounts }}
+{{ toYaml .Values.prometheusExporter.volumeMounts | indent 12 }}
 {{- end }}
       volumes:
         - name: {{ .Values.global.cloudConfig }}

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -774,6 +774,11 @@ prometheusExporter:
 
   enableWorkloadMetrics: false
 
+  # Additional volumes to be mounted on the prometheus exporter
+  volumes: [ ]
+
+  # Additional volumeMounts to be mounted on the prometheus exporter
+  volumeMounts: [ ]
 
 # +++++++++++++++++++++++++++++ Upgrader ++++++++++++++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
## Overview
When I added volume mounts for the kubevuln component, I also noticed differences for the Prometheus Exporter component in Argo CD. I assume this is a copy-paste error that has not yet been discovered.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 