### PR TITLE
fix: annotation for node-agent should use dynamic name

### DIFF
--- a/charts/kubescape-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-operator/assets/host-scanner-definition.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "kubescape-operator.selectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.hostScanner.name) | nindent 12 }}
+      {{- include "kubescape-operator.selectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.hostScanner.name) | nindent 6 }}
   template:
     metadata:
       labels:

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       {{- if ne .Values.global.proxySecretFile "" }}
         checksum/proxy-config: {{ $checksums.proxySecret }}
       {{- end }}
-        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
+        container.apparmor.security.beta.kubernetes.io/{{ .Values.nodeAgent.name }}: unconfined
       {{- if eq .Values.configurations.prometheusAnnotations "enable" }}
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1248,7 +1248,7 @@ all capabilities:
           annotations:
             checksum/cloud-config: e676e6d4282e48cde90d56356ebe417818278b5a260941f00176a2c064b77eb6
             checksum/cloud-secret: cf2e73d4ff0ce943730b3ed5bd4740f0bd8c4386e5843870f51c302b41df8da9
-            checksum/host-scanner-configmap: c338deb642cd369dad5f277d7733b278d5e1960f6338761bf51bac5c78d64e03
+            checksum/host-scanner-configmap: 27bc2a07421efcf5f68970eb30bd83f4f3b8ce2a2718644d7ee0a5c9d264dc5b
             checksum/proxy-config: 3669c08e51ef779cd00a107f19592b34195c3ebdb60bedaf8ebf1491a3f2a747
           labels:
             app: kubescape
@@ -1426,9 +1426,9 @@ all capabilities:
         spec:
           selector:
             matchLabels:
-                    app.kubernetes.io/name: kubescape-operator
-                    app.kubernetes.io/instance: RELEASE-NAME
-                    app.kubernetes.io/component: host-scanner
+              app.kubernetes.io/name: kubescape-operator
+              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/component: host-scanner
           template:
             metadata:
               labels:
@@ -6890,7 +6890,7 @@ default capabilities:
           annotations:
             checksum/cloud-config: f753b01d880e21ddc33cef3935d2ff4d41d12899432962a5a9b5dfda91d2c8d9
             checksum/cloud-secret: cf2e73d4ff0ce943730b3ed5bd4740f0bd8c4386e5843870f51c302b41df8da9
-            checksum/host-scanner-configmap: 12c9c19646e97d11d0c349d972ce0b2c9f5bc2a9e87556605f807322dfd7fceb
+            checksum/host-scanner-configmap: 5638547ec73f645a278a716fac57288e77e6c7319729d6939bb75246e4a6e645
             checksum/proxy-config: 3669c08e51ef779cd00a107f19592b34195c3ebdb60bedaf8ebf1491a3f2a747
           labels:
             app: kubescape
@@ -7056,9 +7056,9 @@ default capabilities:
         spec:
           selector:
             matchLabels:
-                    app.kubernetes.io/name: kubescape-operator
-                    app.kubernetes.io/instance: RELEASE-NAME
-                    app.kubernetes.io/component: host-scanner
+              app.kubernetes.io/name: kubescape-operator
+              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/component: host-scanner
           template:
             metadata:
               labels:
@@ -11486,7 +11486,7 @@ disable otel:
           annotations:
             checksum/cloud-config: d568e07a1bb2d6f372ab0e5a3fb91bd018b05433558890eb621af5234dd7c8c4
             checksum/cloud-secret: cf2e73d4ff0ce943730b3ed5bd4740f0bd8c4386e5843870f51c302b41df8da9
-            checksum/host-scanner-configmap: 12c9c19646e97d11d0c349d972ce0b2c9f5bc2a9e87556605f807322dfd7fceb
+            checksum/host-scanner-configmap: 5638547ec73f645a278a716fac57288e77e6c7319729d6939bb75246e4a6e645
           labels:
             app: kubescape
             app.kubernetes.io/component: kubescape
@@ -11645,9 +11645,9 @@ disable otel:
         spec:
           selector:
             matchLabels:
-                    app.kubernetes.io/name: kubescape-operator
-                    app.kubernetes.io/instance: RELEASE-NAME
-                    app.kubernetes.io/component: host-scanner
+              app.kubernetes.io/name: kubescape-operator
+              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/component: host-scanner
           template:
             metadata:
               labels:
@@ -15164,7 +15164,7 @@ minimal capabilities:
           annotations:
             checksum/cloud-config: f5eda48aecb77a239b89ba75d2c49d92ad3c48f7f2b2951deca9e77052f7c00c
             checksum/cloud-secret: f1356b6dba8ba4a01197f4030346928c33c7dab7b123a2aecaffb0630352929c
-            checksum/host-scanner-configmap: 12c9c19646e97d11d0c349d972ce0b2c9f5bc2a9e87556605f807322dfd7fceb
+            checksum/host-scanner-configmap: 5638547ec73f645a278a716fac57288e77e6c7319729d6939bb75246e4a6e645
           labels:
             app: kubescape
             app.kubernetes.io/component: kubescape
@@ -15319,9 +15319,9 @@ minimal capabilities:
         spec:
           selector:
             matchLabels:
-                    app.kubernetes.io/name: kubescape-operator
-                    app.kubernetes.io/instance: RELEASE-NAME
-                    app.kubernetes.io/component: host-scanner
+              app.kubernetes.io/name: kubescape-operator
+              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/component: host-scanner
           template:
             metadata:
               labels:


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

Modified the AppArmor profile configuration to use the `nodeAgent.name` value from the Helm chart values instead of hardcoding `node-agent`. This change allows for more flexible naming of the node agent container.