### PR TITLE
WIP:  Use secret to pass provider's metadata

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -136,14 +136,15 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | hostScanner.volumes | object | `[]` | Additional volumes for the host scanner |
 | hostScanner.volumeMounts | object | `[]` | Additional volumeMounts for the host scanner |
 | awsIamRoleArn | string | `nil` | AWS IAM arn role |
-| cloudProviderMetadata.cloudRegion | string | `nil` | cloud region |
-| cloudProviderMetadata.gkeProject | string | `nil` | GKE project |
+| cloudProviderMetadata.secretRef.name | string | `nil` | secret name to define values for the provider's metadata |
+| cloudProviderMetadata.cloudRegion | string or through `cloudProviderMetadata.secretRef.cloudRegionKey` if `cloudProviderMetadata.secretRef.name` is set | `nil` | cloud region |
+| cloudProviderMetadata.gkeProject | string or through `cloudProviderMetadata.secretRef.gkeProjectKey` if `cloudProviderMetadata.secretRef.name` is set | `nil` | GKE project |
 | cloudProviderMetadata.gkeServiceAccount | string | `nil` | GKE service account |
-| cloudProviderMetadata.aksSubscriptionID | string | `nil` | AKS subscription ID |
-| cloudProviderMetadata.aksResourceGroup | string | `nil` | AKS resource group |
-| cloudProviderMetadata.aksClientID | string | `nil` | AKS client ID |
-| cloudProviderMetadata.aksClientSecret | string | `nil` | AKS client secret |
-| cloudProviderMetadata.aksTenantID | string | `nil` | AKS tenant ID |
+| cloudProviderMetadata.aksSubscriptionID | string or through `cloudProviderMetadata.secretRef.subscriptionIdKey` if `cloudProviderMetadata.secretRef.name` is set | `nil` | AKS subscription ID |
+| cloudProviderMetadata.aksResourceGroup | string or through `cloudProviderMetadata.secretRef.resourceGroupKey` if `cloudProviderMetadata.secretRef.name` is set | `nil` | AKS resource group |
+| cloudProviderMetadata.aksClientID | string or through `cloudProviderMetadata.secretRef.clientIdKey` if `cloudProviderMetadata.secretRef.name` is set | `nil` | AKS client ID |
+| cloudProviderMetadata.aksClientSecret | string or through `cloudProviderMetadata.secretRef.clientSecretKey` if `cloudProviderMetadata.secretRef.name` is set | `nil` | AKS client secret |
+| cloudProviderMetadata.aksTenantID | string or through `cloudProviderMetadata.secretRef.tenantIdKey` if `cloudProviderMetadata.secretRef.name` is set | `nil` | AKS tenant ID |
 | volumes | object | `[]` | Additional volumes for all containers |
 | volumeMounts | object | `[]` | Additional volumeMounts for all containers |
 | imageScanning.privateRegistries.credentials | object | `[]` | Credentials for scanning images pulled from private container registries. This configuration is not needed when using `imagePullSecrets`|

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -123,34 +123,100 @@ spec:
         - name: {{ .name }}
           value: "{{ .value }}"
         {{- end }}
-        {{- if .Values.cloudProviderMetadata.cloudRegion }}
+
+        {{- /* Check configuration to use a Secret if provided */}}
+        {{- if .Values.cloudProviderMetadata.secretRef }}
+
+          {{- if .Values.cloudProviderMetadata.secretRef.cloudRegionKey }}
+        - name: KS_CLOUD_REGION
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.cloudProviderMetadata.secretRef.name }}"
+              key: "{{ .Values.cloudProviderMetadata.secretRef.cloudRegionKey }}"
+          {{- end }}
+
+          {{- if .Values.cloudProviderMetadata.secretRef.gkeProjectKey }}
+        - name: KS_GKE_PROJECT
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.cloudProviderMetadata.secretRef.name }}"
+              key: "{{ .Values.cloudProviderMetadata.secretRef.gkeProjectKey }}"
+          {{- end }}
+
+          {{- if .Values.cloudProviderMetadata.secretRef.subscriptionIdKey }}
+        - name: AZURE_SUBSCRIPTION_ID
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.cloudProviderMetadata.secretRef.name }}"
+              key: "{{ .Values.cloudProviderMetadata.secretRef.subscriptionIdKey }}"
+          {{- end }}
+
+          {{- if .Values.cloudProviderMetadata.secretRef.clientIdKey }}
+        - name: AZURE_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.cloudProviderMetadata.secretRef.name }}"
+              key: "{{ .Values.cloudProviderMetadata.secretRef.clientIdKey }}"
+          {{- end }}
+
+          {{- if .Values.cloudProviderMetadata.secretRef.clientSecretKey }}
+        - name: AZURE_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.cloudProviderMetadata.secretRef.name }}"
+              key: "{{ .Values.cloudProviderMetadata.secretRef.clientSecretKey }}"
+          {{- end }}
+
+          {{- if .Values.cloudProviderMetadata.secretRef.tenantIdKey }}
+        - name: AZURE_TENANT_ID
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.cloudProviderMetadata.secretRef.name }}"
+              key: "{{ .Values.cloudProviderMetadata.secretRef.tenantIdKey }}"
+          {{- end }}
+
+          {{- if .Values.cloudProviderMetadata.secretRef.resourceGroupKey }}
+        - name: AZURE_RESOURCE_GROUP
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Values.cloudProviderMetadata.secretRef.name }}"
+              key: "{{ .Values.cloudProviderMetadata.secretRef.resourceGroupKey }}"
+          {{- end }}
+
+        {{- /* Fallback: If not using secretRef, use direct values (original method) */}}
+        {{- else }}
+
+          {{- if .Values.cloudProviderMetadata.cloudRegion }}
         - name: KS_CLOUD_REGION
           value: "{{ .Values.cloudProviderMetadata.cloudRegion }}"
-        {{- end }}
-        {{- if .Values.cloudProviderMetadata.gkeProject }}
+          {{- end }}
+          {{- if .Values.cloudProviderMetadata.gkeProject }}
         - name: KS_GKE_PROJECT
           value: "{{ .Values.cloudProviderMetadata.gkeProject }}"
-        {{- end }}
-        {{- if .Values.cloudProviderMetadata.aksSubscriptionID }}
+          {{- end }}
+          {{- if .Values.cloudProviderMetadata.aksSubscriptionID }}
         - name: AZURE_SUBSCRIPTION_ID
           value: "{{ .Values.cloudProviderMetadata.aksSubscriptionID }}"
-        {{- end }}
-        {{- if .Values.cloudProviderMetadata.aksClientID }}
+          {{- end }}
+          {{- if .Values.cloudProviderMetadata.aksClientID }}
         - name: AZURE_CLIENT_ID
           value: "{{ .Values.cloudProviderMetadata.aksClientID }}"
-        {{- end }}
-        {{- if .Values.cloudProviderMetadata.aksClientSecret }}
+          {{- end }}
+          {{- if .Values.cloudProviderMetadata.aksClientSecret }}
         - name: AZURE_CLIENT_SECRET
           value: "{{ .Values.cloudProviderMetadata.aksClientSecret }}"
-        {{- end }}
-        {{- if .Values.cloudProviderMetadata.aksTenantID }}
+          {{- end }}
+          {{- if .Values.cloudProviderMetadata.aksTenantID }}
         - name: AZURE_TENANT_ID
           value: "{{ .Values.cloudProviderMetadata.aksTenantID }}"
-        {{- end }}
-        {{- if .Values.cloudProviderMetadata.aksResourceGroup }}
+          {{- end }}
+          {{- if .Values.cloudProviderMetadata.aksResourceGroup }}
         - name: AZURE_RESOURCE_GROUP
           value: "{{ .Values.cloudProviderMetadata.aksResourceGroup }}"
-        {{- end }}
+          {{- end }}
+
+        {{- end }} {{- /* End of if/else for secretRef vs direct values */}}
+
         {{- if $components.otelCollector.enabled }}
         - name: ACCOUNT_ID
           valueFrom:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -162,6 +162,15 @@ cloudProviderMetadata:
   # -- GKE project
   gkeProject:
 
+  # Provider Metada can also be pulled from a kubernetes secret like
+  # secretRef:
+  #   name: kubescape-secret
+  #   subscriptionIdKey: aksSubscriptionID
+  #   clientIdKey: aksClientID
+  #   clientSecretKey: aksClientSecret
+  #   tenantIdKey: aksTenantID
+  #   resourceGroupKey: aksResourceGroup
+
 # -----------------------------------------------------------------------------------------
 # ------------------------- Configurations ------------------------------------------------
 # -----------------------------------------------------------------------------------------


### PR DESCRIPTION
## Overview
Currently cloudProviderMetadata parameters are forced to passed as plaintext values and some of them are kinda confidential. I would suggest to allow the helm-chart template to accept values from secrets.

## Related issues/PRs:

Resolved #683

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 