### PR TITLE
disable nodeSbomGeneration

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.26.0
+version: 1.26.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.26.0
+appVersion: 1.26.1
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -1,6 +1,6 @@
 # Kubescape Operator
 
-![Version: 1.26.0](https://img.shields.io/badge/Version-1.26.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.26.0](https://img.shields.io/badge/AppVersion-v1.26.0-informational?style=flat-square)
+![Version: 1.26.1](https://img.shields.io/badge/Version-1.26.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.26.1](https://img.shields.io/badge/AppVersion-v1.26.1-informational?style=flat-square)
 
 [Kubescape operator documentation](https://kubescape.io/docs/install-operator/)
 [Troubleshooting guide](https://hub.armosec.io/docs/installation-troubleshooting#3-the-kubescape-pod-restarted)

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 all capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.26.0.
+      Thank you for installing kubescape-operator version 1.26.1.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -34,8 +34,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -52,8 +52,8 @@ all capabilities:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.26.0
-                helm.sh/chart: kubescape-operator-1.26.0
+                app.kubernetes.io/version: 1.26.1
+                helm.sh/chart: kubescape-operator-1.26.1
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -108,8 +108,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -162,8 +162,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -186,8 +186,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -211,8 +211,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -230,8 +230,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -282,8 +282,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -308,8 +308,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -327,8 +327,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -348,8 +348,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -367,8 +367,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -383,9 +383,9 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
+        app.kubernetes.io/version: 1.26.1
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.26.0
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -403,9 +403,9 @@ all capabilities:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.26.0
+                app.kubernetes.io/version: 1.26.1
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.26.0
+                helm.sh/chart: kubescape-operator-1.26.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -453,8 +453,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -481,8 +481,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -520,8 +520,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -554,8 +554,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -578,8 +578,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -602,8 +602,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -629,8 +629,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -647,8 +647,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -664,9 +664,9 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
+        app.kubernetes.io/version: 1.26.1
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.26.0
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -684,9 +684,9 @@ all capabilities:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.26.0
+                app.kubernetes.io/version: 1.26.1
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.26.0
+                helm.sh/chart: kubescape-operator-1.26.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -744,8 +744,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -805,8 +805,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1055,8 +1055,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1078,8 +1078,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1111,8 +1111,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -1270,11 +1270,11 @@ all capabilities:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.26.0
+            helm.sh/chart: kubescape-operator-1.26.1
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.26.0"
+            app.kubernetes.io/version: "1.26.1"
             app.kubernetes.io/managed-by: Helm
             app: host-scanner
             tier: ks-control-plane
@@ -1288,11 +1288,11 @@ all capabilities:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.26.0
+                helm.sh/chart: kubescape-operator-1.26.1
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.26.0"
+                app.kubernetes.io/version: "1.26.1"
                 app.kubernetes.io/managed-by: Helm
                 app: host-scanner
                 tier: ks-control-plane
@@ -1380,8 +1380,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1397,8 +1397,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1480,8 +1480,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1509,8 +1509,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1533,8 +1533,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -1557,8 +1557,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1585,8 +1585,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1601,8 +1601,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -1633,8 +1633,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1650,9 +1650,9 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
+        app.kubernetes.io/version: 1.26.1
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.26.0
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1670,9 +1670,9 @@ all capabilities:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.26.0
+                app.kubernetes.io/version: 1.26.1
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.26.0
+                helm.sh/chart: kubescape-operator-1.26.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -1730,8 +1730,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -1791,8 +1791,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1829,8 +1829,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1852,8 +1852,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1881,8 +1881,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -2014,8 +2014,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2080,8 +2080,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -2104,8 +2104,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2131,8 +2131,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2147,8 +2147,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2269,8 +2269,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2320,8 +2320,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2374,8 +2374,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2401,8 +2401,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -2637,8 +2637,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -2703,8 +2703,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2766,8 +2766,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -2790,8 +2790,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2816,8 +2816,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2832,8 +2832,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -2860,8 +2860,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -2877,8 +2877,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -2923,8 +2923,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3036,8 +3036,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3068,8 +3068,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3085,8 +3085,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3120,8 +3120,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -3132,7 +3132,7 @@ all capabilities:
           containers:
             - env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.26.0
+                  value: kubescape-operator-1.26.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -3347,8 +3347,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3429,8 +3429,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3446,8 +3446,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3613,8 +3613,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3630,8 +3630,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3672,8 +3672,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3696,8 +3696,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -3720,8 +3720,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3747,8 +3747,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3765,8 +3765,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3782,8 +3782,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3813,8 +3813,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -3899,8 +3899,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -3967,8 +3967,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector-scc
@@ -3991,8 +3991,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -4022,8 +4022,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -4038,8 +4038,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4065,8 +4065,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4088,8 +4088,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4112,8 +4112,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -4191,8 +4191,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4219,8 +4219,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4246,8 +4246,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4262,8 +4262,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4297,8 +4297,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -4318,8 +4318,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4334,8 +4334,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             otel: enabled
             tier: ks-control-plane
@@ -4417,8 +4417,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4448,8 +4448,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4476,8 +4476,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4492,8 +4492,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -4516,8 +4516,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4580,8 +4580,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -4603,8 +4603,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4627,8 +4627,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4653,8 +4653,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape-storage
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -4740,8 +4740,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4804,8 +4804,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -4826,8 +4826,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -4850,8 +4850,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -4874,8 +4874,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4899,8 +4899,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4915,8 +4915,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5140,8 +5140,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5411,8 +5411,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5428,8 +5428,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5458,8 +5458,8 @@ all capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -5472,7 +5472,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.26.0
+                  value: kubescape-operator-1.26.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -5582,8 +5582,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5659,8 +5659,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5701,8 +5701,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5725,8 +5725,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -5749,8 +5749,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5776,8 +5776,8 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5785,7 +5785,7 @@ all capabilities:
 default capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.26.0.
+      Thank you for installing kubescape-operator version 1.26.1.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -5819,8 +5819,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -5871,8 +5871,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -5897,8 +5897,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5917,8 +5917,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5936,8 +5936,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -5952,8 +5952,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5980,8 +5980,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -6017,8 +6017,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -6051,8 +6051,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -6079,8 +6079,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6096,9 +6096,9 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
+        app.kubernetes.io/version: 1.26.1
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.26.0
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6116,9 +6116,9 @@ default capabilities:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.26.0
+                app.kubernetes.io/version: 1.26.1
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.26.0
+                helm.sh/chart: kubescape-operator-1.26.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -6174,8 +6174,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -6229,8 +6229,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6479,8 +6479,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6502,8 +6502,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6535,8 +6535,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -6691,11 +6691,11 @@ default capabilities:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.26.0
+            helm.sh/chart: kubescape-operator-1.26.1
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.26.0"
+            app.kubernetes.io/version: "1.26.1"
             app.kubernetes.io/managed-by: Helm
             app: host-scanner
             tier: ks-control-plane
@@ -6709,11 +6709,11 @@ default capabilities:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.26.0
+                helm.sh/chart: kubescape-operator-1.26.1
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.26.0"
+                app.kubernetes.io/version: "1.26.1"
                 app.kubernetes.io/managed-by: Helm
                 app: host-scanner
                 tier: ks-control-plane
@@ -6799,8 +6799,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6816,8 +6816,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6888,8 +6888,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6917,8 +6917,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6941,8 +6941,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6969,8 +6969,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6985,8 +6985,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -7017,8 +7017,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7034,9 +7034,9 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
+        app.kubernetes.io/version: 1.26.1
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.26.0
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7054,9 +7054,9 @@ default capabilities:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.26.0
+                app.kubernetes.io/version: 1.26.1
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.26.0
+                helm.sh/chart: kubescape-operator-1.26.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -7112,8 +7112,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -7167,8 +7167,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7205,8 +7205,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7228,8 +7228,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7257,8 +7257,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -7387,8 +7387,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7447,8 +7447,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7474,8 +7474,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7490,8 +7490,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7612,8 +7612,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7663,8 +7663,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7680,8 +7680,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7707,8 +7707,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -7911,8 +7911,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -7983,8 +7983,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8035,8 +8035,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8061,8 +8061,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8077,8 +8077,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8190,8 +8190,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8222,8 +8222,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8239,8 +8239,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8274,8 +8274,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -8286,7 +8286,7 @@ default capabilities:
           containers:
             - env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.26.0
+                  value: kubescape-operator-1.26.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -8487,8 +8487,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8567,8 +8567,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8584,8 +8584,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8738,8 +8738,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8755,8 +8755,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8797,8 +8797,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8821,8 +8821,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8848,8 +8848,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8866,8 +8866,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8883,8 +8883,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8914,8 +8914,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -8994,8 +8994,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9056,8 +9056,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9087,8 +9087,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9109,8 +9109,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -9130,8 +9130,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9146,8 +9146,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             otel: enabled
             tier: ks-control-plane
@@ -9223,8 +9223,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9254,8 +9254,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9282,8 +9282,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9298,8 +9298,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -9327,8 +9327,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -9344,8 +9344,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9408,8 +9408,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -9431,8 +9431,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9455,8 +9455,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9481,8 +9481,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape-storage
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -9580,8 +9580,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9633,8 +9633,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -9655,8 +9655,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -9679,8 +9679,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9704,8 +9704,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9720,8 +9720,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -9885,8 +9885,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10150,8 +10150,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10167,8 +10167,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10197,8 +10197,8 @@ default capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -10211,7 +10211,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.26.0
+                  value: kubescape-operator-1.26.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -10318,8 +10318,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10384,8 +10384,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10426,8 +10426,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10450,8 +10450,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10477,8 +10477,8 @@ default capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10486,7 +10486,7 @@ default capabilities:
 disable otel:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.26.0.
+      Thank you for installing kubescape-operator version 1.26.1.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -10520,8 +10520,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -10571,8 +10571,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -10597,8 +10597,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10617,8 +10617,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10636,8 +10636,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -10654,8 +10654,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10671,9 +10671,9 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
+        app.kubernetes.io/version: 1.26.1
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.26.0
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10691,9 +10691,9 @@ disable otel:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.26.0
+                app.kubernetes.io/version: 1.26.1
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.26.0
+                helm.sh/chart: kubescape-operator-1.26.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -10749,8 +10749,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -10999,8 +10999,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11022,8 +11022,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11054,8 +11054,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -11195,11 +11195,11 @@ disable otel:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.26.0
+            helm.sh/chart: kubescape-operator-1.26.1
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.26.0"
+            app.kubernetes.io/version: "1.26.1"
             app.kubernetes.io/managed-by: Helm
             app: host-scanner
             tier: ks-control-plane
@@ -11213,11 +11213,11 @@ disable otel:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.26.0
+                helm.sh/chart: kubescape-operator-1.26.1
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.26.0"
+                app.kubernetes.io/version: "1.26.1"
                 app.kubernetes.io/managed-by: Helm
                 app: host-scanner
                 tier: ks-control-plane
@@ -11303,8 +11303,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11320,8 +11320,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11349,8 +11349,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11373,8 +11373,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11401,8 +11401,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11419,8 +11419,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11436,9 +11436,9 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
+        app.kubernetes.io/version: 1.26.1
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.26.0
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11456,9 +11456,9 @@ disable otel:
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/version: 1.26.0
+                app.kubernetes.io/version: 1.26.1
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.26.0
+                helm.sh/chart: kubescape-operator-1.26.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11514,8 +11514,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11552,8 +11552,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11575,8 +11575,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11603,8 +11603,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -11718,8 +11718,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11745,8 +11745,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11761,8 +11761,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -11883,8 +11883,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -11934,8 +11934,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11951,8 +11951,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11977,8 +11977,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -12166,8 +12166,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12192,8 +12192,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12208,8 +12208,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -12236,8 +12236,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -12253,8 +12253,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -12299,8 +12299,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12412,8 +12412,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12444,8 +12444,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12461,8 +12461,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12495,8 +12495,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -12507,7 +12507,7 @@ disable otel:
           containers:
             - env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.26.0
+                  value: kubescape-operator-1.26.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -12702,8 +12702,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12782,8 +12782,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12862,8 +12862,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12879,8 +12879,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12921,8 +12921,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12945,8 +12945,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12972,8 +12972,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13049,8 +13049,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13066,8 +13066,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13096,8 +13096,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -13170,8 +13170,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -13201,8 +13201,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -13221,8 +13221,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13237,8 +13237,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             otel: enabled
             tier: ks-control-plane
@@ -13308,8 +13308,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13339,8 +13339,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13367,8 +13367,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13383,8 +13383,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -13412,8 +13412,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -13429,8 +13429,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13493,8 +13493,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -13516,8 +13516,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13540,8 +13540,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13566,8 +13566,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape-storage
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -13666,8 +13666,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -13688,8 +13688,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -13712,8 +13712,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13737,8 +13737,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13753,8 +13753,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -13918,8 +13918,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14183,8 +14183,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14200,8 +14200,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14229,8 +14229,8 @@ disable otel:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -14243,7 +14243,7 @@ disable otel:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.26.0
+                  value: kubescape-operator-1.26.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -14335,8 +14335,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14377,8 +14377,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14401,8 +14401,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14428,8 +14428,8 @@ disable otel:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14437,7 +14437,7 @@ disable otel:
 minimal capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.26.0.
+      Thank you for installing kubescape-operator version 1.26.1.
 
 
 
@@ -14463,8 +14463,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -14506,8 +14506,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -14532,8 +14532,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14552,8 +14552,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14571,8 +14571,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -14587,8 +14587,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -14837,8 +14837,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -14860,8 +14860,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14892,8 +14892,8 @@ minimal capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -15029,11 +15029,11 @@ minimal capabilities:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.26.0
+            helm.sh/chart: kubescape-operator-1.26.1
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.26.0"
+            app.kubernetes.io/version: "1.26.1"
             app.kubernetes.io/managed-by: Helm
             app: host-scanner
             tier: ks-control-plane
@@ -15047,11 +15047,11 @@ minimal capabilities:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.26.0
+                helm.sh/chart: kubescape-operator-1.26.1
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.26.0"
+                app.kubernetes.io/version: "1.26.1"
                 app.kubernetes.io/managed-by: Helm
                 app: host-scanner
                 tier: ks-control-plane
@@ -15137,8 +15137,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15154,8 +15154,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15183,8 +15183,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15207,8 +15207,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15235,8 +15235,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15251,8 +15251,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15289,8 +15289,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15312,8 +15312,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15340,8 +15340,8 @@ minimal capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -15453,8 +15453,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15480,8 +15480,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15496,8 +15496,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -15618,8 +15618,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -15667,8 +15667,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15684,8 +15684,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15710,8 +15710,8 @@ minimal capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -15897,8 +15897,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -15923,8 +15923,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -15939,8 +15939,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -15967,8 +15967,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -15984,8 +15984,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -16030,8 +16030,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16143,8 +16143,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16174,8 +16174,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16191,8 +16191,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16225,8 +16225,8 @@ minimal capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -16237,7 +16237,7 @@ minimal capabilities:
           containers:
             - env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.26.0
+                  value: kubescape-operator-1.26.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -16426,8 +16426,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16506,8 +16506,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16586,8 +16586,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16603,8 +16603,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16645,8 +16645,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16669,8 +16669,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16696,8 +16696,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16714,8 +16714,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16731,8 +16731,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16761,8 +16761,8 @@ minimal capabilities:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16835,8 +16835,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -16866,8 +16866,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -16882,8 +16882,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -16911,8 +16911,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -16928,8 +16928,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -16992,8 +16992,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -17015,8 +17015,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17039,8 +17039,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17065,8 +17065,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape-storage
-            app.kubernetes.io/version: 1.26.0
-            helm.sh/chart: kubescape-operator-1.26.0
+            app.kubernetes.io/version: 1.26.1
+            helm.sh/chart: kubescape-operator-1.26.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -17161,8 +17161,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape-storage
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -17183,8 +17183,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -17207,8 +17207,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17232,8 +17232,8 @@ minimal capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17259,8 +17259,8 @@ with multiple private registry credentials:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets
@@ -17295,8 +17295,8 @@ with single private registry credentials:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/version: 1.26.0
-        helm.sh/chart: kubescape-operator-1.26.0
+        app.kubernetes.io/version: 1.26.1
+        helm.sh/chart: kubescape-operator-1.26.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -5884,7 +5884,7 @@ default capabilities:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"disable","autoUpgrading":"disable","configurationScan":"enable","httpDetection":"disable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","seccompProfileService":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"disable","autoUpgrading":"disable","configurationScan":"enable","httpDetection":"disable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"disable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","seccompProfileService":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -7641,7 +7641,7 @@ default capabilities:
             "nodeProfileServiceEnabled": false,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
-            "sbomGenerationEnabled": true,
+            "sbomGenerationEnabled": false,
             "seccompServiceEnabled": true,
             "initialDelay": "2m",
             "updateDataPeriod": "10m",
@@ -7698,7 +7698,7 @@ default capabilities:
           annotations:
             checksum/cloud-config: 678e2b8c5497a211b7bc4ac427a61762f142ef6ddb5480f24c6ffe552f874eee
             checksum/cloud-secret: cf2e73d4ff0ce943730b3ed5bd4740f0bd8c4386e5843870f51c302b41df8da9
-            checksum/node-agent-config: c6c6854af7a7457e50553cc36f9ec990c62c76526b7dd97bee7f8bb1f32ba9ad
+            checksum/node-agent-config: c8c5127ec7d8a8cc31a16746bd69c847812be2d76e4f41e827d51aa99682d067
             checksum/proxy-config: 3669c08e51ef779cd00a107f19592b34195c3ebdb60bedaf8ebf1491a3f2a747
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -8262,7 +8262,7 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 382e83556a71673e7d391fc49157f4400bb4d6ac28a947ebb761ab721c9c230f
+            checksum/capabilities-config: a3884b3485c43ed1603dca5d383c5da264de1a0631add04eced7efa580b3850d
             checksum/cloud-config: 678e2b8c5497a211b7bc4ac427a61762f142ef6ddb5480f24c6ffe552f874eee
             checksum/cloud-secret: cf2e73d4ff0ce943730b3ed5bd4740f0bd8c4386e5843870f51c302b41df8da9
             checksum/matching-rules-config: 4244067153661f0c2577cba49b0dba63db5f77acf9904663ca06610953f55e17
@@ -10584,7 +10584,7 @@ disable otel:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","httpDetection":"disable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","seccompProfileService":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","httpDetection":"disable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"disable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","seccompProfileService":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -11912,7 +11912,7 @@ disable otel:
             "nodeProfileServiceEnabled": false,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
-            "sbomGenerationEnabled": true,
+            "sbomGenerationEnabled": false,
             "seccompServiceEnabled": true,
             "initialDelay": "2m",
             "updateDataPeriod": "10m",
@@ -11969,7 +11969,7 @@ disable otel:
           annotations:
             checksum/cloud-config: def218dd594c1e48747f476d985fab8a3abdca0a14402e4dee0675f6fc4b393f
             checksum/cloud-secret: cf2e73d4ff0ce943730b3ed5bd4740f0bd8c4386e5843870f51c302b41df8da9
-            checksum/node-agent-config: c6c6854af7a7457e50553cc36f9ec990c62c76526b7dd97bee7f8bb1f32ba9ad
+            checksum/node-agent-config: c8c5127ec7d8a8cc31a16746bd69c847812be2d76e4f41e827d51aa99682d067
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -12484,7 +12484,7 @@ disable otel:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: b8b930f582308c710402d0eaf519424dcded098c7483afb5dfae1e7ca69f5e87
+            checksum/capabilities-config: 806214dce394bb3ee2ca274a5f1cdc4de2197275e738cdedd6cf173f819adb16
             checksum/cloud-config: def218dd594c1e48747f476d985fab8a3abdca0a14402e4dee0675f6fc4b393f
             checksum/cloud-secret: cf2e73d4ff0ce943730b3ed5bd4740f0bd8c4386e5843870f51c302b41df8da9
             checksum/matching-rules-config: 4244067153661f0c2577cba49b0dba63db5f77acf9904663ca06610953f55e17
@@ -14519,7 +14519,7 @@ minimal capabilities:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","httpDetection":"disable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","seccompProfileService":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","httpDetection":"disable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"disable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","seccompProfileService":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":false},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":false},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
           "configurations":{"otelUrl":"otelCollector:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -15647,7 +15647,7 @@ minimal capabilities:
             "nodeProfileServiceEnabled": false,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
-            "sbomGenerationEnabled": true,
+            "sbomGenerationEnabled": false,
             "seccompServiceEnabled": true,
             "initialDelay": "2m",
             "updateDataPeriod": "10m",
@@ -15702,7 +15702,7 @@ minimal capabilities:
           annotations:
             checksum/cloud-config: 9e8579a8978574318fbe7cbea9a471f1a26154673dfc8384fb7bab97fec56852
             checksum/cloud-secret: f1356b6dba8ba4a01197f4030346928c33c7dab7b123a2aecaffb0630352929c
-            checksum/node-agent-config: 5c04a7da679bba531614e064ab1b48367089278cb1093d6d56cbfec695e385f9
+            checksum/node-agent-config: 9d1c483009c0bc0377bbac6dae855a763db8cef8618685a4a551b389481ddd4f
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -16214,7 +16214,7 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 6ebaa02fce75e1d6a6607beb655b5dcbfafb604d9497824381552f36fa4b5a52
+            checksum/capabilities-config: 367b896404dfaaa375df394d55af1f4e951f3a71e82dc004bf0ac271b8b6d558
             checksum/cloud-config: 9e8579a8978574318fbe7cbea9a471f1a26154673dfc8384fb7bab97fec56852
             checksum/cloud-secret: f1356b6dba8ba4a01197f4030346928c33c7dab7b123a2aecaffb0630352929c
             checksum/matching-rules-config: 4244067153661f0c2577cba49b0dba63db5f77acf9904663ca06610953f55e17

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -83,7 +83,7 @@ capabilities:
 
   # ====== Image vulnerabilities scanning related capabilities ======
   #
-  nodeSbomGeneration: enable  # Warning: When disabled along with enableClusterWideSecretAccess: false, vulnerability scanning capabilities will be limited
+  nodeSbomGeneration: disable  # Warning: When disabled along with enableClusterWideSecretAccess: false, vulnerability scanning capabilities will be limited
   vulnerabilityScan: enable
   relevancy: enable
   # Generate VEX documents alongside the image vulnerabilities report (experimental)


### PR DESCRIPTION
## Overview

* Vulnerability scanning capability was broken in recent version, disabling `nodeSbomGeneration` by default until it is fixed