### PR TITLE
fix relevancy vulnerability scans, prepare new release

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.24.1
+version: 1.24.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.24.1
+appVersion: 1.24.2
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2065,7 +2065,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: gateway,kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.49
+              image: quay.io/amirm_armo/kubevuln:fix-relevancy
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -3268,7 +3268,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: gateway,kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.55
+              image: quay.io/amirm_armo/operator:fix-relevancy
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -4802,7 +4802,7 @@ all capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/storage:v0.0.146
+              image: quay.io/kubescape/storage:v0.0.148
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 tcpSocket:
@@ -7641,7 +7641,7 @@ default capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/kubescape/kubevuln:v0.3.49
+              image: quay.io/amirm_armo/kubevuln:fix-relevancy
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -8604,7 +8604,7 @@ default capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/kubescape/operator:v0.2.55
+              image: quay.io/amirm_armo/operator:fix-relevancy
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -9790,7 +9790,7 @@ default capabilities:
                   value: otel-collector:4317
                 - name: DISABLE_VIRTUAL_CRDS
                   value: "true"
-              image: quay.io/kubescape/storage:v0.0.146
+              image: quay.io/kubescape/storage:v0.0.148
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 tcpSocket:
@@ -12067,7 +12067,7 @@ disable otel:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/kubescape/kubevuln:v0.3.49
+              image: quay.io/amirm_armo/kubevuln:fix-relevancy
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12845,7 +12845,7 @@ disable otel:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/kubescape/operator:v0.2.55
+              image: quay.io/amirm_armo/operator:fix-relevancy
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -13886,7 +13886,7 @@ disable otel:
                   value: otel-collector:4317
                 - name: DISABLE_VIRTUAL_CRDS
                   value: "true"
-              image: quay.io/kubescape/storage:v0.0.146
+              image: quay.io/kubescape/storage:v0.0.148
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 tcpSocket:
@@ -15640,7 +15640,7 @@ minimal capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/kubescape/kubevuln:v0.3.49
+              image: quay.io/amirm_armo/kubevuln:fix-relevancy
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16411,7 +16411,7 @@ minimal capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/kubescape/operator:v0.2.55
+              image: quay.io/amirm_armo/operator:fix-relevancy
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -17220,7 +17220,7 @@ minimal capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4317
-              image: quay.io/kubescape/storage:v0.0.146
+              image: quay.io/kubescape/storage:v0.0.148
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 tcpSocket:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 all capabilities:
   1: |
     raw: |
-      Thank you for installing kubescape-operator version 1.24.1.
+      Thank you for installing kubescape-operator version 1.24.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -33,8 +33,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -51,8 +51,8 @@ all capabilities:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.24.1
-                helm.sh/chart: kubescape-operator-1.24.1
+                app.kubernetes.io/version: 1.24.2
+                helm.sh/chart: kubescape-operator-1.24.2
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -103,8 +103,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -157,8 +157,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -181,8 +181,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -206,8 +206,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -225,8 +225,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -277,8 +277,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -303,8 +303,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -322,8 +322,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -343,8 +343,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -362,8 +362,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -378,8 +378,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -410,8 +410,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -536,8 +536,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: gateway
@@ -602,8 +602,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: gateway-scc
@@ -626,8 +626,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: gateway
@@ -657,8 +657,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: gateway
@@ -673,8 +673,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -701,8 +701,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -739,8 +739,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -773,8 +773,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -801,8 +801,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -818,9 +818,9 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
+        app.kubernetes.io/version: 1.24.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.24.1
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -838,9 +838,9 @@ all capabilities:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.24.1
+                app.kubernetes.io/version: 1.24.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.24.1
+                helm.sh/chart: kubescape-operator-1.24.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -897,8 +897,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -958,8 +958,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1200,8 +1200,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1223,8 +1223,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1256,8 +1256,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -1414,11 +1414,11 @@ all capabilities:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.24.1
+            helm.sh/chart: kubescape-operator-1.24.2
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.24.1"
+            app.kubernetes.io/version: "1.24.2"
             app.kubernetes.io/managed-by: Helm
             app: host-scanner
             tier: ks-control-plane
@@ -1432,11 +1432,11 @@ all capabilities:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.24.1
+                helm.sh/chart: kubescape-operator-1.24.2
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.24.1"
+                app.kubernetes.io/version: "1.24.2"
                 app.kubernetes.io/managed-by: Helm
                 app: host-scanner
                 tier: ks-control-plane
@@ -1523,8 +1523,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1540,8 +1540,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1623,8 +1623,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1652,8 +1652,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1676,8 +1676,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -1700,8 +1700,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1728,8 +1728,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1744,8 +1744,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -1776,8 +1776,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1793,9 +1793,9 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
+        app.kubernetes.io/version: 1.24.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.24.1
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1813,9 +1813,9 @@ all capabilities:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.24.1
+                app.kubernetes.io/version: 1.24.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.24.1
+                helm.sh/chart: kubescape-operator-1.24.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -1872,8 +1872,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -1933,8 +1933,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1971,8 +1971,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1994,8 +1994,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2023,8 +2023,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -2065,7 +2065,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: gateway,kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/amirm_armo/kubevuln:fix-relevancy
+              image: quay.io/kubescape/kubevuln:v0.3.52
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -2155,8 +2155,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2221,8 +2221,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -2245,8 +2245,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2272,8 +2272,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2288,8 +2288,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2409,8 +2409,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2458,8 +2458,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2512,8 +2512,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2539,8 +2539,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -2770,8 +2770,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -2823,8 +2823,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2886,8 +2886,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -2910,8 +2910,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2936,8 +2936,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2952,8 +2952,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -2980,8 +2980,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.NAMESPACE.svc-kubescape-tls-pair
@@ -2997,8 +2997,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -3043,8 +3043,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3149,8 +3149,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3181,8 +3181,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3198,8 +3198,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3233,8 +3233,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -3249,7 +3249,7 @@ all capabilities:
                 - 2>&1
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.24.1
+                  value: kubescape-operator-1.24.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -3268,7 +3268,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: gateway,kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/amirm_armo/operator:fix-relevancy
+              image: quay.io/kubescape/operator:v0.2.60
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -3462,8 +3462,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3543,8 +3543,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3560,8 +3560,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3735,8 +3735,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3752,8 +3752,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3794,8 +3794,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3818,8 +3818,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -3842,8 +3842,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3869,8 +3869,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3887,8 +3887,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3904,8 +3904,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3935,8 +3935,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -4021,8 +4021,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -4089,8 +4089,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector-scc
@@ -4113,8 +4113,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -4144,8 +4144,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -4160,8 +4160,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4185,8 +4185,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4208,8 +4208,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4232,8 +4232,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -4310,8 +4310,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4338,8 +4338,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4365,8 +4365,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4381,8 +4381,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4416,8 +4416,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -4437,8 +4437,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4453,8 +4453,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             otel: enabled
             tier: ks-control-plane
@@ -4535,8 +4535,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4566,8 +4566,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4594,8 +4594,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4610,8 +4610,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -4634,8 +4634,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4698,8 +4698,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -4721,8 +4721,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4745,8 +4745,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4771,8 +4771,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape-storage
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -4857,8 +4857,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4921,8 +4921,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -4943,8 +4943,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -4967,8 +4967,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -4991,8 +4991,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5016,8 +5016,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5032,8 +5032,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5257,8 +5257,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5528,8 +5528,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5545,8 +5545,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5575,8 +5575,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -5589,7 +5589,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.24.1
+                  value: kubescape-operator-1.24.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -5698,8 +5698,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5775,8 +5775,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5817,8 +5817,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5841,8 +5841,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -5865,8 +5865,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5892,8 +5892,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5901,7 +5901,7 @@ all capabilities:
 default capabilities:
   1: |
     raw: |
-      Thank you for installing kubescape-operator version 1.24.1.
+      Thank you for installing kubescape-operator version 1.24.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -5934,8 +5934,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -5986,8 +5986,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -6012,8 +6012,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6032,8 +6032,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6051,8 +6051,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -6067,8 +6067,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6099,8 +6099,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -6213,8 +6213,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: gateway
@@ -6273,8 +6273,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: gateway
@@ -6304,8 +6304,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: gateway
@@ -6320,8 +6320,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6348,8 +6348,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -6384,8 +6384,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -6418,8 +6418,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -6446,8 +6446,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6463,9 +6463,9 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
+        app.kubernetes.io/version: 1.24.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.24.1
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6483,9 +6483,9 @@ default capabilities:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.24.1
+                app.kubernetes.io/version: 1.24.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.24.1
+                helm.sh/chart: kubescape-operator-1.24.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -6540,8 +6540,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -6595,8 +6595,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6837,8 +6837,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6860,8 +6860,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6893,8 +6893,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -7039,11 +7039,11 @@ default capabilities:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.24.1
+            helm.sh/chart: kubescape-operator-1.24.2
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.24.1"
+            app.kubernetes.io/version: "1.24.2"
             app.kubernetes.io/managed-by: Helm
             app: host-scanner
             tier: ks-control-plane
@@ -7057,11 +7057,11 @@ default capabilities:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.24.1
+                helm.sh/chart: kubescape-operator-1.24.2
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.24.1"
+                app.kubernetes.io/version: "1.24.2"
                 app.kubernetes.io/managed-by: Helm
                 app: host-scanner
                 tier: ks-control-plane
@@ -7146,8 +7146,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7163,8 +7163,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7235,8 +7235,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7264,8 +7264,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7288,8 +7288,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7316,8 +7316,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7332,8 +7332,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -7364,8 +7364,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7381,9 +7381,9 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
+        app.kubernetes.io/version: 1.24.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.24.1
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7401,9 +7401,9 @@ default capabilities:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.24.1
+                app.kubernetes.io/version: 1.24.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.24.1
+                helm.sh/chart: kubescape-operator-1.24.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -7458,8 +7458,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -7513,8 +7513,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7551,8 +7551,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7574,8 +7574,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7603,8 +7603,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -7641,7 +7641,7 @@ default capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/amirm_armo/kubevuln:fix-relevancy
+              image: quay.io/kubescape/kubevuln:v0.3.52
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -7723,8 +7723,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7783,8 +7783,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7810,8 +7810,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7826,8 +7826,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7947,8 +7947,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7996,8 +7996,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8013,8 +8013,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8040,8 +8040,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -8230,8 +8230,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -8289,8 +8289,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8341,8 +8341,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8367,8 +8367,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8383,8 +8383,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8489,8 +8489,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8521,8 +8521,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8538,8 +8538,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8573,8 +8573,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -8589,7 +8589,7 @@ default capabilities:
                 - 2>&1
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.24.1
+                  value: kubescape-operator-1.24.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -8604,7 +8604,7 @@ default capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/amirm_armo/operator:fix-relevancy
+              image: quay.io/kubescape/operator:v0.2.60
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -8779,8 +8779,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8858,8 +8858,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8875,8 +8875,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9037,8 +9037,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9054,8 +9054,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9096,8 +9096,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9120,8 +9120,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9147,8 +9147,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9165,8 +9165,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9182,8 +9182,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9213,8 +9213,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -9293,8 +9293,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9355,8 +9355,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9386,8 +9386,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9408,8 +9408,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -9429,8 +9429,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9445,8 +9445,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             otel: enabled
             tier: ks-control-plane
@@ -9521,8 +9521,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9552,8 +9552,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9580,8 +9580,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9596,8 +9596,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -9620,8 +9620,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9684,8 +9684,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -9707,8 +9707,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9731,8 +9731,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9757,8 +9757,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape-storage
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -9843,8 +9843,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9896,8 +9896,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -9918,8 +9918,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -9942,8 +9942,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9967,8 +9967,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9983,8 +9983,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10148,8 +10148,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10413,8 +10413,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10430,8 +10430,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10460,8 +10460,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -10474,7 +10474,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.24.1
+                  value: kubescape-operator-1.24.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -10571,8 +10571,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10637,8 +10637,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10679,8 +10679,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10703,8 +10703,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10730,8 +10730,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10739,7 +10739,7 @@ default capabilities:
 disable otel:
   1: |
     raw: |
-      Thank you for installing kubescape-operator version 1.24.1.
+      Thank you for installing kubescape-operator version 1.24.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -10772,8 +10772,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -10823,8 +10823,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -10849,8 +10849,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10869,8 +10869,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10888,8 +10888,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -10904,8 +10904,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10935,8 +10935,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -11043,8 +11043,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: gateway
@@ -11074,8 +11074,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: gateway
@@ -11092,8 +11092,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11109,9 +11109,9 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
+        app.kubernetes.io/version: 1.24.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.24.1
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11129,9 +11129,9 @@ disable otel:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.24.1
+                app.kubernetes.io/version: 1.24.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.24.1
+                helm.sh/chart: kubescape-operator-1.24.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11186,8 +11186,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11428,8 +11428,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11451,8 +11451,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11483,8 +11483,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -11623,11 +11623,11 @@ disable otel:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.24.1
+            helm.sh/chart: kubescape-operator-1.24.2
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.24.1"
+            app.kubernetes.io/version: "1.24.2"
             app.kubernetes.io/managed-by: Helm
             app: host-scanner
             tier: ks-control-plane
@@ -11641,11 +11641,11 @@ disable otel:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.24.1
+                helm.sh/chart: kubescape-operator-1.24.2
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.24.1"
+                app.kubernetes.io/version: "1.24.2"
                 app.kubernetes.io/managed-by: Helm
                 app: host-scanner
                 tier: ks-control-plane
@@ -11730,8 +11730,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11747,8 +11747,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11776,8 +11776,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11800,8 +11800,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11828,8 +11828,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11846,8 +11846,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11863,9 +11863,9 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
+        app.kubernetes.io/version: 1.24.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.24.1
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11883,9 +11883,9 @@ disable otel:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.24.1
+                app.kubernetes.io/version: 1.24.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.24.1
+                helm.sh/chart: kubescape-operator-1.24.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11940,8 +11940,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11978,8 +11978,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12001,8 +12001,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12029,8 +12029,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -12067,7 +12067,7 @@ disable otel:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/amirm_armo/kubevuln:fix-relevancy
+              image: quay.io/kubescape/kubevuln:v0.3.52
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12143,8 +12143,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12170,8 +12170,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12186,8 +12186,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12307,8 +12307,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12356,8 +12356,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12373,8 +12373,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12399,8 +12399,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -12583,8 +12583,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12609,8 +12609,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12625,8 +12625,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12731,8 +12731,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12763,8 +12763,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12780,8 +12780,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12814,8 +12814,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -12830,7 +12830,7 @@ disable otel:
                 - 2>&1
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.24.1
+                  value: kubescape-operator-1.24.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -12845,7 +12845,7 @@ disable otel:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/amirm_armo/operator:fix-relevancy
+              image: quay.io/kubescape/operator:v0.2.60
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -13014,8 +13014,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13093,8 +13093,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13172,8 +13172,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13189,8 +13189,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13231,8 +13231,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13255,8 +13255,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13282,8 +13282,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13359,8 +13359,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13376,8 +13376,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13406,8 +13406,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -13480,8 +13480,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -13511,8 +13511,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -13531,8 +13531,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13547,8 +13547,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             otel: enabled
             tier: ks-control-plane
@@ -13617,8 +13617,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13648,8 +13648,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13676,8 +13676,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13692,8 +13692,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -13716,8 +13716,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13780,8 +13780,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -13803,8 +13803,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13827,8 +13827,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13853,8 +13853,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape-storage
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -13940,8 +13940,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -13962,8 +13962,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -13986,8 +13986,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14011,8 +14011,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14027,8 +14027,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14192,8 +14192,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14457,8 +14457,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14474,8 +14474,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14503,8 +14503,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -14517,7 +14517,7 @@ disable otel:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.24.1
+                  value: kubescape-operator-1.24.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -14608,8 +14608,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14650,8 +14650,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14674,8 +14674,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14701,8 +14701,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14710,7 +14710,7 @@ disable otel:
 minimal capabilities:
   1: |
     raw: |
-      Thank you for installing kubescape-operator version 1.24.1.
+      Thank you for installing kubescape-operator version 1.24.2.
 
 
 
@@ -14735,8 +14735,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -14778,8 +14778,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -14804,8 +14804,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14824,8 +14824,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14843,8 +14843,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -14859,8 +14859,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15101,8 +15101,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15124,8 +15124,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15156,8 +15156,8 @@ minimal capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -15292,11 +15292,11 @@ minimal capabilities:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.24.1
+            helm.sh/chart: kubescape-operator-1.24.2
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.24.1"
+            app.kubernetes.io/version: "1.24.2"
             app.kubernetes.io/managed-by: Helm
             app: host-scanner
             tier: ks-control-plane
@@ -15310,11 +15310,11 @@ minimal capabilities:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.24.1
+                helm.sh/chart: kubescape-operator-1.24.2
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.24.1"
+                app.kubernetes.io/version: "1.24.2"
                 app.kubernetes.io/managed-by: Helm
                 app: host-scanner
                 tier: ks-control-plane
@@ -15399,8 +15399,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15416,8 +15416,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15445,8 +15445,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15469,8 +15469,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15497,8 +15497,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15513,8 +15513,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15551,8 +15551,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15574,8 +15574,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15602,8 +15602,8 @@ minimal capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -15640,7 +15640,7 @@ minimal capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/amirm_armo/kubevuln:fix-relevancy
+              image: quay.io/kubescape/kubevuln:v0.3.52
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -15714,8 +15714,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15741,8 +15741,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15757,8 +15757,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -15878,8 +15878,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -15925,8 +15925,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15942,8 +15942,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15968,8 +15968,8 @@ minimal capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -16150,8 +16150,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16176,8 +16176,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16192,8 +16192,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16298,8 +16298,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16329,8 +16329,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16346,8 +16346,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16380,8 +16380,8 @@ minimal capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -16396,7 +16396,7 @@ minimal capabilities:
                 - 2>&1
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.24.1
+                  value: kubescape-operator-1.24.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -16411,7 +16411,7 @@ minimal capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/amirm_armo/operator:fix-relevancy
+              image: quay.io/kubescape/operator:v0.2.60
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16574,8 +16574,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16653,8 +16653,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16732,8 +16732,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16749,8 +16749,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16791,8 +16791,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16815,8 +16815,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16842,8 +16842,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16860,8 +16860,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16877,8 +16877,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16907,8 +16907,8 @@ minimal capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16981,8 +16981,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -17012,8 +17012,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -17028,8 +17028,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -17052,8 +17052,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17116,8 +17116,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -17139,8 +17139,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17163,8 +17163,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17189,8 +17189,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape-storage
-            app.kubernetes.io/version: 1.24.1
-            helm.sh/chart: kubescape-operator-1.24.1
+            app.kubernetes.io/version: 1.24.2
+            helm.sh/chart: kubescape-operator-1.24.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -17272,8 +17272,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -17294,8 +17294,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -17318,8 +17318,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17343,8 +17343,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17370,8 +17370,8 @@ with multiple private registry credentials:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets
@@ -17406,8 +17406,8 @@ with single private registry credentials:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.24.1
-        helm.sh/chart: kubescape-operator-1.24.1
+        app.kubernetes.io/version: 1.24.2
+        helm.sh/chart: kubescape-operator-1.24.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -281,8 +281,8 @@ operator:
 
   image:
     # -- source code: https://github.com/kubescape/operator
-    repository: quay.io/kubescape/operator
-    tag: v0.2.55
+    repository: quay.io/amirm_armo/operator
+    tag: fix-relevancy
     pullPolicy: IfNotPresent
 
   service:
@@ -326,8 +326,8 @@ kubevuln:
 
   image:
     # -- source code: https://github.com/kubescape/kubevuln
-    repository: quay.io/kubescape/kubevuln
-    tag: v0.3.49
+    repository: quay.io/amirm_armo/kubevuln
+    tag: fix-relevancy
     pullPolicy: IfNotPresent
 
   replicaCount: 1
@@ -457,7 +457,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: quay.io/kubescape/storage
-    tag: v0.0.146
+    tag: v0.0.148
     pullPolicy: IfNotPresent
 
   # cleanup interval is a duration string

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -281,8 +281,8 @@ operator:
 
   image:
     # -- source code: https://github.com/kubescape/operator
-    repository: quay.io/amirm_armo/operator
-    tag: fix-relevancy
+    repository: quay.io/kubescape/operator
+    tag: v0.2.60
     pullPolicy: IfNotPresent
 
   service:
@@ -326,8 +326,8 @@ kubevuln:
 
   image:
     # -- source code: https://github.com/kubescape/kubevuln
-    repository: quay.io/amirm_armo/kubevuln
-    tag: fix-relevancy
+    repository: quay.io/kubescape/kubevuln
+    tag: v0.3.52
     pullPolicy: IfNotPresent
 
   replicaCount: 1


### PR DESCRIPTION
## List of changes

* operator
    > [Full Changelog](https://github.com/kubescape/operator/compare/v0.2.55...v0.2.60)
    * chore(deps): Bump golang.org/x/crypto from 0.27.0 to 0.31.0 by @dependabot in [operator#274](https://github.com/kubescape/operator/pull/274)
    * bump dependencies to fix vulnerabilities by @matthyx in [operator#275](https://github.com/kubescape/operator/pull/275)
    * fix registry scanning bug for empty repositories by @refaelm92 in [operator#276](https://github.com/kubescape/operator/pull/276)
    * fix: trigger ApplicationProfile scan (relevancy) whenever the ApplicationProfile is ready by @amirmalka in [operator#277](https://github.com/kubescape/operator/pull/277)
    * fix: scan only complete ApplicationProfiles by @amirmalka in [operator#278](https://github.com/kubescape/operator/pull/278)

* kubevuln
    > [Full Changelog](https://github.com/kubescape/kubevuln/compare/v0.3.49...v0.3.52)
    * bump vulnerable dependency by @matthyx in [kubevuln#263](https://github.com/kubescape/kubevuln/pull/263)
    * add registry image count attribute by @refaelm92 in [kubevuln#264](https://github.com/kubescape/kubevuln/pull/264)
    * fix: scan only complete ApplicationProfiles, fixed InstanceID and ImageId by @amirmalka in [kubevuln#266](https://github.com/kubescape/kubevuln/pull/266)


* storage 
    > [Full Changelog](https://github.com/kubescape/storage/compare/v0.0.146...v0.0.148)
    * Bump depencencies by @matthyx in [storage#159](https://github.com/kubescape/storage/pull/159)
    * Cleanup ApplicationProfiles with missing annotations when relevancy is enabled by @amirmalka in [storage#182](https://github.com/kubescape/storage/pull/182)
