### PR TITLE
Bumping version to 1.28.0

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.27.9
+version: 1.28.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.27.9
+appVersion: 1.28.0
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -1,6 +1,6 @@
 # Kubescape Operator
 
-![Version: 1.27.9](https://img.shields.io/badge/Version-1.27.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.27.9](https://img.shields.io/badge/AppVersion-v1.27.9-informational?style=flat-square)
+![Version: 1.28.0](https://img.shields.io/badge/Version-1.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.28.0](https://img.shields.io/badge/AppVersion-v1.28.0-informational?style=flat-square)
 
 [Kubescape operator documentation](https://kubescape.io/docs/install-operator/)
 [Troubleshooting guide](https://hub.armosec.io/docs/installation-troubleshooting#3-the-kubescape-pod-restarted)

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 all capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.27.9.
+      Thank you for installing kubescape-operator version 1.28.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -35,8 +35,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -55,8 +55,8 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.9
-                helm.sh/chart: kubescape-operator-1.27.9
+                app.kubernetes.io/version: 1.28.0
+                helm.sh/chart: kubescape-operator-1.28.0
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -112,8 +112,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -167,8 +167,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -192,8 +192,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -218,8 +218,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -239,8 +239,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -293,8 +293,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -321,8 +321,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -342,8 +342,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -365,8 +365,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -386,8 +386,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -404,9 +404,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
+        app.kubernetes.io/version: 1.28.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.27.9
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -427,10 +427,10 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.9
+                app.kubernetes.io/version: 1.28.0
                 armo.tier: vuln-scan
                 bar: baz
-                helm.sh/chart: kubescape-operator-1.27.9
+                helm.sh/chart: kubescape-operator-1.28.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -484,8 +484,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -515,9 +515,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
+            app.kubernetes.io/version: 1.28.0
             bar: baz
-            helm.sh/chart: kubescape-operator-1.27.9
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -560,8 +560,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -595,8 +595,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -620,8 +620,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -645,8 +645,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -673,8 +673,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -693,8 +693,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -712,9 +712,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
+        app.kubernetes.io/version: 1.28.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.27.9
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -734,9 +734,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.9
+                app.kubernetes.io/version: 1.28.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.27.9
+                helm.sh/chart: kubescape-operator-1.28.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -799,8 +799,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -862,8 +862,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1114,8 +1114,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1139,8 +1139,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1173,8 +1173,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1349,7 +1349,7 @@ all capabilities:
   26: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.27.9\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.27.9\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.27.9\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.27.9\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -1360,8 +1360,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1379,8 +1379,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1464,8 +1464,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1495,8 +1495,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1521,8 +1521,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -1547,8 +1547,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1577,8 +1577,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1595,8 +1595,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -1628,8 +1628,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1647,9 +1647,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
+        app.kubernetes.io/version: 1.28.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.27.9
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1669,9 +1669,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.9
+                app.kubernetes.io/version: 1.28.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.27.9
+                helm.sh/chart: kubescape-operator-1.28.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -1734,8 +1734,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -1797,8 +1797,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1838,8 +1838,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1863,8 +1863,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1893,8 +1893,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -2028,8 +2028,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2096,8 +2096,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -2120,8 +2120,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -2146,8 +2146,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2175,8 +2175,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2193,8 +2193,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2315,8 +2315,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2379,8 +2379,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2435,8 +2435,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2463,9 +2463,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
+            app.kubernetes.io/version: 1.28.0
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.27.9
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -2723,8 +2723,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -2825,8 +2825,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2890,8 +2890,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -2916,8 +2916,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2944,8 +2944,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2962,8 +2962,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -2992,8 +2992,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -3011,8 +3011,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -3059,8 +3059,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3174,8 +3174,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3209,8 +3209,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3228,8 +3228,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3264,8 +3264,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -3279,7 +3279,7 @@ all capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.9
+                  value: kubescape-operator-1.28.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -3505,8 +3505,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3593,8 +3593,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3612,8 +3612,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3788,8 +3788,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3807,8 +3807,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3851,8 +3851,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3877,8 +3877,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -3903,8 +3903,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3932,8 +3932,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3949,8 +3949,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -3977,8 +3977,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4002,8 +4002,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4028,8 +4028,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -4113,8 +4113,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4142,8 +4142,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4170,8 +4170,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4188,8 +4188,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4224,8 +4224,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -4246,8 +4246,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4264,8 +4264,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: RELEASE-NAME
@@ -4351,8 +4351,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4383,8 +4383,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4412,8 +4412,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4430,8 +4430,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -4456,8 +4456,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4522,8 +4522,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -4547,8 +4547,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4579,8 +4579,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4598,8 +4598,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4625,8 +4625,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -4722,8 +4722,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4787,8 +4787,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -4811,8 +4811,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -4837,8 +4837,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -4863,8 +4863,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4891,8 +4891,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4909,8 +4909,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5144,8 +5144,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5435,8 +5435,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5454,8 +5454,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5485,8 +5485,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -5498,7 +5498,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.9
+                  value: kubescape-operator-1.28.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -5610,8 +5610,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5688,8 +5688,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5731,8 +5731,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5756,8 +5756,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -5781,8 +5781,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5809,8 +5809,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5818,7 +5818,7 @@ all capabilities:
 default capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.27.9.
+      Thank you for installing kubescape-operator version 1.28.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -5854,8 +5854,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -5908,8 +5908,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -5936,8 +5936,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5958,8 +5958,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5979,8 +5979,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -5997,8 +5997,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6027,8 +6027,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -6068,8 +6068,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -6103,8 +6103,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -6133,8 +6133,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6152,9 +6152,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
+        app.kubernetes.io/version: 1.28.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.27.9
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6174,9 +6174,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.9
+                app.kubernetes.io/version: 1.28.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.27.9
+                helm.sh/chart: kubescape-operator-1.28.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -6236,8 +6236,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -6293,8 +6293,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6545,8 +6545,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6570,8 +6570,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6604,8 +6604,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -6757,7 +6757,7 @@ default capabilities:
   16: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.27.9\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.27.9\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.27.9\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.27.9\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n        otel: enabled\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: ACCOUNT_ID\n          valueFrom:\n            secretKeyRef:\n              name: cloud-secret\n              key: account\n        - name: CLUSTER_NAME\n          value: \"kind-kind\"\n        - name: OTEL_COLLECTOR_SVC\n          value: \"otel-collector.kubescape.svc:4318\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n        otel: enabled\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: ACCOUNT_ID\n          valueFrom:\n            secretKeyRef:\n              name: cloud-secret\n              key: account\n        - name: CLUSTER_NAME\n          value: \"kind-kind\"\n        - name: OTEL_COLLECTOR_SVC\n          value: \"otel-collector.kubescape.svc:4318\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -6768,8 +6768,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6787,8 +6787,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6861,8 +6861,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6892,8 +6892,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6918,8 +6918,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6948,8 +6948,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6966,8 +6966,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -6999,8 +6999,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7018,9 +7018,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
+        app.kubernetes.io/version: 1.28.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.27.9
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7040,9 +7040,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.9
+                app.kubernetes.io/version: 1.28.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.27.9
+                helm.sh/chart: kubescape-operator-1.28.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -7102,8 +7102,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -7159,8 +7159,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7200,8 +7200,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7225,8 +7225,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7255,8 +7255,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -7391,8 +7391,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7453,8 +7453,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7482,8 +7482,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7500,8 +7500,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7622,8 +7622,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7686,8 +7686,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7705,8 +7705,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7732,8 +7732,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -7962,8 +7962,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -8070,8 +8070,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8124,8 +8124,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8152,8 +8152,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8170,8 +8170,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8285,8 +8285,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8320,8 +8320,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8339,8 +8339,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8375,8 +8375,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -8391,7 +8391,7 @@ default capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.9
+                  value: kubescape-operator-1.28.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -8601,8 +8601,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8686,8 +8686,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8705,8 +8705,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8864,8 +8864,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8883,8 +8883,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8927,8 +8927,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8953,8 +8953,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8982,8 +8982,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9065,8 +9065,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9084,8 +9084,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9116,8 +9116,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -9202,8 +9202,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9263,8 +9263,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9295,8 +9295,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9318,8 +9318,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -9340,8 +9340,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9358,8 +9358,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             otel: enabled
             tier: ks-control-plane
@@ -9439,8 +9439,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9471,8 +9471,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9500,8 +9500,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9518,8 +9518,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -9548,8 +9548,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -9567,8 +9567,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9633,8 +9633,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -9658,8 +9658,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9693,8 +9693,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9712,8 +9712,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9739,8 +9739,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -9840,8 +9840,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9894,8 +9894,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -9918,8 +9918,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -9944,8 +9944,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9972,8 +9972,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9990,8 +9990,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10156,8 +10156,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10429,8 +10429,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10448,8 +10448,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10479,8 +10479,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -10493,7 +10493,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.9
+                  value: kubescape-operator-1.28.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -10606,8 +10606,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10673,8 +10673,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10716,8 +10716,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10741,8 +10741,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10769,8 +10769,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10778,7 +10778,7 @@ default capabilities:
 disable otel:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.27.9.
+      Thank you for installing kubescape-operator version 1.28.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -10814,8 +10814,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -10867,8 +10867,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -10895,8 +10895,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10917,8 +10917,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10938,8 +10938,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -10958,8 +10958,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10977,9 +10977,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
+        app.kubernetes.io/version: 1.28.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.27.9
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10999,9 +10999,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.9
+                app.kubernetes.io/version: 1.28.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.27.9
+                helm.sh/chart: kubescape-operator-1.28.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11062,8 +11062,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11314,8 +11314,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11339,8 +11339,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11372,8 +11372,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -11510,7 +11510,7 @@ disable otel:
   12: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.27.9\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.27.9\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.27.9\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.27.9\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n        otel: enabled\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: ACCOUNT_ID\n          valueFrom:\n            secretKeyRef:\n              name: cloud-secret\n              key: account\n        - name: CLUSTER_NAME\n          value: \"kind-kind\"\n        - name: OTEL_COLLECTOR_SVC\n          value: \"otel-collector.kubescape.svc:4318\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n        otel: enabled\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: ACCOUNT_ID\n          valueFrom:\n            secretKeyRef:\n              name: cloud-secret\n              key: account\n        - name: CLUSTER_NAME\n          value: \"kind-kind\"\n        - name: OTEL_COLLECTOR_SVC\n          value: \"otel-collector.kubescape.svc:4318\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -11521,8 +11521,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11540,8 +11540,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11571,8 +11571,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11597,8 +11597,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11627,8 +11627,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11646,8 +11646,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11665,9 +11665,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
+        app.kubernetes.io/version: 1.28.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.27.9
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11687,9 +11687,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.9
+                app.kubernetes.io/version: 1.28.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.27.9
+                helm.sh/chart: kubescape-operator-1.28.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11750,8 +11750,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11791,8 +11791,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11816,8 +11816,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11845,8 +11845,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -11966,8 +11966,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11995,8 +11995,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12013,8 +12013,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12135,8 +12135,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12199,8 +12199,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12218,8 +12218,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12245,8 +12245,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -12455,8 +12455,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12483,8 +12483,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12501,8 +12501,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -12531,8 +12531,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -12550,8 +12550,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -12598,8 +12598,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12713,8 +12713,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12748,8 +12748,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12767,8 +12767,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12802,8 +12802,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -12818,7 +12818,7 @@ disable otel:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.9
+                  value: kubescape-operator-1.28.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -13022,8 +13022,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13107,8 +13107,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13192,8 +13192,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13211,8 +13211,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13255,8 +13255,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13281,8 +13281,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13310,8 +13310,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13393,8 +13393,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13412,8 +13412,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13443,8 +13443,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -13523,8 +13523,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -13555,8 +13555,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -13576,8 +13576,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13594,8 +13594,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             otel: enabled
             tier: ks-control-plane
@@ -13669,8 +13669,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13701,8 +13701,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13730,8 +13730,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13748,8 +13748,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -13778,8 +13778,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -13797,8 +13797,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13863,8 +13863,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -13888,8 +13888,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13923,8 +13923,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13942,8 +13942,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13969,8 +13969,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -14070,8 +14070,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -14094,8 +14094,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -14120,8 +14120,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14148,8 +14148,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14166,8 +14166,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14332,8 +14332,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14605,8 +14605,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14624,8 +14624,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14654,8 +14654,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -14668,7 +14668,7 @@ disable otel:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.9
+                  value: kubescape-operator-1.28.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -14765,8 +14765,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14808,8 +14808,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14833,8 +14833,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14861,8 +14861,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14870,7 +14870,7 @@ disable otel:
 minimal capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.27.9.
+      Thank you for installing kubescape-operator version 1.28.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -14906,8 +14906,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -14952,8 +14952,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -14980,8 +14980,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15002,8 +15002,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15023,8 +15023,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -15043,8 +15043,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15062,9 +15062,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
+        app.kubernetes.io/version: 1.28.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.27.9
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15084,9 +15084,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.9
+                app.kubernetes.io/version: 1.28.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.27.9
+                helm.sh/chart: kubescape-operator-1.28.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -15147,8 +15147,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15399,8 +15399,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15424,8 +15424,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15457,8 +15457,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15585,7 +15585,7 @@ minimal capabilities:
   12: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.27.9\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.27.9\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.27.9\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.27.9\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -15596,8 +15596,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15615,8 +15615,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15646,8 +15646,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15672,8 +15672,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15702,8 +15702,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15721,8 +15721,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15740,9 +15740,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
+        app.kubernetes.io/version: 1.28.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.27.9
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15762,9 +15762,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.9
+                app.kubernetes.io/version: 1.28.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.27.9
+                helm.sh/chart: kubescape-operator-1.28.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -15825,8 +15825,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15866,8 +15866,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15891,8 +15891,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15920,8 +15920,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16033,8 +16033,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -16062,8 +16062,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -16080,8 +16080,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16202,8 +16202,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16264,8 +16264,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16283,8 +16283,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16310,8 +16310,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16517,8 +16517,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16545,8 +16545,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16563,8 +16563,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -16593,8 +16593,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -16612,8 +16612,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -16660,8 +16660,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16775,8 +16775,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16809,8 +16809,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16828,8 +16828,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16863,8 +16863,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16878,7 +16878,7 @@ minimal capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.9
+                  value: kubescape-operator-1.28.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -17076,8 +17076,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17161,8 +17161,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17246,8 +17246,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17265,8 +17265,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17309,8 +17309,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17335,8 +17335,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17364,8 +17364,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17382,8 +17382,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -17412,8 +17412,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -17431,8 +17431,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17497,8 +17497,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -17522,8 +17522,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17557,8 +17557,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17576,8 +17576,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17603,8 +17603,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17701,8 +17701,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -17725,8 +17725,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -17751,8 +17751,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17779,8 +17779,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17788,7 +17788,7 @@ minimal capabilities:
 relevancy only:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.27.9.
+      Thank you for installing kubescape-operator version 1.28.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -17823,8 +17823,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -17869,8 +17869,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -17897,8 +17897,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17919,8 +17919,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17940,8 +17940,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -17960,8 +17960,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17979,9 +17979,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
+        app.kubernetes.io/version: 1.28.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.27.9
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18001,9 +18001,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.9
+                app.kubernetes.io/version: 1.28.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.27.9
+                helm.sh/chart: kubescape-operator-1.28.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -18064,8 +18064,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18316,8 +18316,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18341,8 +18341,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18374,8 +18374,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18502,7 +18502,7 @@ relevancy only:
   12: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.27.9\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.27.9\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.27.9\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.27.9\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -18513,8 +18513,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18532,8 +18532,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18563,8 +18563,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18589,8 +18589,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18619,8 +18619,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18638,8 +18638,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18657,9 +18657,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
+        app.kubernetes.io/version: 1.28.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.27.9
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18679,9 +18679,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.27.9
+                app.kubernetes.io/version: 1.28.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.27.9
+                helm.sh/chart: kubescape-operator-1.28.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -18742,8 +18742,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -18783,8 +18783,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -18808,8 +18808,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18837,8 +18837,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18950,8 +18950,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -18979,8 +18979,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -18997,8 +18997,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -19119,8 +19119,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -19181,8 +19181,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19200,8 +19200,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19226,8 +19226,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19435,8 +19435,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -19463,8 +19463,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -19481,8 +19481,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -19596,8 +19596,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -19630,8 +19630,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19649,8 +19649,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19684,8 +19684,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19699,7 +19699,7 @@ relevancy only:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.27.9
+                  value: kubescape-operator-1.28.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19888,8 +19888,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19973,8 +19973,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20058,8 +20058,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20077,8 +20077,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -20121,8 +20121,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -20147,8 +20147,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -20176,8 +20176,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -20194,8 +20194,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -20224,8 +20224,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -20243,8 +20243,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -20309,8 +20309,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -20334,8 +20334,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -20369,8 +20369,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20388,8 +20388,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20415,8 +20415,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.27.9
-            helm.sh/chart: kubescape-operator-1.27.9
+            app.kubernetes.io/version: 1.28.0
+            helm.sh/chart: kubescape-operator-1.28.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20513,8 +20513,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -20537,8 +20537,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -20563,8 +20563,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -20591,8 +20591,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -20620,8 +20620,8 @@ with multiple private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets
@@ -20658,8 +20658,8 @@ with single private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.27.9
-        helm.sh/chart: kubescape-operator-1.27.9
+        app.kubernetes.io/version: 1.28.0
+        helm.sh/chart: kubescape-operator-1.28.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -520,7 +520,7 @@ nodeAgent:
   gke:
     allowlist:
       enabled: false
-      name: armo-kubescape-node-agent-1.27
+      name: armo-kubescape-node-agent-1.28
 
   # prometheus (operator) service monitor
   serviceMonitor:


### PR DESCRIPTION
This pull request updates the version of the Kubescape Operator to 1.28.0, reflecting changes in the application and its documentation. The most important changes include updating the version and appVersion in the Helm chart, modifying the README badge to reflect the new version, and updating the node agent allowlist name.

### Version updates:

* [`charts/kubescape-operator/Chart.yaml`](diffhunk://#diff-a982fcb5ed73d5e096917432336870e77884084d3ceb0ac3914489703a7fb1b7L12-R19): Updated `version` and `appVersion` from 1.27.9 to 1.28.0 to reflect the new release.

* [`charts/kubescape-operator/README.md`](diffhunk://#diff-29301ee79c4acf85dcfdaa8326521bc7676bd383dff72b2e41a08c86b6727327L3-R3): Updated the version badge in the README file to display 1.28.0.

### Configuration updates:

* [`charts/kubescape-operator/values.yaml`](diffhunk://#diff-2d5611f69251d498d71f52fa778f6ce1bc93e1e1f46951ede1c50d975bdcad02L523-R523): Updated the `nodeAgent.gke.allowlist.name` to `armo-kubescape-node-agent-1.28` to match the new version.