### PR TITLE
Enabling mTLS in storage

### DIFF
--- a/charts/kubescape-operator/templates/storage/_helpersKubescapeStorage.tpl
+++ b/charts/kubescape-operator/templates/storage/_helpersKubescapeStorage.tpl
@@ -17,7 +17,7 @@ Create the name of the Kubescape Storage Auth Reader RoleBinding to use
 */}}
 {{- define "storage.generateCerts.ca" -}}
 {{- if not .Values.global.storageCA -}}
-{{- $cn := .Values.storage.name -}}
+{{- $cn := printf "%s-%s" .Values.storage.name (randAlphaNum 10) -}}
 {{- $ca := genCA (printf "%s-ca" $cn) (int .Values.storage.mtls.certificateValidityInDays) -}}
 {{- $_ := set .Values.global "storageCA" $ca -}}
 {{- end -}}
@@ -25,9 +25,9 @@ Create the name of the Kubescape Storage Auth Reader RoleBinding to use
 {{- end -}}
 
 {{- define "storage.generateCerts.cert" -}}
-{{- $cn := printf "%s.%s.svc" .Values.storage.name .Release.Namespace -}}
+{{- $cn := printf "%s.%s.svc-%s" .Values.storage.name .Release.Namespace (randAlphaNum 10) -}}
 {{- $ca := .Values.global.storageCA -}}
-{{- $dnsNames := list $cn (printf "%s.%s.svc" .Values.storage.name .Release.Namespace) (printf "%s.%s.svc.cluster.local" .Values.storage.name .Release.Namespace) -}}
+{{- $dnsNames := list (printf "%s.%s.svc" .Values.storage.name .Release.Namespace) (printf "%s.%s.svc.cluster.local" .Values.storage.name .Release.Namespace) -}}
 {{- $cert := genSignedCert $cn nil $dnsNames (int .Values.storage.mtls.certificateValidityInDays) $ca -}}
 {{- $cert | toJson -}}
 {{- end -}}

--- a/charts/kubescape-operator/templates/storage/_helpersKubescapeStorage.tpl
+++ b/charts/kubescape-operator/templates/storage/_helpersKubescapeStorage.tpl
@@ -6,8 +6,28 @@ Create the name of the Kubescape Storage Auth Reader RoleBinding to use
 {{- end }}
 
 {{/*
-Create the name of the Kubescape Storage Auth Reader ClusterRoleBinding to use
-*/}}
+  Create the name of the Kubescape Storage Auth Reader ClusterRoleBinding to use
+  */}}
 {{- define "storage.authDelegatorClusterRoleBindingName" -}}
   {{- .Values.storage.name | printf "%s:system:auth-delegator" }}
 {{- end }}
+
+{{/*
+  Generate a private key and certificate pair for mTLS
+*/}}
+{{- define "storage.generateCerts.ca" -}}
+{{- if not .Values.global.storageCA -}}
+{{- $cn := .Values.storage.name -}}
+{{- $ca := genCA (printf "%s-ca" $cn) (int .Values.storage.mtls.certificateValidityInDays) -}}
+{{- $_ := set .Values.global "storageCA" $ca -}}
+{{- end -}}
+{{- .Values.global.storageCA | toJson -}}
+{{- end -}}
+
+{{- define "storage.generateCerts.cert" -}}
+{{- $cn := printf "%s.%s.svc" .Values.storage.name .Release.Namespace -}}
+{{- $ca := .Values.global.storageCA -}}
+{{- $dnsNames := list $cn (printf "%s.%s.svc" .Values.storage.name .Release.Namespace) (printf "%s.%s.svc.cluster.local" .Values.storage.name .Release.Namespace) -}}
+{{- $cert := genSignedCert $cn nil $dnsNames (int .Values.storage.mtls.certificateValidityInDays) $ca -}}
+{{- $cert | toJson -}}
+{{- end -}}

--- a/charts/kubescape-operator/templates/storage/apiservice.yaml
+++ b/charts/kubescape-operator/templates/storage/apiservice.yaml
@@ -7,7 +7,11 @@ metadata:
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:
+  {{- if .Values.storage.mtls.enabled }}
+  insecureSkipTLSVerify: false
+  {{- else }}
   insecureSkipTLSVerify: true
+  {{- end }}
   group: "spdx.softwarecomposition.kubescape.io"
   groupPriorityMinimum: 1000
   versionPriority: 15
@@ -15,4 +19,7 @@ spec:
   service:
     name: {{ .Values.storage.name }}
     namespace: {{ .Values.ksNamespace }}
+  {{- if .Values.storage.mtls.enabled }}
+  caBundle: {{ .Values.global.storageCA.Cert | b64enc }}
+  {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/storage/ca-secret.yaml
+++ b/charts/kubescape-operator/templates/storage/ca-secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.storage.mtls.enabled }}
+{{- $ca := include "storage.generateCerts.ca" . | fromJson }}
+{{- $cert := include "storage.generateCerts.cert" . | fromJson }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.storage.name }}-ca
+  namespace: {{ .Values.ksNamespace }}
+  labels:
+    {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+{{- end }}

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -64,6 +64,14 @@ spec:
             value: "{{ .Values.logger.level }}"
           - name: KS_LOGGER_NAME
             value: "{{ .Values.logger.name }}"
+          {{- if .Values.storage.mtls.enabled }}
+          - name: TLS_CLIENT_CA_FILE
+            value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+          - name: TLS_SERVER_CERT_FILE
+            value: "/etc/storage-ca-certificates/tls.crt"
+          - name: TLS_SERVER_KEY_FILE
+            value: "/etc/storage-ca-certificates/tls.key"
+          {{- end }}
           {{- if $components.otelCollector.enabled }}
           - name: ACCOUNT_ID
             valueFrom:
@@ -83,6 +91,11 @@ spec:
           - name: {{ .Values.global.cloudConfig }}
             mountPath: /etc/config
             readOnly: true
+          {{- if .Values.storage.mtls.enabled }}
+          - name: "ca-certificates"
+            mountPath: /etc/storage-ca-certificates
+            readOnly: true
+          {{- end }}
         resources:
 {{ toYaml .Values.storage.resources | indent 12 }}
       nodeSelector:
@@ -121,4 +134,9 @@ spec:
             - key: "services"
               path: "services.json"
             {{- end }}
+        {{- if .Values.storage.mtls.enabled }}
+        - name: "ca-certificates"
+          secret:
+            secretName: {{ .Values.storage.name }}-ca
+        {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -10425,7 +10425,7 @@ disable otel:
         {
           "capabilities":{"admissionController":"disable","autoUpgrading":"disable","configurationScan":"enable","httpDetection":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"disable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","seccompProfileService":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
-          "configurations":{"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
+          "configurations":{"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
         }
     kind: ConfigMap
@@ -12210,7 +12210,7 @@ disable otel:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 46f28cfeabce548d6bce6f72f157d046401b2e56872e92b39ba65a7acbd4b6ba
+            checksum/capabilities-config: cf4501e8b328688774fd680ef32df114f3c17c7ee43d4272c32dd7f80b99ee2d
             checksum/cloud-config: 4ae906fd9cea940360abb72cb088bd6f82d009b1748dbeab14a85eef05efd049
             checksum/cloud-secret: cf2e73d4ff0ce943730b3ed5bd4740f0bd8c4386e5843870f51c302b41df8da9
             checksum/matching-rules-config: 4244067153661f0c2577cba49b0dba63db5f77acf9904663ca06610953f55e17

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -10425,7 +10425,7 @@ disable otel:
         {
           "capabilities":{"admissionController":"disable","autoUpgrading":"disable","configurationScan":"enable","httpDetection":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"disable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","seccompProfileService":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
-          "configurations":{"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
+          "configurations":{"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
         }
     kind: ConfigMap
@@ -12210,7 +12210,7 @@ disable otel:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: cf4501e8b328688774fd680ef32df114f3c17c7ee43d4272c32dd7f80b99ee2d
+            checksum/capabilities-config: 46f28cfeabce548d6bce6f72f157d046401b2e56872e92b39ba65a7acbd4b6ba
             checksum/cloud-config: 4ae906fd9cea940360abb72cb088bd6f82d009b1748dbeab14a85eef05efd049
             checksum/cloud-secret: cf2e73d4ff0ce943730b3ed5bd4740f0bd8c4386e5843870f51c302b41df8da9
             checksum/matching-rules-config: 4244067153661f0c2577cba49b0dba63db5f77acf9904663ca06610953f55e17

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -60,6 +60,7 @@ tests:
       kubevulnScheduler.scanSchedule: "1 2 3 4 5"
       nodeAgent.config.skipKernelVersionCheck: true
       storage.forceVirtualCrds: true
+      storage.mtls.enabled: false
       prometheusExporter:
         enableWorkloadMetrics: true
   - it: minimal capabilities

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -412,6 +412,9 @@ storage:
 
   # Values or the Aggregated APIServer
   name: "storage"
+  mtls:
+    enabled: true
+    certificateValidityInDays: 730
 
   image:
     # -- source code: https://github.com/kubescape/storage
@@ -547,7 +550,7 @@ nodeAgent:
 
   nodeSelector:
     kubernetes.io/os: linux
-  
+
   startupJitterContainer:
     enabled: false
     maxStartupJitter: 60

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -413,7 +413,7 @@ storage:
   # Values or the Aggregated APIServer
   name: "storage"
   mtls:
-    enabled: true
+    enabled: false
     certificateValidityInDays: 730
 
   image:


### PR DESCRIPTION
This pull request introduces enhancements to the Kubescape operator's storage component, focusing on enabling mutual TLS (mTLS) support. The key changes include generating certificates, updating deployment configurations, and conditionally managing secrets based on the mTLS setting.

Enhancements to mTLS support:

* [`charts/kubescape-operator/templates/storage/_helpersKubescapeStorage.tpl`](diffhunk://#diff-2a9c29dd4f281ac98cef7e20fbaa36f67b63f4313e33990436ffd9d5a6550856R14-R33): Added functions to generate a private key and certificate pair for mTLS (`storage.generateCerts.ca` and `storage.generateCerts.cert`).

* [`charts/kubescape-operator/templates/storage/apiservice.yaml`](diffhunk://#diff-03a926e020af25cc9df8c7036d07bfc7f09bd89a7100b90e44cc5daf82602fe1R10-R24): Updated the API service configuration to conditionally handle `insecureSkipTLSVerify` and `caBundle` based on the mTLS setting.

* [`charts/kubescape-operator/templates/storage/ca-secret.yaml`](diffhunk://#diff-8099b8fd65acf3889c974f458656c675173abeee7ded4b1a0362e04ae83098f8R1-R16): Added a new secret template to store the generated CA and certificate when mTLS is enabled.

Deployment configuration updates:

* [`charts/kubescape-operator/templates/storage/deployment.yaml`](diffhunk://#diff-a0d251bc3c5b81dfcb6c909fcb6d0ec7675b475379cf1632ae3dfa22f0e6e52aR67-R74): Updated the deployment to include environment variables and volume mounts for mTLS certificates when mTLS is enabled. [[1]](diffhunk://#diff-a0d251bc3c5b81dfcb6c909fcb6d0ec7675b475379cf1632ae3dfa22f0e6e52aR67-R74) [[2]](diffhunk://#diff-a0d251bc3c5b81dfcb6c909fcb6d0ec7675b475379cf1632ae3dfa22f0e6e52aR94-R98) [[3]](diffhunk://#diff-a0d251bc3c5b81dfcb6c909fcb6d0ec7675b475379cf1632ae3dfa22f0e6e52aR137-R141)

Configuration values:

* [`charts/kubescape-operator/values.yaml`](diffhunk://#diff-2d5611f69251d498d71f52fa778f6ce1bc93e1e1f46951ede1c50d975bdcad02R415-R417): Added new configuration options for enabling mTLS and setting certificate validity.