### PR TITLE
added necessary resources to ClusterRole when workload metrics are enabled

### DIFF
--- a/charts/kubescape-operator/templates/prometheus-exporter/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/clusterrole.yaml
@@ -8,6 +8,12 @@ metadata:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.prometheusExporter.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 rules:
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
-    resources: ["configurationscansummaries", "vulnerabilitysummaries"]
+    resources:
+      - configurationscansummaries
+      - vulnerabilitysummaries
+      {{- if .Values.prometheusExporter.enableWorkloadMetrics }}
+      - workloadconfigurationscansummaries
+      - vulnerabilitymanifestsummaries
+      {{- end }}
     verbs: ["get", "watch", "list"]
 {{- end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -4176,6 +4176,8 @@ all capabilities:
         resources:
           - configurationscansummaries
           - vulnerabilitysummaries
+          - workloadconfigurationscansummaries
+          - vulnerabilitymanifestsummaries
         verbs:
           - get
           - watch


### PR DESCRIPTION
## Overview
I just recognized that I missed updating the ClusteRole for prometheus-exporter in order to access the additional Kubescape CustomResources.

```
{"level":"info","ts":"2025-01-08T18:41:18Z","msg":"prometheus metrics server started","port":8080,"path":"/metrics"}
{"level":"warn","ts":"2025-01-08T18:41:18Z","msg":"failed getting workload configuration scan summaries","error":"workloadconfigurationscansummaries.spdx.softwarecomposition.kubescape.io is forbidden: User \"system:serviceaccount:kubescape:prometheus-exporter\" cannot list resource \"workloadconfigurationscansummaries\" in API group \"spdx.softwarecomposition.kubescape.io\" at the cluster scope"}
{"level":"warn","ts":"2025-01-08T18:41:18Z","msg":"failed getting vulnerability manifest summaries","error":"vulnerabilitymanifestsummaries.spdx.softwarecomposition.kubescape.io is forbidden: User \"system:serviceaccount:kubescape:prometheus-exporter\" cannot list resource \"vulnerabilitymanifestsummaries\" in API group \"spdx.softwarecomposition.kubescape.io\" at the cluster scope"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x16c61e5]

goroutine 69 [running]:
main.watchWorkloadConfigScanSummaries(0xc000067780?)
    /work/main.go:64 +0x25
created by main.main in goroutine 1
    /work/main.go:31 +0xab
Stream closed EOF for kubescape/prometheus-exporter-66849df9dc-qddtb (prometheus-exporter)
```

After adding the missing resources to the ClusterRole manually the prometheus-exporter was able to start and gather information.

```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: prometheus-exporter
rules:
  - apiGroups:
      - spdx.softwarecomposition.kubescape.io
    resources:
      - configurationscansummaries
      - vulnerabilitysummaries
      - workloadconfigurationscansummaries
      - vulnerabilitymanifestsummaries
    verbs:
      - get
      - watch
      - list
```

## Additional Information

Introduced by this PR: https://github.com/kubescape/helm-charts/pull/573

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 