### PR TITLE
Add GKE Autopilot allowlist configuration to nodeAgent

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -39,6 +39,9 @@ spec:
         prometheus.io/scrape: "true"
       {{- end }}
       labels:
+        {{- if .Values.nodeAgent.gke.allowlist.enabled }}
+        cloud.google.com/matching-allowlist: {{ .Values.nodeAgent.gke.allowlist.name }}
+        {{- end }}
         {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 8 }}
         kubescape.io/tier: "core"
       {{- if $components.otelCollector.enabled }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2471,6 +2471,7 @@ all capabilities:
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
             app.kubernetes.io/version: 1.27.4
+            cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
             helm.sh/chart: kubescape-operator-1.27.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -72,6 +72,9 @@ tests:
       imagePullSecrets: [foo, bar]
       grypeOfflineDB.enabled: true
       grypeOfflineDB.image.tag: "latest"
+      nodeAgent.gke.allowlist:
+        enabled: true
+        name: armo-kubescape-node-agent-1.27
       kubescape.serviceMonitor.enabled: true
       kubescapeScheduler.scanSchedule: "1 2 3 4 5"
       kubevuln.config.useDefaultMatchers: true

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -493,6 +493,12 @@ nodeAgent:
     hostMalwareSensor: disable
     hostNetworkSensor: disable
 
+  # GKE Autopilot allowlist
+  gke:
+    allowlist:
+      enabled: false
+      name: armo-kubescape-node-agent-1.27
+
   # prometheus (operator) service monitor
   serviceMonitor:
     # -- enable/disable service monitor for prometheus


### PR DESCRIPTION
This pull request introduces a feature to support GKE Autopilot allowlists in the `kubescape-operator` Helm chart. The most significant changes include adding configuration options for the allowlist in `values.yaml` and updating the `daemonset.yaml` template to conditionally include the allowlist label.

### GKE Autopilot allowlist support:

* **Template update for allowlist label**: Added a conditional block in `charts/kubescape-operator/templates/node-agent/daemonset.yaml` to include the `cloud.google.com/matching-allowlist` label if the allowlist feature is enabled.
* **Configuration options**: Introduced a new `nodeAgent.gke.allowlist` section in `charts/kubescape-operator/values.yaml` with options to enable the allowlist and specify its name.