### PR TITLE
tmpDirPersistence configuration for Kubevuln

### DIFF
--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -176,7 +176,12 @@ spec:
             secretName: {{ .Values.global.extraCaCertificates.secretName }}
       {{- end }}
         - name: tmp-dir
+          {{- if .Values.kubevuln.tmpDirPersistence.enabled }}
+          persistentVolumeClaim:
+            claimName: kubescape-{{ .Values.kubevuln.name }}-tmp
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         - name: grype-db-cache
           emptyDir: {}
         - name: {{ .Values.global.cloudConfig }}

--- a/charts/kubescape-operator/templates/kubevuln/tmp-dir-pvc.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/tmp-dir-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.kubevuln.tmpDirPersistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kubescape-{{ .Values.kubevuln.name }}-tmp
+  namespace: {{ .Values.ksNamespace }}
+  annotations:
+    {{- toYaml .Values.kubevuln.tmpDirPersistence.annotations | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.kubevuln.tmpDirPersistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.kubevuln.tmpDirPersistence.size }}
+  {{- if .Values.kubevuln.tmpDirPersistence.storageClassName }}
+  storageClassName: {{ .Values.kubevuln.tmpDirPersistence.storageClassName }}
+  {{- end }}
+{{- end }}

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -410,6 +410,14 @@ kubevuln:
   # Additional volumeMounts to be mounted on the vulnerability scanning microservice
   volumeMounts: []
 
+  tmpDirPersistence:
+    enabled: false
+    storageClassName: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 50Gi
+    annotations: {}
+
 # +++++++++++++++++++++++++++++++ Host-scanner ++++++++++++++++++++++++++++++++++++++++++++++++
 
 hostScanner:


### PR DESCRIPTION
This pull request introduces support for persistent storage for the `tmp-dir` volume in the `kubescape-operator` Helm chart, allowing users to optionally enable a PersistentVolumeClaim (PVC) for the temporary directory. The changes include updates to the deployment template, a new PVC template, and configuration options in the `values.yaml` file.

### Persistent storage for `tmp-dir`:

* **Deployment template update**:
  - Modified `charts/kubescape-operator/templates/kubevuln/deployment.yaml` to conditionally use a PersistentVolumeClaim for the `tmp-dir` volume if `tmpDirPersistence.enabled` is set to `true`. Otherwise, it defaults to using an `emptyDir`.

* **New PVC template**:
  - Added a new template file `charts/kubescape-operator/templates/kubevuln/tmp-dir-pvc.yaml` to define the PersistentVolumeClaim for the `tmp-dir` volume. This template is conditionally rendered based on the `tmpDirPersistence.enabled` flag.

* **Configuration options**:
  - Updated `charts/kubescape-operator/values.yaml` to include a new `tmpDirPersistence` section, allowing users to configure the PVC settings such as `enabled`, `storageClassName`, `accessModes`, `size`, and `annotations`. By default, `tmpDirPersistence.enabled` is set to `false`.