### PR TITLE
allow prometheus-exporter to export metrics on workload level

### DIFF
--- a/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
@@ -63,6 +63,10 @@ spec:
               value: "{{ .Values.logger.level }}"
             - name: KS_LOGGER_NAME
               value: "{{ .Values.logger.name }}"
+            {{- if .Values.prometheusExporter.enableWorkloadMetrics }}
+            - name: ENABLE_WORKLOAD_METRICS
+              value: "true"
+            {{- end }}
           volumeMounts:
             - name: {{ .Values.global.cloudConfig }}
               mountPath: /etc/config

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -4253,7 +4253,9 @@ all capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/prometheus-exporter:v0.0.129
+                - name: ENABLE_WORKLOAD_METRICS
+                  value: "true"
+              image: quay.io/kubescape/prometheus-exporter:v0.2.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 initialDelaySeconds: 3

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -58,6 +58,8 @@ tests:
       kubevulnScheduler.scanSchedule: "1 2 3 4 5"
       nodeAgent.config.skipKernelVersionCheck: true
       storage.forceVirtualCrds: true
+      prometheusExporter:
+        enableWorkloadMetrics: true
   - it: minimal capabilities
     asserts:
       - matchSnapshot: {}

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -756,7 +756,7 @@ prometheusExporter:
   name: "prometheus-exporter"
   image:
     repository: quay.io/kubescape/prometheus-exporter
-    tag: v0.0.129
+    tag: v0.2.0
     pullPolicy: IfNotPresent
 
   resources:
@@ -771,6 +771,9 @@ prometheusExporter:
     port: 8080
     targetPort: 8080
     protocol: TCP
+
+  enableWorkloadMetrics: false
+
 
 # +++++++++++++++++++++++++++++ Upgrader ++++++++++++++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
## Overview

With this change it's possible to set extra environment variables for the prometheus-exporter. This is desired to set `ENABLE_WORKLOAD_METRICS=true`. Additionally I've updated the image tag to the latest version.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

## Additional Information

The logic has been implemented in this PR:
https://github.com/kubescape/prometheus-exporter/pull/24

~~Don't be confused by the version reduction associated with CI creating negative versions:~~
https://github.com/kubescape/prometheus-exporter/issues/26

The Docker tag `v0.2.0` has been created manually to avoid the above problem.
https://quay.io/repository/kubescape/prometheus-exporter?tab=tags

## How to Test

Create a `values.yaml` with minimal config:

```yaml
capabilities:
  prometheusExporter: enable
prometheusExporter:
  env:
    - name: ENABLE_WORKLOAD_METRICS
      value: "true"
```

Render the helm template and and check the occurrence:
```
helm template kubescape-operator kubescape-operator -f values.yaml | grep -5 "ENABLE_WORKLOAD_METRICS"
                  resource: limits.cpu
            - name: KS_LOGGER_LEVEL
              value: "info"
            - name: KS_LOGGER_NAME
              value: "zap"
            - name: ENABLE_WORKLOAD_METRICS
              value: "true"
          volumeMounts:
            - name: ks-cloud-config
              mountPath: /etc/config
              readOnly: true

```

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 