### PR TITLE
Enable host sensor configurations

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/configmap.yaml
@@ -24,6 +24,8 @@ data:
         "httpDetectionEnabled": {{ eq .Values.capabilities.httpDetection "enable" }},
         "networkServiceEnabled": {{ eq .Values.capabilities.networkPolicyService "enable" }},
         "malwareDetectionEnabled": {{ eq .Values.capabilities.malwareDetection "enable" }},
+        "hostMalwareSensorEnabled": {{ eq .Values.nodeAgent.config.hostMalwareSensor "enable" }},
+        "hostNetworkSensorEnabled": {{ eq .Values.nodeAgent.config.hostNetworkSensor "enable" }},
         "nodeProfileServiceEnabled": {{ eq .Values.capabilities.nodeProfileService "enable" }},
         "maxImageSize": {{ .Values.kubevuln.config.maxImageSize }},
         "maxSBOMSize": {{ .Values.kubevuln.config.maxSBOMSize }},

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2282,6 +2282,8 @@ all capabilities:
             "httpDetectionEnabled": true,
             "networkServiceEnabled": true,
             "malwareDetectionEnabled": true,
+            "hostMalwareSensorEnabled": false,
+            "hostNetworkSensorEnabled": false,
             "nodeProfileServiceEnabled": true,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
@@ -2379,7 +2381,7 @@ all capabilities:
           annotations:
             checksum/cloud-config: d6f711c907ac404868d836f559972d6b753ab085a3cf4ed47a079db75cd206fa
             checksum/cloud-secret: cf2e73d4ff0ce943730b3ed5bd4740f0bd8c4386e5843870f51c302b41df8da9
-            checksum/node-agent-config: a466fa221874bba84fb7d2397ad6f171549ae53c041c035c45da114214158585
+            checksum/node-agent-config: dce50ffdaefa9085520f1ffa39bb559a8ebf90721c765aef9414dcb244a512bf
             checksum/proxy-config: 3669c08e51ef779cd00a107f19592b34195c3ebdb60bedaf8ebf1491a3f2a747
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -7609,6 +7611,8 @@ default capabilities:
             "httpDetectionEnabled": false,
             "networkServiceEnabled": true,
             "malwareDetectionEnabled": false,
+            "hostMalwareSensorEnabled": false,
+            "hostNetworkSensorEnabled": false,
             "nodeProfileServiceEnabled": false,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
@@ -7669,7 +7673,7 @@ default capabilities:
           annotations:
             checksum/cloud-config: 678e2b8c5497a211b7bc4ac427a61762f142ef6ddb5480f24c6ffe552f874eee
             checksum/cloud-secret: cf2e73d4ff0ce943730b3ed5bd4740f0bd8c4386e5843870f51c302b41df8da9
-            checksum/node-agent-config: b63c41145cab22dc8940dbaee9ed1c00273c9fd71c3a865274186244437de025
+            checksum/node-agent-config: 76fceafb522a36b967bccf444e302c5fed634dc2aa81d23eaeed3411720a20b9
             checksum/proxy-config: 3669c08e51ef779cd00a107f19592b34195c3ebdb60bedaf8ebf1491a3f2a747
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -11832,6 +11836,8 @@ disable otel:
             "httpDetectionEnabled": false,
             "networkServiceEnabled": true,
             "malwareDetectionEnabled": false,
+            "hostMalwareSensorEnabled": false,
+            "hostNetworkSensorEnabled": false,
             "nodeProfileServiceEnabled": false,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
@@ -11892,7 +11898,7 @@ disable otel:
           annotations:
             checksum/cloud-config: def218dd594c1e48747f476d985fab8a3abdca0a14402e4dee0675f6fc4b393f
             checksum/cloud-secret: cf2e73d4ff0ce943730b3ed5bd4740f0bd8c4386e5843870f51c302b41df8da9
-            checksum/node-agent-config: b63c41145cab22dc8940dbaee9ed1c00273c9fd71c3a865274186244437de025
+            checksum/node-agent-config: 76fceafb522a36b967bccf444e302c5fed634dc2aa81d23eaeed3411720a20b9
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -15421,6 +15427,8 @@ minimal capabilities:
             "httpDetectionEnabled": false,
             "networkServiceEnabled": true,
             "malwareDetectionEnabled": false,
+            "hostMalwareSensorEnabled": false,
+            "hostNetworkSensorEnabled": false,
             "nodeProfileServiceEnabled": false,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
@@ -15479,7 +15487,7 @@ minimal capabilities:
           annotations:
             checksum/cloud-config: 9e8579a8978574318fbe7cbea9a471f1a26154673dfc8384fb7bab97fec56852
             checksum/cloud-secret: f1356b6dba8ba4a01197f4030346928c33c7dab7b123a2aecaffb0630352929c
-            checksum/node-agent-config: b658595793549f32aed093f8d72f18be9ec60174d15fabc8429674c14a96b12a
+            checksum/node-agent-config: a7d1aa7e114c06c5cc185571f42a84a25f6c50d0c95ab89e3226b2d57cfab6ae
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -466,6 +466,8 @@ nodeAgent:
     stdoutExporter: true
     syslogExporterURL: ""
     skipKernelVersionCheck: false
+    hostMalwareSensor: disable
+    hostNetworkSensor: disable
 
   # prometheus (operator) service monitor
   serviceMonitor:


### PR DESCRIPTION
This pull request includes updates to the `kubescape-operator` to add new configuration options for host sensors and corresponding changes to the test snapshots to reflect these new options.

### Configuration updates:
* Added `hostMalwareSensor` and `hostNetworkSensor` configuration options to `nodeAgent` in `values.yaml`.
* Updated `configmap.yaml` to include the new configuration options for `hostMalwareSensor` and `hostNetworkSensor`.

### Test snapshot updates:
* Updated test snapshots in `snapshot_test.yaml.snap` to include the new configuration options 