### PR TITLE
fix operator network policy for admission controller port

### DIFF
--- a/charts/kubescape-operator/templates/operator/networkpolicy.yaml
+++ b/charts/kubescape-operator/templates/operator/networkpolicy.yaml
@@ -45,7 +45,6 @@ spec:
 {{ tpl (.Files.Get "assets/common-egress-rules.yaml") . | indent 4 }}
   {{- end }}
   ingress:
-    
     {{- if eq .Values.capabilities.admissionController "enable" }}
     - ports:
       - port: admission-port

--- a/charts/kubescape-operator/templates/operator/networkpolicy.yaml
+++ b/charts/kubescape-operator/templates/operator/networkpolicy.yaml
@@ -45,6 +45,12 @@ spec:
 {{ tpl (.Files.Get "assets/common-egress-rules.yaml") . | indent 4 }}
   {{- end }}
   ingress:
+    
+    {{- if eq .Values.capabilities.admissionController "enable" }}
+    - ports:
+      - port: admission-port
+        protocol: TCP
+    {{- end }}
     - from:
         - podSelector:
             matchLabels:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -3498,6 +3498,9 @@ all capabilities:
             - ipBlock:
                 cidr: 1.1.1.1/32
       ingress:
+        - ports:
+            - port: admission-port
+              protocol: TCP
         - from:
             - podSelector:
                 matchLabels:


### PR DESCRIPTION
## Overview

Operator's network policy was missing an ingress rule for admission controller port.