### PR TITLE
Fix serviceScanConfig.enabled whitespace

### DIFF
--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -115,7 +115,7 @@ capabilities:
       replicas: 5
 
 serviceScanConfig:
-  enabled : false
+  enabled: false
   interval: 1h
 
 configurations:


### PR DESCRIPTION
## Overview
Fixed some extra whitespace in the serviceScanConfig.enabled key in the operator chart defaults

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes
 