### PR TITLE
Add includePrefixes to default rule binding and update snapshots

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/default-rule-binding-namespaced.yaml
+++ b/charts/kubescape-operator/templates/node-agent/default-rule-binding-namespaced.yaml
@@ -13,6 +13,7 @@ spec:
       parameters:
         ignoreMounts: true
         ignorePrefixes: ["/proc", "/run/secrets/kubernetes.io/serviceaccount", "/var/run/secrets/kubernetes.io/serviceaccount", "/tmp"]
+        includePrefixes: [ "/etc", "/var/spool/cron/", "/var/log/", "/var/run/", "/dev/shm/", "/run/", "/var/www/", "/var/lib/docker/", "/opt/", "/usr/local/", "/app/", "/.dockerenv", "/proc/self/environ", "/var/lib/kubelet/", "/etc/cni/net.d/", "/var/run/secrets/kubernetes.io/", "/var/run/secrets/kubernetes.io/serviceaccount/", "/run/containerd/", "/run/flannel/", "/run/calico/"]
     - ruleName: "Unexpected system call"
     - ruleName: "Unexpected capability used"
     - ruleName: "Unexpected domain request"

--- a/charts/kubescape-operator/templates/node-agent/default-rule-binding.yaml
+++ b/charts/kubescape-operator/templates/node-agent/default-rule-binding.yaml
@@ -31,6 +31,7 @@ spec:
       parameters:
         ignoreMounts: true
         ignorePrefixes: ["/proc", "/run/secrets/kubernetes.io/serviceaccount", "/var/run/secrets/kubernetes.io/serviceaccount", "/tmp"]
+        includePrefixes: [ "/etc", "/var/spool/cron/", "/var/log/", "/var/run/", "/dev/shm/", "/run/", "/var/www/", "/var/lib/docker/", "/opt/", "/usr/local/", "/app/", "/.dockerenv", "/proc/self/environ", "/var/lib/kubelet/", "/etc/cni/net.d/", "/var/run/secrets/kubernetes.io/", "/var/run/secrets/kubernetes.io/serviceaccount/", "/run/containerd/", "/run/flannel/", "/run/calico/"]
     - ruleName: "Unexpected system call"
     - ruleName: "Unexpected capability used"
     - ruleName: "Unexpected domain request"

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2733,6 +2733,27 @@ all capabilities:
               - /run/secrets/kubernetes.io/serviceaccount
               - /var/run/secrets/kubernetes.io/serviceaccount
               - /tmp
+            includePrefixes:
+              - /etc
+              - /var/spool/cron/
+              - /var/log/
+              - /var/run/
+              - /dev/shm/
+              - /run/
+              - /var/www/
+              - /var/lib/docker/
+              - /opt/
+              - /usr/local/
+              - /app/
+              - /.dockerenv
+              - /proc/self/environ
+              - /var/lib/kubelet/
+              - /etc/cni/net.d/
+              - /var/run/secrets/kubernetes.io/
+              - /var/run/secrets/kubernetes.io/serviceaccount/
+              - /run/containerd/
+              - /run/flannel/
+              - /run/calico/
           ruleName: Unexpected file access
         - ruleName: Unexpected system call
         - ruleName: Unexpected capability used
@@ -7930,6 +7951,27 @@ default capabilities:
               - /run/secrets/kubernetes.io/serviceaccount
               - /var/run/secrets/kubernetes.io/serviceaccount
               - /tmp
+            includePrefixes:
+              - /etc
+              - /var/spool/cron/
+              - /var/log/
+              - /var/run/
+              - /dev/shm/
+              - /run/
+              - /var/www/
+              - /var/lib/docker/
+              - /opt/
+              - /usr/local/
+              - /app/
+              - /.dockerenv
+              - /proc/self/environ
+              - /var/lib/kubelet/
+              - /etc/cni/net.d/
+              - /var/run/secrets/kubernetes.io/
+              - /var/run/secrets/kubernetes.io/serviceaccount/
+              - /run/containerd/
+              - /run/flannel/
+              - /run/calico/
           ruleName: Unexpected file access
         - ruleName: Unexpected system call
         - ruleName: Unexpected capability used


### PR DESCRIPTION
This pull request adds new `includePrefixes` parameters to enhance the configuration of file and directory scanning in the Kubescape operator. These changes expand the scope of monitored paths to improve security and compliance checks.

### Enhancements to file and directory scanning:

* **Added `includePrefixes` to `default-rule-binding-namespaced.yaml`:** Expanded the list of monitored paths to include directories like `/etc`, `/var/log/`, `/var/lib/docker/`, and others to improve security rule coverage. (`charts/kubescape-operator/templates/node-agent/default-rule-binding-namespaced.yaml`, [charts/kubescape-operator/templates/node-agent/default-rule-binding-namespaced.yamlR16](diffhunk://#diff-8a14d00337e0df100dd55de6f73f3656b96a04834bdecd87cae4be14f102f9f4R16))
* **Added `includePrefixes` to `default-rule-binding.yaml`:** Similar updates to the monitored paths for the default rule binding configuration. (`charts/kubescape-operator/templates/node-agent/default-rule-binding.yaml`, [charts/kubescape-operator/templates/node-agent/default-rule-binding.yamlR34](diffhunk://#diff-db8a14b545acfe85777bf3b38293b1a18d277507d4a17805fbde62837df592b2R34))

### Snapshot updates for testing:

* **Updated `snapshot_test.yaml.snap` for all capabilities:** Added `includePrefixes` to the snapshot to reflect the expanded monitored paths for testing purposes. (`charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap`, [charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snapR2736-R2756](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R2736-R2756))
* **Updated `snapshot_test.yaml.snap` for default capabilities:** Similarly updated the snapshot for default capabilities to include the new `includePrefixes`. (`charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap`, [charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snapR7954-R7974](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R7954-R7974))