### PR TITLE
Implement disableVirtualCRDs configuration in values.yaml

### DIFF
--- a/charts/kubescape-operator/templates/storage/configmap.yaml
+++ b/charts/kubescape-operator/templates/storage/configmap.yaml
@@ -13,7 +13,11 @@ data:
   config.json: |
     {
       "cleanupInterval": "{{ .Values.storage.cleanupInterval }}",
+      {{- if .Values.storage.disableVirtualCRDs }}
+      "disableVirtualCRDs": true,
+      {{- else }}
       "disableVirtualCRDs": {{ not $configurations.virtualCrds }},
+      {{- end }}
       "excludeJsonPaths": {{ .Values.configurations.excludeJsonPaths | toJson }},
       {{- if .Values.storage.mtls.enabled }}
       "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -145,7 +145,6 @@ configurations:
   excludeJsonPaths:
     # - ".containers[*].env[?(@.name==\"DD_INJECT_ID\")]"
 
-
 # installation of the alertCRD chart
 alertCRD:
   installDefault: false # install the default CRD
@@ -489,6 +488,8 @@ storage:
     limits:
       cpu: 1500m
       memory: 1500Mi
+
+  disableVirtualCRDs: false  # set to true or false to override auto-detection
 
 # +++++++++++++++++++++++++++++ Node-agent ++++++++++++++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
This pull request introduces changes to the `kubescape-operator` Helm chart to enhance configurability and improve clarity in the configuration options. The key updates include adding a new option to explicitly disable virtual CRDs and ensuring consistency in the configuration files.

### Enhancements to configurability:

* **Support for disabling virtual CRDs explicitly**: Added a new `disableVirtualCRDs` field in `charts/kubescape-operator/values.yaml` to allow users to explicitly enable or disable virtual CRDs, overriding the auto-detection mechanism.
* **Conditional logic for `disableVirtualCRDs` in the ConfigMap**: Updated `charts/kubescape-operator/templates/storage/configmap.yaml` to include conditional logic for setting the `disableVirtualCRDs` field in the configuration JSON based on the value provided in `values.yaml`.

### Other changes:

* **Minor cleanup in `values.yaml`**: Removed an unnecessary blank line in the `configurations` section for improved readability.