### PR TITLE
Add kubelet directory support in node agent configuration

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -226,6 +226,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: KUBELET_ROOT
+              value: "/var/lib/kubelet"
             {{- if .Values.capabilities.testing.nodeAgentMultiplication.enabled }}
             - name: MULTIPLY
               value: "true"

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2545,6 +2545,8 @@ all capabilities:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: KUBELET_ROOT
+                  value: /var/lib/kubelet
                 - name: NodeName
               image: quay.io/kubescape/node-agent:v0.2.343
               imagePullPolicy: IfNotPresent
@@ -2586,6 +2588,8 @@ all capabilities:
                 - mountPath: /host
                   name: host
                   readOnly: true
+                - mountPath: /var/lib/kubelet
+                  name: kubeletdir
                 - mountPath: /run
                   name: run
                   readOnly: false
@@ -2646,6 +2650,9 @@ all capabilities:
             - hostPath:
                 path: /
               name: host
+            - hostPath:
+                path: /var/lib/kubelet
+              name: kubeletdir
             - hostPath:
                 path: /run
               name: run
@@ -7774,6 +7781,8 @@ default capabilities:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: KUBELET_ROOT
+                  value: /var/lib/kubelet
                 - name: NodeName
               image: quay.io/kubescape/node-agent:v0.2.343
               imagePullPolicy: IfNotPresent
@@ -7815,6 +7824,8 @@ default capabilities:
                 - mountPath: /host
                   name: host
                   readOnly: true
+                - mountPath: /var/lib/kubelet
+                  name: kubeletdir
                 - mountPath: /run
                   name: run
                   readOnly: false
@@ -7878,6 +7889,9 @@ default capabilities:
             - hostPath:
                 path: /
               name: host
+            - hostPath:
+                path: /var/lib/kubelet
+              name: kubeletdir
             - hostPath:
                 path: /run
               name: run
@@ -12280,6 +12294,8 @@ disable otel:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: KUBELET_ROOT
+                  value: /var/lib/kubelet
                 - name: NodeName
               image: quay.io/kubescape/node-agent:v0.2.343
               imagePullPolicy: IfNotPresent
@@ -12321,6 +12337,8 @@ disable otel:
                 - mountPath: /host
                   name: host
                   readOnly: true
+                - mountPath: /var/lib/kubelet
+                  name: kubeletdir
                 - mountPath: /run
                   name: run
                   readOnly: false
@@ -12370,6 +12388,9 @@ disable otel:
             - hostPath:
                 path: /
               name: host
+            - hostPath:
+                path: /var/lib/kubelet
+              name: kubeletdir
             - hostPath:
                 path: /run
               name: run
@@ -16337,6 +16358,8 @@ minimal capabilities:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: KUBELET_ROOT
+                  value: /var/lib/kubelet
                 - name: NodeName
               image: quay.io/kubescape/node-agent:v0.2.343
               imagePullPolicy: IfNotPresent
@@ -16378,6 +16401,8 @@ minimal capabilities:
                 - mountPath: /host
                   name: host
                   readOnly: true
+                - mountPath: /var/lib/kubelet
+                  name: kubeletdir
                 - mountPath: /run
                   name: run
                   readOnly: false
@@ -16427,6 +16452,9 @@ minimal capabilities:
             - hostPath:
                 path: /
               name: host
+            - hostPath:
+                path: /var/lib/kubelet
+              name: kubeletdir
             - hostPath:
                 path: /run
               name: run
@@ -19246,6 +19274,8 @@ relevancy only:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: KUBELET_ROOT
+                  value: /var/lib/kubelet
                 - name: NodeName
               image: quay.io/kubescape/node-agent:v0.2.343
               imagePullPolicy: IfNotPresent
@@ -19287,6 +19317,8 @@ relevancy only:
                 - mountPath: /host
                   name: host
                   readOnly: true
+                - mountPath: /var/lib/kubelet
+                  name: kubeletdir
                 - mountPath: /run
                   name: run
                   readOnly: false
@@ -19338,6 +19370,9 @@ relevancy only:
             - hostPath:
                 path: /
               name: host
+            - hostPath:
+                path: /var/lib/kubelet
+              name: kubeletdir
             - hostPath:
                 path: /run
               name: run

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -557,6 +557,8 @@ nodeAgent:
     - mountPath: /host
       name: host
       readOnly: true
+    - mountPath: /var/lib/kubelet
+      name: kubeletdir
     - mountPath: /run
       name: run
       readOnly: false # Must be writable for the node-agent to open container runtime socket for writing
@@ -589,6 +591,9 @@ nodeAgent:
     - hostPath:
         path: /
       name: host
+    - hostPath:
+        path: /var/lib/kubelet
+      name: kubeletdir
     - hostPath:
         path: /run
       name: run


### PR DESCRIPTION
This pull request introduces changes to the `kubescape-operator` Helm chart to enhance the configuration of the node-agent by adding support for the `/var/lib/kubelet` directory mount. These updates include modifications to the `daemonset.yaml` template, the Helm chart values, and associated snapshot tests.

This PR should only be merged and release after this https://github.com/kubescape/node-agent/pull/581 is release in Node-agent.

### Enhancements to Node-Agent Configuration:

* **Addition of `KUBELET_ROOT` Environment Variable**:
  - Added the `KUBELET_ROOT` environment variable with the value `/var/lib/kubelet` in the `daemonset.yaml` template and reflected this in various snapshot test scenarios (`all capabilities`, `default capabilities`, `disable otel`, `minimal capabilities`, and `relevancy only`). [[1]](diffhunk://#diff-87cf3c6035cbedc17bdc75a7055fa64e7e38d2e83f4b0a79654a4c37c94f4efdR229-R230) [[2]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R2548-R2549) [[3]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R7784-R7785) [[4]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R12297-R12298) [[5]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R16361-R16362) [[6]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R19277-R19278)

* **Mounting `/var/lib/kubelet` Directory**:
  - Updated the `node-agent` configuration to mount the `/var/lib/kubelet` directory, both in the `daemonset.yaml` and `values.yaml` files. This includes defining a new volume mount (`kubeletdir`) and corresponding `hostPath`. These changes are also reflected in the snapshot tests for all scenarios. [[1]](diffhunk://#diff-2d5611f69251d498d71f52fa778f6ce1bc93e1e1f46951ede1c50d975bdcad02R560-R561) [[2]](diffhunk://#diff-2d5611f69251d498d71f52fa778f6ce1bc93e1e1f46951ede1c50d975bdcad02R594-R596) [[3]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R2591-R2592) [[4]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R2653-R2655) [[5]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R7827-R7828) [[6]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R7892-R7894) [[7]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R12340-R12341) [[8]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R12391-R12393) [[9]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R16404-R16405) [[10]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R16455-R16457) [[11]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R19320-R19321) [[12]](diffhunk://#diff-07dfcf2cad8f5cdd38c89c7e40cad33efef32c625fc39d3954478de854438bc7R19373-R19375)

These changes ensure better integration with Kubernetes by allowing the node-agent to access and use the `/var/lib/kubelet` directory, which is critical for certain operations. The updates to the snapshot tests confirm that the new configuration is applied consistently across various capability scenarios.