### PR TITLE
prepare release 1.28.4

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.28.3
+version: 1.28.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.28.3
+appVersion: 1.28.4
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 all capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.28.3.
+      Thank you for installing kubescape-operator version 1.28.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -35,8 +35,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -55,8 +55,8 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
-                helm.sh/chart: kubescape-operator-1.28.3
+                app.kubernetes.io/version: 1.28.4
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -112,8 +112,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -167,8 +167,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -192,8 +192,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -218,8 +218,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -239,8 +239,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -293,8 +293,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -321,8 +321,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -342,8 +342,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -365,8 +365,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -386,8 +386,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -404,9 +404,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -427,10 +427,10 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: vuln-scan
                 bar: baz
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -484,8 +484,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -515,9 +515,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
+            app.kubernetes.io/version: 1.28.4
             bar: baz
-            helm.sh/chart: kubescape-operator-1.28.3
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -560,8 +560,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -595,8 +595,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -620,8 +620,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -645,8 +645,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -673,8 +673,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -693,8 +693,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -712,9 +712,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -734,9 +734,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -799,8 +799,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -862,8 +862,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1114,8 +1114,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1139,8 +1139,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1173,8 +1173,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1349,7 +1349,7 @@ all capabilities:
   26: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -1360,8 +1360,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1379,8 +1379,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1464,8 +1464,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1495,8 +1495,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1521,8 +1521,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -1547,8 +1547,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1577,8 +1577,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1595,8 +1595,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -1628,8 +1628,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1647,9 +1647,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1669,9 +1669,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -1734,8 +1734,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -1797,8 +1797,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1838,8 +1838,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1863,8 +1863,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1893,8 +1893,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -2028,8 +2028,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2096,8 +2096,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -2120,8 +2120,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -2146,8 +2146,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2175,8 +2175,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2193,8 +2193,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2315,8 +2315,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2379,8 +2379,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2435,8 +2435,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2463,9 +2463,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
+            app.kubernetes.io/version: 1.28.4
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.28.3
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -2716,8 +2716,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -2818,8 +2818,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2883,8 +2883,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -2909,8 +2909,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2937,8 +2937,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2955,8 +2955,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -2985,8 +2985,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -3004,8 +3004,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -3052,8 +3052,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3167,8 +3167,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3202,8 +3202,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3221,8 +3221,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3257,8 +3257,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -3272,7 +3272,7 @@ all capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.28.3
+                  value: kubescape-operator-1.28.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -3498,8 +3498,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3586,8 +3586,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3605,8 +3605,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3781,8 +3781,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3800,8 +3800,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3844,8 +3844,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3870,8 +3870,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -3896,8 +3896,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3925,8 +3925,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3942,8 +3942,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -3970,8 +3970,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -3995,8 +3995,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4021,8 +4021,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -4106,8 +4106,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4135,8 +4135,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4163,8 +4163,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4181,8 +4181,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4217,8 +4217,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -4239,8 +4239,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4257,8 +4257,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: RELEASE-NAME
@@ -4344,8 +4344,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4376,8 +4376,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4405,8 +4405,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -4423,8 +4423,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -4449,8 +4449,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4515,8 +4515,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -4540,8 +4540,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4572,8 +4572,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4591,8 +4591,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4618,8 +4618,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -4715,8 +4715,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4780,8 +4780,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -4804,8 +4804,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -4830,8 +4830,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -4856,8 +4856,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4884,8 +4884,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -4902,8 +4902,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5137,8 +5137,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5428,8 +5428,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5447,8 +5447,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5478,8 +5478,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -5491,7 +5491,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.28.3
+                  value: kubescape-operator-1.28.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -5603,8 +5603,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5681,8 +5681,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5724,8 +5724,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5749,8 +5749,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -5774,8 +5774,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5802,8 +5802,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5811,7 +5811,7 @@ all capabilities:
 default capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.28.3.
+      Thank you for installing kubescape-operator version 1.28.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -5847,8 +5847,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -5901,8 +5901,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -5929,8 +5929,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5951,8 +5951,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5972,8 +5972,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -5990,8 +5990,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6020,8 +6020,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -6061,8 +6061,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -6096,8 +6096,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -6126,8 +6126,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6145,9 +6145,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6167,9 +6167,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -6229,8 +6229,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -6286,8 +6286,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6538,8 +6538,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6563,8 +6563,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6597,8 +6597,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -6750,7 +6750,7 @@ default capabilities:
   16: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n        otel: enabled\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: ACCOUNT_ID\n          valueFrom:\n            secretKeyRef:\n              name: cloud-secret\n              key: account\n        - name: CLUSTER_NAME\n          value: \"kind-kind\"\n        - name: OTEL_COLLECTOR_SVC\n          value: \"otel-collector.kubescape.svc:4318\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n        otel: enabled\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: ACCOUNT_ID\n          valueFrom:\n            secretKeyRef:\n              name: cloud-secret\n              key: account\n        - name: CLUSTER_NAME\n          value: \"kind-kind\"\n        - name: OTEL_COLLECTOR_SVC\n          value: \"otel-collector.kubescape.svc:4318\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -6761,8 +6761,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6780,8 +6780,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6854,8 +6854,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6885,8 +6885,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6911,8 +6911,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6941,8 +6941,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -6959,8 +6959,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -6992,8 +6992,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7011,9 +7011,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7033,9 +7033,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -7095,8 +7095,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -7152,8 +7152,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7193,8 +7193,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7218,8 +7218,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7248,8 +7248,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -7384,8 +7384,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7446,8 +7446,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7475,8 +7475,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -7493,8 +7493,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7615,8 +7615,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7679,8 +7679,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7698,8 +7698,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7725,8 +7725,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -7950,8 +7950,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -8058,8 +8058,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8112,8 +8112,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8140,8 +8140,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8158,8 +8158,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8273,8 +8273,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8308,8 +8308,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8327,8 +8327,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8363,8 +8363,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -8379,7 +8379,7 @@ default capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.28.3
+                  value: kubescape-operator-1.28.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -8589,8 +8589,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8674,8 +8674,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8693,8 +8693,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8852,8 +8852,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8871,8 +8871,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8915,8 +8915,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8941,8 +8941,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8970,8 +8970,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9053,8 +9053,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9072,8 +9072,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9104,8 +9104,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -9190,8 +9190,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9251,8 +9251,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9283,8 +9283,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -9306,8 +9306,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -9328,8 +9328,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9346,8 +9346,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             otel: enabled
             tier: ks-control-plane
@@ -9427,8 +9427,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9459,8 +9459,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9488,8 +9488,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -9506,8 +9506,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -9536,8 +9536,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -9555,8 +9555,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9621,8 +9621,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -9646,8 +9646,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9681,8 +9681,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9700,8 +9700,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9727,8 +9727,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -9828,8 +9828,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9882,8 +9882,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -9906,8 +9906,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -9932,8 +9932,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9960,8 +9960,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -9978,8 +9978,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10144,8 +10144,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10417,8 +10417,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10436,8 +10436,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10467,8 +10467,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -10481,7 +10481,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.28.3
+                  value: kubescape-operator-1.28.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -10594,8 +10594,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10661,8 +10661,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10704,8 +10704,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10729,8 +10729,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10757,8 +10757,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10766,7 +10766,7 @@ default capabilities:
 disable otel:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.28.3.
+      Thank you for installing kubescape-operator version 1.28.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -10802,8 +10802,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -10855,8 +10855,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -10883,8 +10883,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10905,8 +10905,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10926,8 +10926,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -10946,8 +10946,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10965,9 +10965,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10987,9 +10987,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11050,8 +11050,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11302,8 +11302,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11327,8 +11327,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11360,8 +11360,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -11498,7 +11498,7 @@ disable otel:
   12: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n        otel: enabled\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: ACCOUNT_ID\n          valueFrom:\n            secretKeyRef:\n              name: cloud-secret\n              key: account\n        - name: CLUSTER_NAME\n          value: \"kind-kind\"\n        - name: OTEL_COLLECTOR_SVC\n          value: \"otel-collector.kubescape.svc:4318\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n        otel: enabled\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: ACCOUNT_ID\n          valueFrom:\n            secretKeyRef:\n              name: cloud-secret\n              key: account\n        - name: CLUSTER_NAME\n          value: \"kind-kind\"\n        - name: OTEL_COLLECTOR_SVC\n          value: \"otel-collector.kubescape.svc:4318\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -11509,8 +11509,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11528,8 +11528,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11559,8 +11559,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11585,8 +11585,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11615,8 +11615,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11634,8 +11634,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11653,9 +11653,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11675,9 +11675,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11738,8 +11738,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11779,8 +11779,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11804,8 +11804,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11833,8 +11833,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -11954,8 +11954,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11983,8 +11983,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12001,8 +12001,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12123,8 +12123,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12187,8 +12187,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12206,8 +12206,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12233,8 +12233,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -12438,8 +12438,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12466,8 +12466,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12484,8 +12484,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -12514,8 +12514,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -12533,8 +12533,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -12581,8 +12581,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12696,8 +12696,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12731,8 +12731,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12750,8 +12750,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12785,8 +12785,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -12801,7 +12801,7 @@ disable otel:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.28.3
+                  value: kubescape-operator-1.28.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -13005,8 +13005,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13090,8 +13090,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13175,8 +13175,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13194,8 +13194,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13238,8 +13238,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13264,8 +13264,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13293,8 +13293,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13376,8 +13376,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13395,8 +13395,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13426,8 +13426,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -13506,8 +13506,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -13538,8 +13538,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: otel-collector
@@ -13559,8 +13559,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13577,8 +13577,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             otel: enabled
             tier: ks-control-plane
@@ -13652,8 +13652,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13684,8 +13684,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13713,8 +13713,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -13731,8 +13731,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -13761,8 +13761,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -13780,8 +13780,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13846,8 +13846,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -13871,8 +13871,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13906,8 +13906,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13925,8 +13925,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13952,8 +13952,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -14053,8 +14053,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -14077,8 +14077,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -14103,8 +14103,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14131,8 +14131,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14149,8 +14149,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14315,8 +14315,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14588,8 +14588,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14607,8 +14607,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14637,8 +14637,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -14651,7 +14651,7 @@ disable otel:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.28.3
+                  value: kubescape-operator-1.28.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -14748,8 +14748,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14791,8 +14791,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14816,8 +14816,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14844,8 +14844,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14853,7 +14853,7 @@ disable otel:
 minimal capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.28.3.
+      Thank you for installing kubescape-operator version 1.28.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -14889,8 +14889,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -14935,8 +14935,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -14963,8 +14963,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14985,8 +14985,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15006,8 +15006,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -15026,8 +15026,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15045,9 +15045,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15067,9 +15067,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -15130,8 +15130,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15382,8 +15382,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15407,8 +15407,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15440,8 +15440,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15568,7 +15568,7 @@ minimal capabilities:
   12: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -15579,8 +15579,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15598,8 +15598,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15629,8 +15629,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15655,8 +15655,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15685,8 +15685,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15704,8 +15704,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15723,9 +15723,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15745,9 +15745,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -15808,8 +15808,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15849,8 +15849,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15874,8 +15874,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15903,8 +15903,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16016,8 +16016,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -16045,8 +16045,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -16063,8 +16063,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16185,8 +16185,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16247,8 +16247,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16266,8 +16266,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16293,8 +16293,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16495,8 +16495,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16523,8 +16523,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16541,8 +16541,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -16571,8 +16571,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -16590,8 +16590,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -16638,8 +16638,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16753,8 +16753,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16787,8 +16787,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16806,8 +16806,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16841,8 +16841,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16856,7 +16856,7 @@ minimal capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.28.3
+                  value: kubescape-operator-1.28.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -17054,8 +17054,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17139,8 +17139,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17224,8 +17224,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17243,8 +17243,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17287,8 +17287,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17313,8 +17313,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17342,8 +17342,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17360,8 +17360,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -17390,8 +17390,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -17409,8 +17409,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17475,8 +17475,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -17500,8 +17500,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17535,8 +17535,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17554,8 +17554,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17581,8 +17581,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17679,8 +17679,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -17703,8 +17703,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -17729,8 +17729,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17757,8 +17757,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17766,7 +17766,7 @@ minimal capabilities:
 multiple node agents:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.28.3.
+      Thank you for installing kubescape-operator version 1.28.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -17800,8 +17800,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -17820,8 +17820,8 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
-                helm.sh/chart: kubescape-operator-1.28.3
+                app.kubernetes.io/version: 1.28.4
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -17877,8 +17877,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -17932,8 +17932,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -17957,8 +17957,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -17983,8 +17983,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -18004,8 +18004,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -18058,8 +18058,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -18086,8 +18086,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18107,8 +18107,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -18130,8 +18130,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18151,8 +18151,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -18169,9 +18169,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18192,10 +18192,10 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: vuln-scan
                 bar: baz
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -18249,8 +18249,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18280,9 +18280,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
+            app.kubernetes.io/version: 1.28.4
             bar: baz
-            helm.sh/chart: kubescape-operator-1.28.3
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18325,8 +18325,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -18360,8 +18360,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -18385,8 +18385,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -18410,8 +18410,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -18438,8 +18438,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -18458,8 +18458,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18477,9 +18477,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18499,9 +18499,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -18564,8 +18564,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -18627,8 +18627,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18879,8 +18879,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18904,8 +18904,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18938,8 +18938,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19114,7 +19114,7 @@ multiple node agents:
   26: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -19125,8 +19125,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19144,8 +19144,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -19229,8 +19229,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -19260,8 +19260,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -19286,8 +19286,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -19312,8 +19312,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -19342,8 +19342,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -19360,8 +19360,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -19393,8 +19393,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19412,9 +19412,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19434,9 +19434,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -19499,8 +19499,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -19562,8 +19562,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -19603,8 +19603,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -19628,8 +19628,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19658,8 +19658,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19793,8 +19793,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -19861,8 +19861,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -19885,8 +19885,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -19911,8 +19911,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -19940,8 +19940,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -19958,8 +19958,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -20080,8 +20080,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -20144,8 +20144,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20200,8 +20200,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20227,9 +20227,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
+            app.kubernetes.io/version: 1.28.4
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.28.3
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20483,8 +20483,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20510,9 +20510,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
+            app.kubernetes.io/version: 1.28.4
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.28.3
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20766,8 +20766,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -20868,8 +20868,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -20933,8 +20933,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -20959,8 +20959,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -20987,8 +20987,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -21005,8 +21005,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21035,8 +21035,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -21054,8 +21054,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -21102,8 +21102,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -21217,8 +21217,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -21252,8 +21252,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21271,8 +21271,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21307,8 +21307,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21322,7 +21322,7 @@ multiple node agents:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.28.3
+                  value: kubescape-operator-1.28.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -21548,8 +21548,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21636,8 +21636,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21655,8 +21655,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -21831,8 +21831,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21850,8 +21850,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -21894,8 +21894,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -21920,8 +21920,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -21946,8 +21946,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -21975,8 +21975,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -21992,8 +21992,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -22020,8 +22020,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -22045,8 +22045,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -22071,8 +22071,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -22156,8 +22156,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -22185,8 +22185,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -22213,8 +22213,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -22231,8 +22231,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -22267,8 +22267,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -22289,8 +22289,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22307,8 +22307,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: RELEASE-NAME
@@ -22394,8 +22394,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -22426,8 +22426,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -22455,8 +22455,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: service-discovery
@@ -22473,8 +22473,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -22499,8 +22499,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -22565,8 +22565,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -22590,8 +22590,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -22622,8 +22622,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22641,8 +22641,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22668,8 +22668,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22765,8 +22765,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -22830,8 +22830,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -22854,8 +22854,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -22880,8 +22880,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -22906,8 +22906,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -22934,8 +22934,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -22952,8 +22952,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -23187,8 +23187,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -23478,8 +23478,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23497,8 +23497,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23528,8 +23528,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23541,7 +23541,7 @@ multiple node agents:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.28.3
+                  value: kubescape-operator-1.28.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -23653,8 +23653,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -23731,8 +23731,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -23774,8 +23774,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -23799,8 +23799,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -23824,8 +23824,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -23852,8 +23852,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -23861,7 +23861,7 @@ multiple node agents:
 relevancy only:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.28.3.
+      Thank you for installing kubescape-operator version 1.28.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -23896,8 +23896,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -23942,8 +23942,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -23970,8 +23970,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23992,8 +23992,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24013,8 +24013,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -24033,8 +24033,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24052,9 +24052,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24074,9 +24074,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -24137,8 +24137,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24389,8 +24389,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24414,8 +24414,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24447,8 +24447,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24575,7 +24575,7 @@ relevancy only:
   12: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.28.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.28.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.28.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.28.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.73\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n          procMount: Unmasked\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -24586,8 +24586,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24605,8 +24605,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24636,8 +24636,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24662,8 +24662,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24692,8 +24692,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24711,8 +24711,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24730,9 +24730,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
+        app.kubernetes.io/version: 1.28.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.28.3
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24752,9 +24752,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.28.3
+                app.kubernetes.io/version: 1.28.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.28.3
+                helm.sh/chart: kubescape-operator-1.28.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -24815,8 +24815,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -24856,8 +24856,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -24881,8 +24881,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24910,8 +24910,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -25023,8 +25023,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -25052,8 +25052,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -25070,8 +25070,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25192,8 +25192,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25254,8 +25254,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25273,8 +25273,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25299,8 +25299,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -25503,8 +25503,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25531,8 +25531,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25549,8 +25549,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -25664,8 +25664,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -25698,8 +25698,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25717,8 +25717,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25752,8 +25752,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -25767,7 +25767,7 @@ relevancy only:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.28.3
+                  value: kubescape-operator-1.28.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -25956,8 +25956,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26041,8 +26041,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26126,8 +26126,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26145,8 +26145,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -26189,8 +26189,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -26215,8 +26215,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -26244,8 +26244,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -26262,8 +26262,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -26292,8 +26292,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -26311,8 +26311,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -26377,8 +26377,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -26402,8 +26402,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -26437,8 +26437,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26456,8 +26456,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26483,8 +26483,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.28.3
-            helm.sh/chart: kubescape-operator-1.28.3
+            app.kubernetes.io/version: 1.28.4
+            helm.sh/chart: kubescape-operator-1.28.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -26581,8 +26581,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -26605,8 +26605,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -26631,8 +26631,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -26659,8 +26659,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -26688,8 +26688,8 @@ with multiple private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets
@@ -26726,8 +26726,8 @@ with single private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.28.3
-        helm.sh/chart: kubescape-operator-1.28.3
+        app.kubernetes.io/version: 1.28.4
+        helm.sh/chart: kubescape-operator-1.28.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets


### PR DESCRIPTION
This pull request includes a version bump for the `kubescape-operator` Helm chart to align with the updated application version.

* [`charts/kubescape-operator/Chart.yaml`](diffhunk://#diff-a982fcb5ed73d5e096917432336870e77884084d3ceb0ac3914489703a7fb1b7L12-R19): Updated `version` and `appVersion` fields from `1.28.3` to `1.28.4` to reflect the new application release.