### PR TITLE
Configurable storage port

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.27.3
+version: 1.27.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.27.3
+appVersion: 1.27.4
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -51,11 +51,13 @@ spec:
           runAsNonRoot: true
         livenessProbe:
           tcpSocket:
-            port: 8443
+            port: {{ .Values.storage.serverPort }}
         readinessProbe:
           tcpSocket:
-            port: 8443
+            port: {{ .Values.storage.serverPort }}
         env:
+          - name: "SERVER_BIND_PORT"
+            value: "{{ .Values.storage.serverPort }}"
           - name: "CLEANUP_INTERVAL"
             value: "{{ .Values.storage.cleanupInterval }}"
           - name: GOMEMLIMIT

--- a/charts/kubescape-operator/templates/storage/service.yaml
+++ b/charts/kubescape-operator/templates/storage/service.yaml
@@ -11,7 +11,8 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 8443
+    targetPort: {{ .Values.storage.serverPort }}
+    name: https
   selector:
     {{- include "kubescape-operator.selectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name) | nindent 6 }}
 {{- end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -4541,6 +4541,8 @@ all capabilities:
           affinity: null
           containers:
             - env:
+                - name: SERVER_BIND_PORT
+                  value: "8443"
                 - name: CLEANUP_INTERVAL
                   value: 6h
                 - name: GOMEMLIMIT
@@ -4559,7 +4561,7 @@ all capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.172
+              image: quay.io/kubescape/storage:v0.0.175
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 tcpSocket:
@@ -4764,7 +4766,8 @@ all capabilities:
       namespace: kubescape
     spec:
       ports:
-        - port: 443
+        - name: https
+          port: 443
           protocol: TCP
           targetPort: 8443
       selector:
@@ -9586,6 +9589,8 @@ default capabilities:
           affinity: null
           containers:
             - env:
+                - name: SERVER_BIND_PORT
+                  value: "8443"
                 - name: CLEANUP_INTERVAL
                   value: 6h
                 - name: GOMEMLIMIT
@@ -9617,7 +9622,7 @@ default capabilities:
                   value: otel-collector:4318
                 - name: DISABLE_VIRTUAL_CRDS
                   value: "true"
-              image: quay.io/kubescape/storage:v0.0.172
+              image: quay.io/kubescape/storage:v0.0.175
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 tcpSocket:
@@ -9789,7 +9794,8 @@ default capabilities:
       namespace: kubescape
     spec:
       ports:
-        - port: 443
+        - name: https
+          port: 443
           protocol: TCP
           targetPort: 8443
       selector:
@@ -13812,6 +13818,8 @@ disable otel:
           affinity: null
           containers:
             - env:
+                - name: SERVER_BIND_PORT
+                  value: "8443"
                 - name: CLEANUP_INTERVAL
                   value: 6h
                 - name: GOMEMLIMIT
@@ -13843,7 +13851,7 @@ disable otel:
                   value: otel-collector:4318
                 - name: DISABLE_VIRTUAL_CRDS
                   value: "true"
-              image: quay.io/kubescape/storage:v0.0.172
+              image: quay.io/kubescape/storage:v0.0.175
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 tcpSocket:
@@ -13962,7 +13970,8 @@ disable otel:
       namespace: kubescape
     spec:
       ports:
-        - port: 443
+        - name: https
+          port: 443
           protocol: TCP
           targetPort: 8443
       selector:
@@ -17223,6 +17232,8 @@ minimal capabilities:
           affinity: null
           containers:
             - env:
+                - name: SERVER_BIND_PORT
+                  value: "8443"
                 - name: CLEANUP_INTERVAL
                   value: 6h
                 - name: GOMEMLIMIT
@@ -17247,7 +17258,7 @@ minimal capabilities:
                   value: /etc/storage-ca-certificates/tls.key
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.172
+              image: quay.io/kubescape/storage:v0.0.175
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 tcpSocket:
@@ -17364,7 +17375,8 @@ minimal capabilities:
       namespace: kubescape
     spec:
       ports:
-        - port: 443
+        - name: https
+          port: 443
           protocol: TCP
           targetPort: 8443
       selector:
@@ -19811,6 +19823,8 @@ relevancy only:
           affinity: null
           containers:
             - env:
+                - name: SERVER_BIND_PORT
+                  value: "8443"
                 - name: CLEANUP_INTERVAL
                   value: 6h
                 - name: GOMEMLIMIT
@@ -19835,7 +19849,7 @@ relevancy only:
                   value: /etc/storage-ca-certificates/tls.key
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.172
+              image: quay.io/kubescape/storage:v0.0.175
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 tcpSocket:
@@ -19952,7 +19966,8 @@ relevancy only:
       namespace: kubescape
     spec:
       ports:
-        - port: 443
+        - name: https
+          port: 443
           protocol: TCP
           targetPort: 8443
       selector:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 all capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.27.3.
+      Thank you for installing kubescape-operator version 1.27.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -35,8 +35,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -54,8 +54,8 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.3
-                helm.sh/chart: kubescape-operator-1.27.3
+                app.kubernetes.io/version: 1.27.4
+                helm.sh/chart: kubescape-operator-1.27.4
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -113,8 +113,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -168,8 +168,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -193,8 +193,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -219,8 +219,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -239,8 +239,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -292,8 +292,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -319,8 +319,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -339,8 +339,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -361,8 +361,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -381,8 +381,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -398,9 +398,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
+        app.kubernetes.io/version: 1.27.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.27.3
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -419,9 +419,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.3
+                app.kubernetes.io/version: 1.27.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.27.3
+                helm.sh/chart: kubescape-operator-1.27.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -474,8 +474,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -503,8 +503,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -547,8 +547,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -582,8 +582,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -607,8 +607,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -632,8 +632,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -660,8 +660,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -679,8 +679,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -697,9 +697,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
+        app.kubernetes.io/version: 1.27.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.27.3
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -718,9 +718,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.3
+                app.kubernetes.io/version: 1.27.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.27.3
+                helm.sh/chart: kubescape-operator-1.27.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -783,8 +783,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -845,8 +845,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1096,8 +1096,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1120,8 +1120,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1154,8 +1154,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1312,11 +1312,11 @@ all capabilities:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.27.3
+            helm.sh/chart: kubescape-operator-1.27.4
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.27.3"
+            app.kubernetes.io/version: "1.27.4"
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: kubescape
             app: host-scanner
@@ -1331,11 +1331,11 @@ all capabilities:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.27.3
+                helm.sh/chart: kubescape-operator-1.27.4
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.27.3"
+                app.kubernetes.io/version: "1.27.4"
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/part-of: kubescape
                 app: host-scanner
@@ -1421,8 +1421,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1439,8 +1439,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1523,8 +1523,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1553,8 +1553,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1578,8 +1578,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -1603,8 +1603,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1632,8 +1632,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1649,8 +1649,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -1682,8 +1682,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1700,9 +1700,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
+        app.kubernetes.io/version: 1.27.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.27.3
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1721,9 +1721,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.3
+                app.kubernetes.io/version: 1.27.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.27.3
+                helm.sh/chart: kubescape-operator-1.27.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -1786,8 +1786,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -1848,8 +1848,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1888,8 +1888,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1912,8 +1912,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1942,8 +1942,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -2075,8 +2075,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2142,8 +2142,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -2167,8 +2167,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2195,8 +2195,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2212,8 +2212,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2333,8 +2333,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2387,8 +2387,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2442,8 +2442,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2469,8 +2469,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -2713,8 +2713,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -2792,8 +2792,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2856,8 +2856,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -2881,8 +2881,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2908,8 +2908,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2925,8 +2925,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -2954,8 +2954,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -2972,8 +2972,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -3019,8 +3019,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3133,8 +3133,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3166,8 +3166,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3184,8 +3184,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3220,8 +3220,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -3231,7 +3231,7 @@ all capabilities:
           containers:
             - env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.3
+                  value: kubescape-operator-1.27.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -3456,8 +3456,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3543,8 +3543,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3561,8 +3561,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3736,8 +3736,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3754,8 +3754,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3797,8 +3797,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3822,8 +3822,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -3847,8 +3847,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3875,8 +3875,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3892,8 +3892,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -3920,8 +3920,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -3944,8 +3944,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -3969,8 +3969,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -4054,8 +4054,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4083,8 +4083,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4111,8 +4111,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4128,8 +4128,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4164,8 +4164,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -4186,8 +4186,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4203,8 +4203,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: RELEASE-NAME
@@ -4290,8 +4290,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4322,8 +4322,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4351,8 +4351,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4368,8 +4368,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -4393,8 +4393,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4458,8 +4458,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -4482,8 +4482,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4506,8 +4506,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4532,8 +4532,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -4621,8 +4621,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4685,8 +4685,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -4708,8 +4708,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -4733,8 +4733,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -4758,8 +4758,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4785,8 +4785,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4802,8 +4802,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5028,8 +5028,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5306,8 +5306,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5324,8 +5324,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5355,8 +5355,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -5368,7 +5368,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.3
+                  value: kubescape-operator-1.27.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -5479,8 +5479,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5557,8 +5557,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5600,8 +5600,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5625,8 +5625,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -5650,8 +5650,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5678,8 +5678,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5687,7 +5687,7 @@ all capabilities:
 default capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.27.3.
+      Thank you for installing kubescape-operator version 1.27.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -5722,8 +5722,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -5775,8 +5775,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -5802,8 +5802,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5823,8 +5823,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5843,8 +5843,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -5860,8 +5860,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5889,8 +5889,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -5930,8 +5930,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -5965,8 +5965,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -5994,8 +5994,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6012,9 +6012,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
+        app.kubernetes.io/version: 1.27.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.27.3
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6033,9 +6033,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.3
+                app.kubernetes.io/version: 1.27.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.27.3
+                helm.sh/chart: kubescape-operator-1.27.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -6095,8 +6095,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -6151,8 +6151,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6402,8 +6402,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6426,8 +6426,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6460,8 +6460,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -6620,11 +6620,11 @@ default capabilities:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.27.3
+            helm.sh/chart: kubescape-operator-1.27.4
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.27.3"
+            app.kubernetes.io/version: "1.27.4"
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: kubescape
             app: host-scanner
@@ -6639,11 +6639,11 @@ default capabilities:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.27.3
+                helm.sh/chart: kubescape-operator-1.27.4
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.27.3"
+                app.kubernetes.io/version: "1.27.4"
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/part-of: kubescape
                 app: host-scanner
@@ -6734,8 +6734,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6752,8 +6752,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6825,8 +6825,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6855,8 +6855,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6880,8 +6880,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6909,8 +6909,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6926,8 +6926,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -6959,8 +6959,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6977,9 +6977,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
+        app.kubernetes.io/version: 1.27.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.27.3
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6998,9 +6998,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.3
+                app.kubernetes.io/version: 1.27.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.27.3
+                helm.sh/chart: kubescape-operator-1.27.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -7060,8 +7060,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -7116,8 +7116,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7156,8 +7156,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7180,8 +7180,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7210,8 +7210,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -7345,8 +7345,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7406,8 +7406,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7434,8 +7434,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7451,8 +7451,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7572,8 +7572,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7626,8 +7626,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7644,8 +7644,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7671,8 +7671,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -7883,8 +7883,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -7968,8 +7968,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8021,8 +8021,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8048,8 +8048,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8065,8 +8065,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8179,8 +8179,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8212,8 +8212,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8230,8 +8230,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8266,8 +8266,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -8278,7 +8278,7 @@ default capabilities:
           containers:
             - env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.3
+                  value: kubescape-operator-1.27.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -8487,8 +8487,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8571,8 +8571,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8589,8 +8589,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8747,8 +8747,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8765,8 +8765,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8808,8 +8808,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8833,8 +8833,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8861,8 +8861,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8943,8 +8943,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8961,8 +8961,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8993,8 +8993,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -9079,8 +9079,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9140,8 +9140,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9172,8 +9172,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9195,8 +9195,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -9217,8 +9217,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9234,8 +9234,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             otel: enabled
             tier: ks-control-plane
@@ -9315,8 +9315,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9347,8 +9347,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9376,8 +9376,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9393,8 +9393,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -9422,8 +9422,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -9440,8 +9440,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9505,8 +9505,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -9529,8 +9529,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9553,8 +9553,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9579,8 +9579,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -9685,8 +9685,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9738,8 +9738,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -9761,8 +9761,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -9786,8 +9786,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9813,8 +9813,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9830,8 +9830,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -9996,8 +9996,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10268,8 +10268,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10286,8 +10286,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10317,8 +10317,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -10331,7 +10331,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.3
+                  value: kubescape-operator-1.27.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -10443,8 +10443,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10510,8 +10510,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10553,8 +10553,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10578,8 +10578,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10606,8 +10606,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10615,7 +10615,7 @@ default capabilities:
 disable otel:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.27.3.
+      Thank you for installing kubescape-operator version 1.27.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -10650,8 +10650,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -10702,8 +10702,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -10729,8 +10729,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10750,8 +10750,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10770,8 +10770,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -10789,8 +10789,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10807,9 +10807,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
+        app.kubernetes.io/version: 1.27.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.27.3
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10828,9 +10828,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.3
+                app.kubernetes.io/version: 1.27.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.27.3
+                helm.sh/chart: kubescape-operator-1.27.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -10890,8 +10890,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11141,8 +11141,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11165,8 +11165,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11198,8 +11198,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -11343,11 +11343,11 @@ disable otel:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.27.3
+            helm.sh/chart: kubescape-operator-1.27.4
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.27.3"
+            app.kubernetes.io/version: "1.27.4"
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: kubescape
             app: host-scanner
@@ -11362,11 +11362,11 @@ disable otel:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.27.3
+                helm.sh/chart: kubescape-operator-1.27.4
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.27.3"
+                app.kubernetes.io/version: "1.27.4"
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/part-of: kubescape
                 app: host-scanner
@@ -11457,8 +11457,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11475,8 +11475,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11505,8 +11505,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11530,8 +11530,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11559,8 +11559,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11578,8 +11578,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11596,9 +11596,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
+        app.kubernetes.io/version: 1.27.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.27.3
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11617,9 +11617,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.3
+                app.kubernetes.io/version: 1.27.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.27.3
+                helm.sh/chart: kubescape-operator-1.27.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11679,8 +11679,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11719,8 +11719,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11743,8 +11743,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11772,8 +11772,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -11892,8 +11892,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11920,8 +11920,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11937,8 +11937,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12058,8 +12058,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12112,8 +12112,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12130,8 +12130,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12156,8 +12156,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -12353,8 +12353,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12380,8 +12380,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12397,8 +12397,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -12426,8 +12426,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -12444,8 +12444,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -12491,8 +12491,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12605,8 +12605,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12638,8 +12638,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12656,8 +12656,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12691,8 +12691,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -12703,7 +12703,7 @@ disable otel:
           containers:
             - env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.3
+                  value: kubescape-operator-1.27.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -12906,8 +12906,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12990,8 +12990,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13074,8 +13074,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13092,8 +13092,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13135,8 +13135,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13160,8 +13160,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13188,8 +13188,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13270,8 +13270,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13288,8 +13288,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13319,8 +13319,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -13399,8 +13399,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -13431,8 +13431,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -13452,8 +13452,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13469,8 +13469,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             otel: enabled
             tier: ks-control-plane
@@ -13544,8 +13544,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13576,8 +13576,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13605,8 +13605,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13622,8 +13622,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -13651,8 +13651,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -13669,8 +13669,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13734,8 +13734,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -13758,8 +13758,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13782,8 +13782,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13808,8 +13808,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -13914,8 +13914,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -13937,8 +13937,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -13962,8 +13962,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13989,8 +13989,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14006,8 +14006,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14172,8 +14172,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14444,8 +14444,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14462,8 +14462,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14492,8 +14492,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -14506,7 +14506,7 @@ disable otel:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.3
+                  value: kubescape-operator-1.27.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -14603,8 +14603,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14646,8 +14646,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14671,8 +14671,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14699,8 +14699,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14708,7 +14708,7 @@ disable otel:
 minimal capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.27.3.
+      Thank you for installing kubescape-operator version 1.27.4.
 
 
 
@@ -14735,8 +14735,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -14779,8 +14779,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -14806,8 +14806,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14827,8 +14827,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14847,8 +14847,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -14864,8 +14864,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15115,8 +15115,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15139,8 +15139,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15172,8 +15172,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15307,11 +15307,11 @@ minimal capabilities:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.27.3
+            helm.sh/chart: kubescape-operator-1.27.4
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.27.3"
+            app.kubernetes.io/version: "1.27.4"
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: kubescape
             app: host-scanner
@@ -15326,11 +15326,11 @@ minimal capabilities:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.27.3
+                helm.sh/chart: kubescape-operator-1.27.4
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.27.3"
+                app.kubernetes.io/version: "1.27.4"
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/part-of: kubescape
                 app: host-scanner
@@ -15413,8 +15413,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15431,8 +15431,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15461,8 +15461,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15486,8 +15486,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15515,8 +15515,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15532,8 +15532,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15572,8 +15572,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15596,8 +15596,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15625,8 +15625,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15737,8 +15737,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15765,8 +15765,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15782,8 +15782,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -15903,8 +15903,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -15955,8 +15955,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15973,8 +15973,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15999,8 +15999,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16193,8 +16193,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16220,8 +16220,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16237,8 +16237,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -16266,8 +16266,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -16284,8 +16284,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -16331,8 +16331,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16445,8 +16445,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16477,8 +16477,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16495,8 +16495,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16530,8 +16530,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16541,7 +16541,7 @@ minimal capabilities:
           containers:
             - env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.3
+                  value: kubescape-operator-1.27.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -16738,8 +16738,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16822,8 +16822,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16906,8 +16906,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16924,8 +16924,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16967,8 +16967,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16992,8 +16992,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17020,8 +17020,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17037,8 +17037,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -17066,8 +17066,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -17084,8 +17084,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17149,8 +17149,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -17173,8 +17173,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17197,8 +17197,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17223,8 +17223,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17319,8 +17319,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -17342,8 +17342,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -17367,8 +17367,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17394,8 +17394,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17403,7 +17403,7 @@ minimal capabilities:
 relevancy only:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.27.3.
+      Thank you for installing kubescape-operator version 1.27.4.
 
 
 
@@ -17429,8 +17429,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -17473,8 +17473,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -17500,8 +17500,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17521,8 +17521,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17541,8 +17541,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -17558,8 +17558,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -17809,8 +17809,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -17833,8 +17833,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17866,8 +17866,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18001,11 +18001,11 @@ relevancy only:
           name: host-scanner
           namespace: kubescape
           labels:
-            helm.sh/chart: kubescape-operator-1.27.3
+            helm.sh/chart: kubescape-operator-1.27.4
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/component: host-scanner
-            app.kubernetes.io/version: "1.27.3"
+            app.kubernetes.io/version: "1.27.4"
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: kubescape
             app: host-scanner
@@ -18020,11 +18020,11 @@ relevancy only:
           template:
             metadata:
               labels:
-                helm.sh/chart: kubescape-operator-1.27.3
+                helm.sh/chart: kubescape-operator-1.27.4
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/instance: RELEASE-NAME
                 app.kubernetes.io/component: host-scanner
-                app.kubernetes.io/version: "1.27.3"
+                app.kubernetes.io/version: "1.27.4"
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/part-of: kubescape
                 app: host-scanner
@@ -18107,8 +18107,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18125,8 +18125,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18155,8 +18155,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18180,8 +18180,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18209,8 +18209,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18226,8 +18226,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -18266,8 +18266,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -18290,8 +18290,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18319,8 +18319,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18431,8 +18431,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -18459,8 +18459,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -18476,8 +18476,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -18597,8 +18597,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -18649,8 +18649,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18667,8 +18667,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18693,8 +18693,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18887,8 +18887,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -18914,8 +18914,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -18931,8 +18931,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -19045,8 +19045,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -19077,8 +19077,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19095,8 +19095,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19130,8 +19130,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19141,7 +19141,7 @@ relevancy only:
           containers:
             - env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.3
+                  value: kubescape-operator-1.27.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19329,8 +19329,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19413,8 +19413,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19497,8 +19497,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19515,8 +19515,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -19558,8 +19558,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -19583,8 +19583,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -19611,8 +19611,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -19628,8 +19628,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -19657,8 +19657,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -19675,8 +19675,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -19740,8 +19740,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -19764,8 +19764,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -19788,8 +19788,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19814,8 +19814,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.3
-            helm.sh/chart: kubescape-operator-1.27.3
+            app.kubernetes.io/version: 1.27.4
+            helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19910,8 +19910,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -19933,8 +19933,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -19958,8 +19958,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -19985,8 +19985,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -20013,8 +20013,8 @@ with multiple private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets
@@ -20050,8 +20050,8 @@ with single private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.3
-        helm.sh/chart: kubescape-operator-1.27.3
+        app.kubernetes.io/version: 1.27.4
+        helm.sh/chart: kubescape-operator-1.27.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -441,11 +441,13 @@ storage:
   mtls:
     enabled: true
     certificateValidityInDays: 730
+  serverPort: 8443
 
+  # -- source code: https://github.com/kubescape/storage
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: quay.io/kubescape/storage
-    tag: v0.0.172
+    tag: v0.0.175
     pullPolicy: IfNotPresent
 
   nodeSelector:


### PR DESCRIPTION
This pull request introduces updates to the `kubescape-operator` Helm chart, focusing on version upgrades, configuration flexibility, and port customization. The most significant changes include updating the chart and application versions, introducing a configurable `serverPort` value, and adjusting templates to use this new value dynamically.

### Version Updates:
* Updated `version` and `appVersion` in `charts/kubescape-operator/Chart.yaml` from `1.27.3` to `1.27.4` to reflect the new release.

### Configuration Flexibility:
* Added a new `serverPort` value in `charts/kubescape-operator/values.yaml` to allow dynamic configuration of the storage server port. Default is set to `8443`.

### Port Customization in Templates:
* Modified `charts/kubescape-operator/templates/storage/deployment.yaml` to replace hardcoded port `8443` with the new `serverPort` value for `livenessProbe`, `readinessProbe`, and added an environment variable `SERVER_BIND_PORT`.
* Updated `charts/kubescape-operator/templates/storage/service.yaml` to use the `serverPort` value for `targetPort` and added a `name` field for the port (`https`).

These changes enhance the flexibility and maintainability of the `kubescape-operator` Helm chart by allowing port configuration through values, while also updating to the latest application version.