### PR TITLE
Replace full folder mount to per file mount of extra CA certificates

### DIFF
--- a/charts/kubescape-operator/templates/_common.tpl
+++ b/charts/kubescape-operator/templates/_common.tpl
@@ -90,11 +90,11 @@ autoUpdater:
 {{- end -}}
 
 {{- define "admission-certificates" -}}
-{{- $svcName := (printf "kubescape-admission-webhook.%s.svc" .Release.Namespace) -}}
+{{- $svcName := (printf "kubescape-admission-webhook.%s.svc" .Values.ksNamespace) -}}
 {{- $ca := dict "Key" "mock-ca-key" "Cert" "mock-ca-cert" -}}
 {{- $cert := dict "Key" "mock-cert-key" "Cert" "mock-cert-cert" -}}
 {{- if not .Values.unittest }}
-  {{- $generatedCA := genCA (printf "*.%s.svc" .Release.Namespace) 1024 -}}
+  {{- $generatedCA := genCA (printf "*.%s.svc" .Values.ksNamespace) 1024 -}}
   {{- $generatedCert := genSignedCert $svcName nil (list $svcName) 1024 $generatedCA -}}
   {{- $_ := set $ca "Key" $generatedCA.Key -}}
   {{- $_ := set $ca "Cert" $generatedCA.Cert -}}

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -209,8 +209,11 @@ spec:
           subPath: ca-certificates.crt
 {{- end }}
 {{- if .Values.global.extraCaCertificates.enabled }}
+    {{- range $key, $value := (lookup "v1" "Secret" .Release.Namespace .Values.global.extraCaCertificates.secretName).data }}
         - name: extra-ca-certificates
-          mountPath: /etc/ssl/certs/
+          mountPath: /etc/ssl/certs/{{ $key }}
+          subPath: {{ $key }}
+    {{- end }}
 {{- end }}
       volumes:
       - name: {{ $components.cloudSecret.name }}

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -209,7 +209,7 @@ spec:
           subPath: ca-certificates.crt
 {{- end }}
 {{- if .Values.global.extraCaCertificates.enabled }}
-    {{- range $key, $value := (lookup "v1" "Secret" .Release.Namespace .Values.global.extraCaCertificates.secretName).data }}
+    {{- range $key, $value := (lookup "v1" "Secret" .Values.ksNamespace .Values.global.extraCaCertificates.secretName).data }}
         - name: extra-ca-certificates
           mountPath: /etc/ssl/certs/{{ $key }}
           subPath: {{ $key }}

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -131,8 +131,11 @@ spec:
               subPath: ca-certificates.crt
 {{- end }}
 {{- if .Values.global.extraCaCertificates.enabled }}
+        {{- range $key, $value := (lookup "v1" "Secret" .Release.Namespace .Values.global.extraCaCertificates.secretName).data }}
             - name: extra-ca-certificates
-              mountPath: /etc/ssl/certs/
+              mountPath: /etc/ssl/certs/{{ $key }}
+              subPath: {{ $key }}
+        {{- end }}
 {{- end }}
       volumes:
         - name: {{ $components.cloudSecret.name }}

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -131,7 +131,7 @@ spec:
               subPath: ca-certificates.crt
 {{- end }}
 {{- if .Values.global.extraCaCertificates.enabled }}
-        {{- range $key, $value := (lookup "v1" "Secret" .Release.Namespace .Values.global.extraCaCertificates.secretName).data }}
+        {{- range $key, $value := (lookup "v1" "Secret" .Values.ksNamespace .Values.global.extraCaCertificates.secretName).data }}
             - name: extra-ca-certificates
               mountPath: /etc/ssl/certs/{{ $key }}
               subPath: {{ $key }}

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -248,7 +248,7 @@ spec:
             subPath: ca-certificates.crt
           {{- end }}
           {{- if .Values.global.extraCaCertificates.enabled }}
-          {{- range $key, $value := (lookup "v1" "Secret" .Release.Namespace .Values.global.extraCaCertificates.secretName).data }}
+          {{- range $key, $value := (lookup "v1" "Secret" .Values.ksNamespace .Values.global.extraCaCertificates.secretName).data }}
           - name: extra-ca-certificates
             mountPath: /etc/ssl/certs/{{ $key }}
             subPath: {{ $key }}

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -248,9 +248,11 @@ spec:
             subPath: ca-certificates.crt
           {{- end }}
           {{- if .Values.global.extraCaCertificates.enabled }}
+          {{- range $key, $value := (lookup "v1" "Secret" .Release.Namespace .Values.global.extraCaCertificates.secretName).data }}
           - name: extra-ca-certificates
-            mountPath: /etc/ssl/certs/
-            subPath: {{ .Values.global.extraCaCertificates.secretName }}
+            mountPath: /etc/ssl/certs/{{ $key }}
+            subPath: {{ $key }}
+          {{- end }}
           {{- end }}
       nodeSelector:
       {{- if .Values.nodeAgent.nodeSelector }}

--- a/charts/kubescape-operator/templates/operator/admission-webhook.yaml
+++ b/charts/kubescape-operator/templates/operator/admission-webhook.yaml
@@ -1,7 +1,7 @@
 {{- $components := fromYaml (include "components" .) }}
 {{- if $components.operator.enabled }}
 {{- if eq .Values.capabilities.admissionController "enable" }}
-{{- $svcName := (printf "kubescape-admission-webhook.%s.svc" .Release.Namespace) -}}
+{{- $svcName := (printf "kubescape-admission-webhook.%s.svc" .Values.ksNamespace) -}}
 {{- $certData := fromYaml (include "admission-certificates" .) -}}
 {{- $ca := $certData.ca -}}
 {{- $cert := $certData.cert -}}

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -144,7 +144,7 @@ spec:
               subPath: ca-certificates.crt
             {{- end }}
             {{- if .Values.global.extraCaCertificates.enabled }}
-            {{- range $key, $value := (lookup "v1" "Secret" .Release.Namespace .Values.global.extraCaCertificates.secretName).data }}
+            {{- range $key, $value := (lookup "v1" "Secret" .Values.ksNamespace .Values.global.extraCaCertificates.secretName).data }}
             - name: extra-ca-certificates
               mountPath: /etc/ssl/certs/{{ $key }}
               subPath: {{ $key }}

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -144,8 +144,11 @@ spec:
               subPath: ca-certificates.crt
             {{- end }}
             {{- if .Values.global.extraCaCertificates.enabled }}
+            {{- range $key, $value := (lookup "v1" "Secret" .Release.Namespace .Values.global.extraCaCertificates.secretName).data }}
             - name: extra-ca-certificates
-              mountPath: /etc/ssl/certs/
+              mountPath: /etc/ssl/certs/{{ $key }}
+              subPath: {{ $key }}
+            {{- end }}
             {{- end }}
             {{- if eq .Values.capabilities.admissionController "enable" }}
             - name: tls-certs

--- a/charts/kubescape-operator/templates/storage/_helpersKubescapeStorage.tpl
+++ b/charts/kubescape-operator/templates/storage/_helpersKubescapeStorage.tpl
@@ -25,9 +25,9 @@ Create the name of the Kubescape Storage Auth Reader RoleBinding to use
 {{- end -}}
 
 {{- define "storage.generateCerts.cert" -}}
-{{- $cn := printf "%s.%s.svc-%s" .Values.storage.name .Release.Namespace (randAlphaNum 10) -}}
+{{- $cn := printf "%s.%s.svc-%s" .Values.storage.name .Values.ksNamespace (randAlphaNum 10) -}}
 {{- $ca := .Values.global.storageCA -}}
-{{- $dnsNames := list (printf "%s.%s.svc" .Values.storage.name .Release.Namespace) (printf "%s.%s.svc.cluster.local" .Values.storage.name .Release.Namespace) -}}
+{{- $dnsNames := list (printf "%s.%s.svc" .Values.storage.name .Values.ksNamespace) (printf "%s.%s.svc.cluster.local" .Values.storage.name .Values.ksNamespace) -}}
 {{- $cert := genSignedCert $cn nil $dnsNames (int .Values.storage.mtls.certificateValidityInDays) $ca -}}
 {{- $cert | toJson -}}
 {{- end -}}

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -113,9 +113,11 @@ spec:
               subPath: ca-certificates.crt
             {{- end }}
             {{- if .Values.global.extraCaCertificates.enabled }}
+            {{- range $key, $value := (lookup "v1" "Secret" .Release.Namespace .Values.global.extraCaCertificates.secretName).data }}
             - name: extra-ca-certificates
-              mountPath: /etc/ssl/certs/
-              subPath: {{ .Values.global.extraCaCertificates.secretName }}
+              mountPath: /etc/ssl/certs/{{ $key }}
+              subPath: {{ $key }}
+            {{- end }}
             {{- end }}
             - name: config
               mountPath: /etc/config/config.json

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -113,7 +113,7 @@ spec:
               subPath: ca-certificates.crt
             {{- end }}
             {{- if .Values.global.extraCaCertificates.enabled }}
-            {{- range $key, $value := (lookup "v1" "Secret" .Release.Namespace .Values.global.extraCaCertificates.secretName).data }}
+            {{- range $key, $value := (lookup "v1" "Secret" .Values.ksNamespace .Values.global.extraCaCertificates.secretName).data }}
             - name: extra-ca-certificates
               mountPath: /etc/ssl/certs/{{ $key }}
               subPath: {{ $key }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2845,7 +2845,7 @@ all capabilities:
         helm.sh/chart: kubescape-operator-1.25.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
-      name: kubescape-admission-webhook.NAMESPACE.svc-kubescape-tls-pair
+      name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
       namespace: kubescape
     type: kubernetes.io/tls
   56: |
@@ -6611,6 +6611,12 @@ default capabilities:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+                - mountPath: /etc/ssl/certs/cert1.pem
+                  name: extra-ca-certificates
+                  subPath: cert1.pem
+                - mountPath: /etc/ssl/certs/cert2.pem
+                  name: extra-ca-certificates
+                  subPath: cert2.pem
           nodeSelector: null
           securityContext:
             fsGroup: 65532
@@ -6624,6 +6630,9 @@ default capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
+            - name: extra-ca-certificates
+              secret:
+                secretName: extra-certificates
             - configMap:
                 items:
                   - key: clusterData
@@ -7298,6 +7307,12 @@ default capabilities:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+                - mountPath: /etc/ssl/certs/cert1.pem
+                  name: extra-ca-certificates
+                  subPath: cert1.pem
+                - mountPath: /etc/ssl/certs/cert2.pem
+                  name: extra-ca-certificates
+                  subPath: cert2.pem
           nodeSelector: null
           securityContext:
             fsGroup: 65532
@@ -7311,6 +7326,9 @@ default capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
+            - name: extra-ca-certificates
+              secret:
+                secretName: extra-certificates
             - emptyDir: {}
               name: tmp-dir
             - emptyDir: {}
@@ -7773,6 +7791,12 @@ default capabilities:
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
+                - mountPath: /etc/ssl/certs/cert1.pem
+                  name: extra-ca-certificates
+                  subPath: cert1.pem
+                - mountPath: /etc/ssl/certs/cert2.pem
+                  name: extra-ca-certificates
+                  subPath: cert2.pem
           hostPID: true
           nodeSelector:
             kubernetes.io/os: linux
@@ -7838,6 +7862,9 @@ default capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
+            - name: extra-ca-certificates
+              secret:
+                secretName: extra-certificates
   36: |
     apiVersion: kubescape.io/v1
     kind: RuntimeRuleAlertBinding
@@ -8292,6 +8319,12 @@ default capabilities:
                   name: config
                   readOnly: true
                   subPath: config.json
+                - mountPath: /etc/ssl/certs/cert1.pem
+                  name: extra-ca-certificates
+                  subPath: cert1.pem
+                - mountPath: /etc/ssl/certs/cert2.pem
+                  name: extra-ca-certificates
+                  subPath: cert2.pem
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
                   subPath: proxy.crt
@@ -8308,6 +8341,9 @@ default capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
+            - name: extra-ca-certificates
+              secret:
+                secretName: extra-certificates
             - emptyDir: {}
               name: tmp-dir
             - configMap:
@@ -10147,6 +10183,12 @@ default capabilities:
                   name: ks-cloud-config
                   readOnly: true
                   subPath: services.json
+                - mountPath: /etc/ssl/certs/cert1.pem
+                  name: extra-ca-certificates
+                  subPath: cert1.pem
+                - mountPath: /etc/ssl/certs/cert2.pem
+                  name: extra-ca-certificates
+                  subPath: cert2.pem
                 - mountPath: /etc/config/config.json
                   name: config
                   readOnly: true
@@ -10167,6 +10209,9 @@ default capabilities:
             - name: proxy-secret
               secret:
                 secretName: kubescape-proxy-certificate
+            - name: extra-ca-certificates
+              secret:
+                secretName: extra-certificates
             - configMap:
                 items:
                   - key: clusterData

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -1,4 +1,20 @@
 suite: Snapshot tests
+kubernetesProvider:
+  scheme:
+    "v1/Secret":
+      gvr:
+        version: v1
+        resource: secrets
+      namespaced: true
+  objects:
+    - kind: Secret
+      apiVersion: v1
+      metadata:
+        name: extra-certificates
+        namespace: kubescape
+      data:
+        cert1.pem: Zm9v
+        cert2.pem: Zm9v
 tests:
   - it: all capabilities
     asserts:
@@ -121,6 +137,9 @@ tests:
       clusterName: kind-kind
       excludeNamespaces: "kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public"
       global:
+        extraCaCertificates:
+          enabled: true
+          secretName: "extra-certificates"
         networkPolicy:
           createEgressRules: true
           enabled: true


### PR DESCRIPTION
This pull request includes changes to the `kubescape-operator` Helm chart templates to improve the handling of extra CA certificates. The main modification involves iterating over the keys in the specified secret and mounting each key as a separate file instead of overriding the whole directory

Changes to improve handling of extra CA certificates:

* [`charts/kubescape-operator/templates/kubescape/deployment.yaml`](diffhunk://#diff-b2d573694275628033f9c8251c96711107d99e5c1a189bdc54fc4bbfc8effd68R212-R216): Added iteration over secret keys to mount each key as a separate file.
* [`charts/kubescape-operator/templates/kubevuln/deployment.yaml`](diffhunk://#diff-f7294729ce6b129a91f13f4ed1b7df6aaab5898ef645730498ad6b331d88d3f9R134-R138): Modified to iterate over secret keys for mounting each key as a separate file.
* [`charts/kubescape-operator/templates/node-agent/daemonset.yaml`](diffhunk://#diff-87cf3c6035cbedc17bdc75a7055fa64e7e38d2e83f4b0a79654a4c37c94f4efdR251-R255): Updated to iterate over secret keys and mount each key individually.
* [`charts/kubescape-operator/templates/operator/deployment.yaml`](diffhunk://#diff-f64af5d3eb479f76bb827eefb0b345664e25457d016772051a4548e3d2840467R147-R151): Changed to iterate over secret keys to mount each key as a separate file.
* [`charts/kubescape-operator/templates/synchronizer/deployment.yaml`](diffhunk://#diff-1ce85104708bacb5ffce82a7c0239f8a8766368598c654f4d388f0f6ee5f0addR116-R120): Revised to iterate over secret keys for mounting each key separately.