### PR TITLE
fix: stop synchronizer from retrying connection on invalid credentials

### DIFF
--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -5308,7 +5308,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.95
+              image: quay.io/kubescape/synchronizer:v0.0.98
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -9926,7 +9926,7 @@ default capabilities:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/kubescape/synchronizer:v0.0.95
+              image: quay.io/kubescape/synchronizer:v0.0.98
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -13782,7 +13782,7 @@ disable otel:
                       name: cloud-secret
                 - name: OTEL_COLLECTOR_SVC
                   value: otel-collector:4318
-              image: quay.io/kubescape/synchronizer:v0.0.95
+              image: quay.io/kubescape/synchronizer:v0.0.98
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -608,7 +608,7 @@ synchronizer:
   image:
     # -- source code: https://github.com/kubescape/synchronizer
     repository: quay.io/kubescape/synchronizer
-    tag: v0.0.95
+    tag: v0.0.98
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
## Overview

This PR updates the synchronizer to stop retrying connections when invalid credentials are detected. This prevents unnecessary retries and ensures better error handling in cases of authentication failures.

### Related PR
- [kubescape/synchronizer#103](https://github.com/kubescape/synchronizer/pull/103)