### PR TITLE
Update node-agent volume mounts to specify read-only access where applicable

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -266,17 +266,20 @@ spec:
           - name: proxy-secret
             mountPath: /etc/ssl/certs/proxy.crt
             subPath: proxy.crt
+            readOnly: true
           {{- end }}
           {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
           - name: custom-ca-certificates
             mountPath: /etc/ssl/certs/ca-certificates.crt
             subPath: ca-certificates.crt
+            readOnly: true
           {{- end }}
           {{- if .Values.global.extraCaCertificates.enabled }}
           {{- range $key, $value := (lookup "v1" "Secret" .Values.ksNamespace .Values.global.extraCaCertificates.secretName).data }}
           - name: extra-ca-certificates
             mountPath: /etc/ssl/certs/{{ $key }}
             subPath: {{ $key }}
+            readOnly: true
           {{- end }}
           {{- end }}
       nodeSelector:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2591,22 +2591,31 @@ all capabilities:
               volumeMounts:
                 - mountPath: /host
                   name: host
+                  readOnly: true
                 - mountPath: /run
                   name: run
+                  readOnly: false
                 - mountPath: /var
                   name: var
+                  readOnly: true
                 - mountPath: /lib/modules
                   name: modules
+                  readOnly: true
                 - mountPath: /sys/kernel/debug
                   name: debugfs
+                  readOnly: false
                 - mountPath: /sys/fs/cgroup
                   name: cgroup
+                  readOnly: true
                 - mountPath: /sys/fs/bpf
                   name: bpffs
+                  readOnly: true
                 - mountPath: /data
                   name: data
+                  readOnly: false
                 - mountPath: /boot
                   name: boot
+                  readOnly: true
                 - mountPath: /clamav
                   name: clamrun
                   readOnly: false
@@ -2623,9 +2632,11 @@ all capabilities:
                   subPath: config.json
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
+                  readOnly: true
                   subPath: proxy.crt
                 - mountPath: /etc/ssl/certs/ca-certificates.crt
                   name: custom-ca-certificates
+                  readOnly: true
                   subPath: ca-certificates.crt
           hostPID: true
           imagePullSecrets:
@@ -7780,22 +7791,31 @@ default capabilities:
               volumeMounts:
                 - mountPath: /host
                   name: host
+                  readOnly: true
                 - mountPath: /run
                   name: run
+                  readOnly: false
                 - mountPath: /var
                   name: var
+                  readOnly: true
                 - mountPath: /lib/modules
                   name: modules
+                  readOnly: true
                 - mountPath: /sys/kernel/debug
                   name: debugfs
+                  readOnly: false
                 - mountPath: /sys/fs/cgroup
                   name: cgroup
+                  readOnly: true
                 - mountPath: /sys/fs/bpf
                   name: bpffs
+                  readOnly: true
                 - mountPath: /data
                   name: data
+                  readOnly: false
                 - mountPath: /boot
                   name: boot
+                  readOnly: true
                 - mountPath: /clamav
                   name: clamrun
                   readOnly: false
@@ -7812,12 +7832,15 @@ default capabilities:
                   subPath: config.json
                 - mountPath: /etc/ssl/certs/proxy.crt
                   name: proxy-secret
+                  readOnly: true
                   subPath: proxy.crt
                 - mountPath: /etc/ssl/certs/cert1.pem
                   name: extra-ca-certificates
+                  readOnly: true
                   subPath: cert1.pem
                 - mountPath: /etc/ssl/certs/cert2.pem
                   name: extra-ca-certificates
+                  readOnly: true
                   subPath: cert2.pem
           hostPID: true
           nodeSelector:
@@ -12266,22 +12289,31 @@ disable otel:
               volumeMounts:
                 - mountPath: /host
                   name: host
+                  readOnly: true
                 - mountPath: /run
                   name: run
+                  readOnly: false
                 - mountPath: /var
                   name: var
+                  readOnly: true
                 - mountPath: /lib/modules
                   name: modules
+                  readOnly: true
                 - mountPath: /sys/kernel/debug
                   name: debugfs
+                  readOnly: false
                 - mountPath: /sys/fs/cgroup
                   name: cgroup
+                  readOnly: true
                 - mountPath: /sys/fs/bpf
                   name: bpffs
+                  readOnly: true
                 - mountPath: /data
                   name: data
+                  readOnly: false
                 - mountPath: /boot
                   name: boot
+                  readOnly: true
                 - mountPath: /clamav
                   name: clamrun
                   readOnly: false
@@ -16107,22 +16139,31 @@ minimal capabilities:
               volumeMounts:
                 - mountPath: /host
                   name: host
+                  readOnly: true
                 - mountPath: /run
                   name: run
+                  readOnly: false
                 - mountPath: /var
                   name: var
+                  readOnly: true
                 - mountPath: /lib/modules
                   name: modules
+                  readOnly: true
                 - mountPath: /sys/kernel/debug
                   name: debugfs
+                  readOnly: false
                 - mountPath: /sys/fs/cgroup
                   name: cgroup
+                  readOnly: true
                 - mountPath: /sys/fs/bpf
                   name: bpffs
+                  readOnly: true
                 - mountPath: /data
                   name: data
+                  readOnly: false
                 - mountPath: /boot
                   name: boot
+                  readOnly: true
                 - mountPath: /clamav
                   name: clamrun
                   readOnly: false
@@ -18799,22 +18840,31 @@ relevancy only:
               volumeMounts:
                 - mountPath: /host
                   name: host
+                  readOnly: true
                 - mountPath: /run
                   name: run
+                  readOnly: false
                 - mountPath: /var
                   name: var
+                  readOnly: true
                 - mountPath: /lib/modules
                   name: modules
+                  readOnly: true
                 - mountPath: /sys/kernel/debug
                   name: debugfs
+                  readOnly: false
                 - mountPath: /sys/fs/cgroup
                   name: cgroup
+                  readOnly: true
                 - mountPath: /sys/fs/bpf
                   name: bpffs
+                  readOnly: true
                 - mountPath: /data
                   name: data
+                  readOnly: false
                 - mountPath: /boot
                   name: boot
+                  readOnly: true
                 - mountPath: /clamav
                   name: clamrun
                   readOnly: false

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2609,7 +2609,7 @@ all capabilities:
                   readOnly: true
                 - mountPath: /sys/fs/bpf
                   name: bpffs
-                  readOnly: true
+                  readOnly: false
                 - mountPath: /data
                   name: data
                   readOnly: false
@@ -7809,7 +7809,7 @@ default capabilities:
                   readOnly: true
                 - mountPath: /sys/fs/bpf
                   name: bpffs
-                  readOnly: true
+                  readOnly: false
                 - mountPath: /data
                   name: data
                   readOnly: false
@@ -12307,7 +12307,7 @@ disable otel:
                   readOnly: true
                 - mountPath: /sys/fs/bpf
                   name: bpffs
-                  readOnly: true
+                  readOnly: false
                 - mountPath: /data
                   name: data
                   readOnly: false
@@ -16157,7 +16157,7 @@ minimal capabilities:
                   readOnly: true
                 - mountPath: /sys/fs/bpf
                   name: bpffs
-                  readOnly: true
+                  readOnly: false
                 - mountPath: /data
                   name: data
                   readOnly: false
@@ -18858,7 +18858,7 @@ relevancy only:
                   readOnly: true
                 - mountPath: /sys/fs/bpf
                   name: bpffs
-                  readOnly: true
+                  readOnly: false
                 - mountPath: /data
                   name: data
                   readOnly: false

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -525,25 +525,34 @@ nodeAgent:
   volumeMounts:
     - mountPath: /host
       name: host
+      readOnly: true
     - mountPath: /run
       name: run
+      readOnly: false # Must be writable for the node-agent to open container runtime socket for writing
     - mountPath: /var
       name: var
+      readOnly: true
     - mountPath: /lib/modules
       name: modules
+      readOnly: true
     - mountPath: /sys/kernel/debug
       name: debugfs
+      readOnly: false # Must be writable for the node-agent to load eBPF programs
     - mountPath: /sys/fs/cgroup
       name: cgroup
+      readOnly: true
     - mountPath: /sys/fs/bpf
       name: bpffs
+      readOnly: true # Must be writable for the node-agent to load eBPF programs
     - mountPath: /data
       name: data
+      readOnly: false # EmptyDir volume
     - mountPath: /boot
       name: boot
+      readOnly: true
     - mountPath: /clamav
       name: clamrun
-      readOnly: false
+      readOnly: false # EmptyDir volume
 
   volumes:
     - hostPath:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -543,7 +543,7 @@ nodeAgent:
       readOnly: true
     - mountPath: /sys/fs/bpf
       name: bpffs
-      readOnly: true # Must be writable for the node-agent to load eBPF programs
+      readOnly: false # Must be writable for the node-agent to load eBPF programs
     - mountPath: /data
       name: data
       readOnly: false # EmptyDir volume


### PR DESCRIPTION
This pull request introduces changes to improve the `kubescape-operator's security posture by setting appropriate `readOnly` flags for volume mounts in the `node-agent` configuration. These changes ensure that volumes are marked as read-only wherever possible, reducing the risk of unintended write operations.

### Security Enhancements:

* **`daemonset.yaml` Updates**: Added `readOnly: true` to volume mounts for `proxy-secret`, `custom-ca-certificates`, and `extra-ca-certificates` to ensure these sensitive files are mounted as read-only.

* **`values.yaml` Updates**:
  - Marked several volume mounts as `readOnly: true`, including `/host`, `/var`, `/lib/modules`, `/sys/fs/cgroup`, `/sys/fs/bpf`, and `/boot`, to restrict write access.
  - Retained write access (`readOnly: false`) for specific paths like `/run` (container runtime socket), `/sys/kernel/debug` (eBPF program loading), and `/data` and `/clamav` (emptyDir volumes), where write operations are necessary.