### PR TITLE
enabling node profile capability by default

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/configmap.yaml
@@ -28,7 +28,7 @@ data:
         "malwareDetectionEnabled": {{ eq .Values.capabilities.malwareDetection "enable" }},
         "hostMalwareSensorEnabled": {{ eq .Values.nodeAgent.config.hostMalwareSensor "enable" }},
         "hostNetworkSensorEnabled": {{ eq .Values.nodeAgent.config.hostNetworkSensor "enable" }},
-        "nodeProfileServiceEnabled": {{ eq .Values.capabilities.nodeProfileService "enable" }},
+        "nodeProfileServiceEnabled": {{ and $components.synchronizer.enabled (eq .Values.capabilities.nodeProfileService "enable") }},
         "networkStreamingEnabled": {{ eq .Values.capabilities.networkEventsStreaming "enable" }},
         "maxImageSize": {{ .Values.kubevuln.config.maxImageSize }},
         "maxSBOMSize": {{ .Values.kubevuln.config.maxSBOMSize }},

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -10821,7 +10821,7 @@ disable otel:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"disable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"disable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":true},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -12102,7 +12102,7 @@ disable otel:
             "malwareDetectionEnabled": false,
             "hostMalwareSensorEnabled": false,
             "hostNetworkSensorEnabled": false,
-            "nodeProfileServiceEnabled": false,
+            "nodeProfileServiceEnabled": true,
             "networkStreamingEnabled": false,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
@@ -12171,7 +12171,7 @@ disable otel:
           annotations:
             checksum/cloud-config: 3c2cb169171427fb98efb5d9fd396943df6cfd9141f82a6289f8dea0cde7039b
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: fdcf3f29fa1edc0cdb7917fe8a83bc70aab5b88bf3fb22fc6aa582cad0838963
+            checksum/node-agent-config: e7fec25e281bc08db96817d8c0fc1ada8b8d76a9e4f687f82a52c0b3686859f9
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -12718,7 +12718,7 @@ disable otel:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 0a270d47fb14fe5866885bc10511bfdf930729d82d0ed73cbdcdb617df3b66ac
+            checksum/capabilities-config: e77b63ce040ed4ae84f3eafde860a1896563803f9f78ffc7896af06ee0ab8ed0
             checksum/cloud-config: 3c2cb169171427fb98efb5d9fd396943df6cfd9141f82a6289f8dea0cde7039b
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -14889,7 +14889,7 @@ minimal capabilities:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"disable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"disable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":false},"prometheusExporter":{"enabled":false},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":"otelCollector.svc.monitoring:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -16762,7 +16762,7 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 8c707dc3c262adad4e3b76f779a14cdf4e85e713072297daa48a5dbecbffa04b
+            checksum/capabilities-config: c10e605e5c89f36ea9967dea48940bbf88b31c4f888ac1bf98303f6294c6cf6d
             checksum/cloud-config: 8f40f001a3e31db9895e7bbb06ab070f25ab66c83b31d1929b273cfd22402097
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -105,7 +105,7 @@ capabilities:
   networkEventsStreaming: disable
   runtimeDetection: disable
   malwareDetection: disable
-  nodeProfileService: disable # this should only be enabled when using a backend service that supports node profiles
+  nodeProfileService: enable
   admissionController: enable
   httpDetection: enable
   seccompProfileService: enable


### PR DESCRIPTION
This pull request introduces changes to enable the `nodeProfileService` feature in the `kubescape-operator` configuration, along with updates to ensure compatibility with the `synchronizer` component. The changes primarily impact configuration files and snapshots related to the operator's capabilities and annotations.

### Configuration Updates

* [`charts/kubescape-operator/templates/node-agent/configmap.yaml`](diffhunk://#diff-b8ccd25dcf7198d49ac143cb1ab55a34bc09894349c91c3d6767ba9ca210094dL31-R31): Modified the logic for enabling `nodeProfileService` to depend on both the `synchronizer` component being enabled and the `nodeProfileService` capability being set to "enable."
* [`charts/kubescape-operator/values.yaml`](diffhunk://#diff-2d5611f69251d498d71f52fa778f6ce1bc93e1e1f46951ede1c50d975bdcad02L108-R108): Changed the default value of `nodeProfileService` from "disable" to "enable."

### Snapshot Updates

* [`charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap`](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7L10824-R10824): Updated multiple snapshots to reflect the enabled state of `nodeProfileService` and the corresponding checksum changes for configuration files. [[1]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7L10824-R10824) [[2]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7L12105-R12105) [[3]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7L12174-R12174) [[4]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7L12721-R12721) [[5]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7L14892-R14892) [[6]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7L16765-R16765)