### PR TITLE
Add support for mapping extra CA certificates in Kubescape Helm chart

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -94,6 +94,8 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | global.proxySecretFile | string | `""` | Set proxy certificate / RootCA file content (not the file path) for all components to be used for proxy configured in global.httpsProxy |
 | global.overrideDefaultCaCertificates.enabled | bool | `false` | Use to enable custom CA Certificates |
 | global.overrideDefaultCaCertificates.caCertificates | string | `""` | Set the custom CA Certificates file in all container |
+| global.extraCaCertificates.enabled | bool | `false` | Use to enable mapping extra CA Certificate files |
+| global.extraCaCertificates.secretName | bool | `""` | Name of the secret that contents will be mapped to `/etc/ssl/certs` in each workload |
 | customScheduling.affinity | yaml |  | Use the `affinity` sub-section to define affinity rules that will apply to all of the workloads managed by the kubescape-operator |
 | customScheduling.nodeSelector | yaml | | Configure `nodeSelector` rules under the nodeSelector sub-section that will apply to all of the workloads managed by the kubescape-operator |
 | customScheduling.tolerations | yaml | | Define `tolerations` in the tolerations sub-section that will apply to all of the workloads managed by the kubescape-operator |
@@ -234,7 +236,7 @@ graph TB
     sync1("Synchronizer (In-cluster)")
     store1(Storage)
   end;
-  
+
   dashboard --> event --> masterSync
   masterSync .- sync1
   masterSync .- sync2

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -204,6 +204,10 @@ spec:
           mountPath: /etc/ssl/certs/ca-certificates.crt
           subPath: ca-certificates.crt
 {{- end }}
+{{- if .Values.global.extraCaCertificates.enabled }}
+        - name: extra-ca-certificates
+          mountPath: /etc/ssl/certs/
+{{- end }}
       volumes:
       - name: {{ $components.cloudSecret.name }}
         secret:
@@ -217,6 +221,11 @@ spec:
       - name: custom-ca-certificates
         secret:
           secretName: {{ $components.customCaCertificates.name }}
+      {{- end }}
+      {{- if .Values.global.extraCaCertificates.enabled }}
+      - name: extra-ca-certificates
+        secret:
+          secretName: {{ .Values.global.extraCaCertificates.secretName }}
       {{- end }}
       - name: {{ .Values.global.cloudConfig }}
         configMap:

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -130,6 +130,10 @@ spec:
               mountPath: /etc/ssl/certs/ca-certificates.crt
               subPath: ca-certificates.crt
 {{- end }}
+{{- if .Values.global.extraCaCertificates.enabled }}
+            - name: extra-ca-certificates
+              mountPath: /etc/ssl/certs/
+{{- end }}
       volumes:
         - name: {{ $components.cloudSecret.name }}
           secret:
@@ -143,6 +147,11 @@ spec:
         - name: custom-ca-certificates
           secret:
             secretName: {{ $components.customCaCertificates.name }}
+      {{- end }}
+      {{- if .Values.global.extraCaCertificates.enabled }}
+        - name: extra-ca-certificates
+          secret:
+            secretName: {{ .Values.global.extraCaCertificates.secretName }}
       {{- end }}
         - name: tmp-dir
           emptyDir: {}

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -57,7 +57,7 @@ spec:
       initContainers:
       - name: startup-jitter
         image: "busybox:latest"
-        command: 
+        command:
         - /bin/sh
         - -c
         - |
@@ -106,6 +106,11 @@ spec:
         - name: custom-ca-certificates
           secret:
             secretName: {{ $components.customCaCertificates.name }}
+        {{- end }}
+        {{- if .Values.global.extraCaCertificates.enabled }}
+        - name: extra-ca-certificates
+          secret:
+            secretName: {{ .Values.global.extraCaCertificates.secretName }}
         {{- end }}
       containers:
         {{- if $components.clamAV.enabled }}
@@ -241,6 +246,11 @@ spec:
           - name: custom-ca-certificates
             mountPath: /etc/ssl/certs/ca-certificates.crt
             subPath: ca-certificates.crt
+          {{- end }}
+          {{- if .Values.global.extraCaCertificates.enabled }}
+          - name: extra-ca-certificates
+            mountPath: /etc/ssl/certs/
+            subPath: {{ .Values.global.extraCaCertificates.secretName }}
           {{- end }}
       nodeSelector:
       {{- if .Values.nodeAgent.nodeSelector }}

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -143,6 +143,10 @@ spec:
               mountPath: /etc/ssl/certs/ca-certificates.crt
               subPath: ca-certificates.crt
             {{- end }}
+            {{- if .Values.global.extraCaCertificates.enabled }}
+            - name: extra-ca-certificates
+              mountPath: /etc/ssl/certs/
+            {{- end }}
             {{- if eq .Values.capabilities.admissionController "enable" }}
             - name: tls-certs
               mountPath: /etc/certs
@@ -172,6 +176,11 @@ spec:
         - name: custom-ca-certificates
           secret:
             secretName: {{ $components.customCaCertificates.name }}
+        {{- end }}
+        {{- if .Values.global.extraCaCertificates.enabled }}
+        - name: extra-ca-certificates
+          secret:
+            secretName: {{ .Values.global.extraCaCertificates.secretName }}
         {{- end }}
         {{- if eq .Values.capabilities.admissionController "enable" }}
         - name: tls-certs

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -112,6 +112,11 @@ spec:
               mountPath: /etc/ssl/certs/ca-certificates.crt
               subPath: ca-certificates.crt
             {{- end }}
+            {{- if .Values.global.extraCaCertificates.enabled }}
+            - name: extra-ca-certificates
+              mountPath: /etc/ssl/certs/
+              subPath: {{ .Values.global.extraCaCertificates.secretName }}
+            {{- end }}
             - name: config
               mountPath: /etc/config/config.json
               readOnly: true
@@ -140,6 +145,11 @@ spec:
         - name: custom-ca-certificates
           secret:
             secretName: {{ $components.customCaCertificates.name }}
+      {{- end }}
+      {{- if .Values.global.extraCaCertificates.enabled }}
+        - name: extra-ca-certificates
+          secret:
+            secretName: {{ .Values.global.extraCaCertificates.secretName }}
       {{- end }}
         - name: {{ .Values.global.cloudConfig }}
           configMap:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -201,6 +201,9 @@ global:
   overrideDefaultCaCertificates:
     enabled: false
     caCertificates: ""
+  extraCaCertificates:
+    enabled: false
+    secretName: ""
   openshift: # Openshift Security Context Constraint support
     scc:
       enabled: false


### PR DESCRIPTION
This pull request introduces a new feature to support extra CA certificates in the Helm chart.

### New Feature: Support for Extra CA Certificates

* [`charts/kubescape-operator/values.yaml`](diffhunk://#diff-2d5611f69251d498d71f52fa778f6ce1bc93e1e1f46951ede1c50d975bdcad02R204-R206): Added new configuration options under `global.extraCaCertificates` to enable the feature and specify the secret name containing the extra CA certificates.

### Deployment Template Modifications

* [`charts/kubescape-operator/templates/kubescape/deployment.yaml`](diffhunk://#diff-b2d573694275628033f9c8251c96711107d99e5c1a189bdc54fc4bbfc8effd68R206-R209): Updated to mount and use the extra CA certificates if the feature is enabled. [[1]](diffhunk://#diff-b2d573694275628033f9c8251c96711107d99e5c1a189bdc54fc4bbfc8effd68R206-R209) [[2]](diffhunk://#diff-b2d573694275628033f9c8251c96711107d99e5c1a189bdc54fc4bbfc8effd68R225-R229)
* [`charts/kubescape-operator/templates/kubevuln/deployment.yaml`](diffhunk://#diff-f7294729ce6b129a91f13f4ed1b7df6aaab5898ef645730498ad6b331d88d3f9R132-R135): Added logic to mount and use the extra CA certificates when enabled. [[1]](diffhunk://#diff-f7294729ce6b129a91f13f4ed1b7df6aaab5898ef645730498ad6b331d88d3f9R132-R135) [[2]](diffhunk://#diff-f7294729ce6b129a91f13f4ed1b7df6aaab5898ef645730498ad6b331d88d3f9R150-R154)
* [`charts/kubescape-operator/templates/node-agent/daemonset.yaml`](diffhunk://#diff-87cf3c6035cbedc17bdc75a7055fa64e7e38d2e83f4b0a79654a4c37c94f4efdR110-R114): Modified to include the extra CA certificates in the volume mounts if enabled. [[1]](diffhunk://#diff-87cf3c6035cbedc17bdc75a7055fa64e7e38d2e83f4b0a79654a4c37c94f4efdR110-R114) [[2]](diffhunk://#diff-87cf3c6035cbedc17bdc75a7055fa64e7e38d2e83f4b0a79654a4c37c94f4efdR250-R254)
* [`charts/kubescape-operator/templates/operator/deployment.yaml`](diffhunk://#diff-f64af5d3eb479f76bb827eefb0b345664e25457d016772051a4548e3d2840467R146-R149): Included changes to mount and use the extra CA certificates if the feature is enabled. [[1]](diffhunk://#diff-f64af5d3eb479f76bb827eefb0b345664e25457d016772051a4548e3d2840467R146-R149) [[2]](diffhunk://#diff-f64af5d3eb479f76bb827eefb0b345664e25457d016772051a4548e3d2840467R180-R184)
* [`charts/kubescape-operator/templates/synchronizer/deployment.yaml`](diffhunk://#diff-1ce85104708bacb5ffce82a7c0239f8a8766368598c654f4d388f0f6ee5f0addR115-R119): Updated to support mounting and using the extra CA certificates when enabled. [[1]](diffhunk://#diff-1ce85104708bacb5ffce82a7c0239f8a8766368598c654f4d388f0f6ee5f0addR115-R119) [[2]](diffhunk://#diff-1ce85104708bacb5ffce82a7c0239f8a8766368598c654f4d388f0f6ee5f0addR148-R152)

### Documentation Update

* [`charts/kubescape-operator/README.md`](diffhunk://#diff-29301ee79c4acf85dcfdaa8326521bc7676bd383dff72b2e41a08c86b6727327R97-R98): Documented the new `global.extraCaCertificates` configuration options.