### PR TITLE
Add pod and container security contexts for all components

### DIFF
--- a/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
@@ -30,9 +30,10 @@ spec:
         {{- with .Values.grypeOfflineDB.podLabels }}{{- toYaml . | nindent 8 }}{{- end }}
         kubescape.io/tier: "core"
     spec:
+      {{- with (coalesce .Values.grypeOfflineDB.podSecurityContext .Values.global.podSecurityContext) }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- if kindIs "string" .Values.imagePullSecrets }}
@@ -47,9 +48,10 @@ spec:
         - name: {{ .Values.grypeOfflineDB.name }}
           image: "{{ .Values.grypeOfflineDB.image.repository }}{{ if .Values.grypeOfflineDB.image.tag }}:{{ .Values.grypeOfflineDB.image.tag }}{{ else }}@{{ .Values.grypeOfflineDB.image.sha }}{{ end }}"
           imagePullPolicy: {{ .Values.grypeOfflineDB.image.pullPolicy }}
+          {{- with (coalesce .Values.grypeOfflineDB.securityContext .Values.global.securityContext) }}
           securityContext:
-            allowPrivilegeEscalation: false
-            runAsNonRoot: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
           - containerPort: 8080
             protocol: TCP

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -58,11 +58,10 @@ spec:
       {{- end }}
       {{- end }}
       {{- end }}
+      {{- with (coalesce .Values.kubescape.podSecurityContext .Values.global.podSecurityContext) }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
-        runAsUser: 65532
-        fsGroup: 65532
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $components.serviceDiscovery.enabled }}
       initContainers:
       - name: {{ .Values.serviceDiscovery.urlDiscovery.name }}
@@ -103,10 +102,10 @@ spec:
       - name: kubescape
         image: "{{ .Values.kubescape.image.repository }}:{{ .Values.kubescape.image.tag }}"
         imagePullPolicy: "{{ .Values.kubescape.image.pullPolicy }}"
+        {{- with (coalesce .Values.kubescape.securityContext .Values.global.securityContext) }}
         securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
           - name: http
             containerPort: 8080

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -48,11 +48,10 @@ spec:
       {{- end }}
       {{- end }}
       {{- end }}
+      {{- with (coalesce .Values.kubevuln.podSecurityContext .Values.global.podSecurityContext) }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
-        runAsUser: 65532
-        fsGroup: 65532
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $components.serviceDiscovery.enabled }}
       initContainers:
         - name: {{ .Values.serviceDiscovery.urlDiscovery.name }}
@@ -93,10 +92,10 @@ spec:
         - name: {{ .Values.kubevuln.name }}
           image: "{{ .Values.kubevuln.image.repository }}:{{ .Values.kubevuln.image.tag }}"
           imagePullPolicy: {{ .Values.kubevuln.image.pullPolicy }}
+          {{- with (coalesce .Values.kubevuln.securityContext .Values.global.securityContext) }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
           - containerPort: {{ .Values.kubevuln.service.port }}
             protocol: TCP

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -53,11 +53,20 @@ spec:
         otel: enabled
       {{- end }}
     spec:
+      {{- with (coalesce .Values.nodeAgent.podSecurityContext) }}
+      securityContext:
+        {{- if ge ($.Capabilities.KubeVersion.Minor | int) 29 }}
+        appArmorProfile:
+          type: Unconfined
+        {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- else }}
       securityContext:
         {{- if ge (.Capabilities.KubeVersion.Minor | int) 29 }}
         appArmorProfile:
           type: Unconfined
         {{- end }}
+      {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- if kindIs "string" .Values.imagePullSecrets }}
@@ -234,6 +243,17 @@ spec:
               value: "{{ .value }}"
             {{- end }}
             {{- end }}
+          {{- with (coalesce .Values.nodeAgent.securityContext) }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+            {{- if not (hasKey . "privileged") }}
+            privileged: {{ $.Values.nodeAgent.privileged }}
+            {{- end }}
+            {{- if not (hasKey . "seLinuxOptions") }}
+            seLinuxOptions:
+              type: {{ $.Values.nodeAgent.seLinuxType }}
+            {{- end }}
+          {{- else }}
           securityContext:
             runAsUser: 0
             privileged: {{ .Values.nodeAgent.privileged }}
@@ -248,6 +268,7 @@ spec:
                 - NET_RAW
             seLinuxOptions:
               type: {{ .Values.nodeAgent.seLinuxType }}
+          {{- end }}
           volumeMounts:
           {{- if .Values.volumeMounts }}
           {{- toYaml .Values.volumeMounts | nindent 10 }}

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -55,19 +55,18 @@ spec:
       {{- end }}
       {{- end }}
       {{- end }}
+      {{- with (coalesce .Values.operator.podSecurityContext .Values.global.podSecurityContext) }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
-        runAsUser: 65532
-        fsGroup: 65532
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.operator.name }}
           image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+          {{- with (coalesce .Values.operator.securityContext .Values.global.securityContext) }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: "trigger-port"
               containerPort: 4002

--- a/charts/kubescape-operator/templates/otel-collector/deployment.yaml
+++ b/charts/kubescape-operator/templates/otel-collector/deployment.yaml
@@ -37,9 +37,10 @@ spec:
         {{- with .Values.otelCollector.podLabels }}{{- toYaml . | nindent 8 }}{{- end }}
         kubescape.io/tier: "core"
     spec:
+      {{- with (coalesce .Values.otelCollector.podSecurityContext .Values.global.podSecurityContext) }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- if kindIs "string" .Values.imagePullSecrets }}
@@ -54,10 +55,10 @@ spec:
       - name: {{ .Values.otelCollector.name }}
         image: "{{ .Values.otelCollector.image.repository }}:{{ .Values.otelCollector.image.tag }}"
         imagePullPolicy: "{{ .Values.otelCollector.image.pullPolicy }}"
+        {{- with (coalesce .Values.otelCollector.securityContext .Values.global.securityContext) }}
         securityContext:
-          allowPrivilegeEscalation: false
-          runAsNonRoot: true
-          runAsUser: 100
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
           - name: otlp
             containerPort: 4317

--- a/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
@@ -37,19 +37,18 @@ spec:
       {{- end }}
       {{- end }}
       {{- end }}
+      {{- with (coalesce .Values.prometheusExporter.podSecurityContext .Values.global.podSecurityContext) }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
-        runAsUser: 65532
-        fsGroup: 65532
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.prometheusExporter.name }}
           image: {{ .Values.prometheusExporter.image.repository }}:{{ .Values.prometheusExporter.image.tag }}
           imagePullPolicy: {{ .Values.prometheusExporter.image.pullPolicy }}
+          {{- with (coalesce .Values.prometheusExporter.securityContext .Values.global.securityContext) }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
           - name: metrics
             containerPort: {{ .Values.prometheusExporter.service.port }}

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -43,18 +43,18 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{ .Values.storage.name }}
+      {{- with (coalesce .Values.storage.podSecurityContext .Values.global.podSecurityContext) }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
-        runAsUser: 65532
-        fsGroup: 65532
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: apiserver
         image: "{{ .Values.storage.image.repository }}:{{ .Values.storage.image.tag }}"
         imagePullPolicy: {{ .Values.storage.image.pullPolicy }}
+        {{- with (coalesce .Values.storage.securityContext .Values.global.securityContext) }}
         securityContext:
-          allowPrivilegeEscalation: false
-          runAsNonRoot: true
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /livez

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -49,11 +49,10 @@ spec:
       {{- end }}
       {{- end }}
       {{- end }}
+      {{- with (coalesce .Values.synchronizer.podSecurityContext .Values.global.podSecurityContext) }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
-        runAsUser: 65532
-        fsGroup: 65532
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $components.serviceDiscovery.enabled }}
       initContainers:
         - name: {{ .Values.serviceDiscovery.urlDiscovery.name }}
@@ -94,10 +93,10 @@ spec:
         - name: {{ .Values.synchronizer.name }}
           image: "{{ .Values.synchronizer.image.repository }}:{{ .Values.synchronizer.image.tag }}"
           imagePullPolicy: {{ .Values.synchronizer.image.pullPolicy }}
+          {{- with (coalesce .Values.synchronizer.securityContext .Values.global.securityContext) }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -532,6 +532,10 @@ all capabilities:
                   memory: 200Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
                 runAsNonRoot: true
           imagePullSecrets:
             - name: foo
@@ -539,6 +543,10 @@ all capabilities:
           nodeSelector:
             kubernetes.io/os: linux
           securityContext:
+            fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
           tolerations: null
@@ -1275,6 +1283,9 @@ all capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -1344,6 +1355,8 @@ all capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -1988,6 +2001,9 @@ all capabilities:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -2053,6 +2069,8 @@ all capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -3397,6 +3415,9 @@ all capabilities:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -3437,6 +3458,8 @@ all capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -4134,6 +4157,9 @@ all capabilities:
                   memory: 10Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -4147,6 +4173,8 @@ all capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -4547,6 +4575,10 @@ all capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -4566,6 +4598,8 @@ all capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -5415,6 +5449,9 @@ all capabilities:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -5478,6 +5515,8 @@ all capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -5952,10 +5991,18 @@ default capabilities:
                   memory: 200Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
                 runAsNonRoot: true
           nodeSelector:
             kubernetes.io/os: linux
           securityContext:
+            fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
           tolerations: null
@@ -6584,6 +6631,9 @@ default capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -6649,6 +6699,8 @@ default capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -7241,6 +7293,9 @@ default capabilities:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -7302,6 +7357,8 @@ default capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -8383,6 +8440,9 @@ default capabilities:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -8420,6 +8480,8 @@ default capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -9233,6 +9295,10 @@ default capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -9252,6 +9318,8 @@ default capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -9974,6 +10042,9 @@ default capabilities:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -10033,6 +10104,8 @@ default capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -10911,6 +10984,9 @@ disable otel:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -10964,6 +11040,8 @@ disable otel:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -11387,6 +11465,9 @@ disable otel:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -11436,6 +11517,8 @@ disable otel:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -12366,6 +12449,9 @@ disable otel:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -12397,6 +12483,8 @@ disable otel:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -13090,6 +13178,10 @@ disable otel:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -13109,6 +13201,8 @@ disable otel:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -13776,6 +13870,9 @@ disable otel:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -13823,6 +13920,8 @@ disable otel:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -14627,6 +14726,9 @@ minimal capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -14651,6 +14753,8 @@ minimal capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -15074,6 +15178,9 @@ minimal capabilities:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -15094,6 +15201,8 @@ minimal capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -16023,6 +16132,9 @@ minimal capabilities:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -16054,6 +16166,8 @@ minimal capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -16749,6 +16863,10 @@ minimal capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -16768,6 +16886,8 @@ minimal capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -17422,6 +17542,10 @@ multiple node agents:
                   memory: 200Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
                 runAsNonRoot: true
           imagePullSecrets:
             - name: foo
@@ -17429,6 +17553,10 @@ multiple node agents:
           nodeSelector:
             kubernetes.io/os: linux
           securityContext:
+            fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
           tolerations: null
@@ -18165,6 +18293,9 @@ multiple node agents:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -18234,6 +18365,8 @@ multiple node agents:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -18878,6 +19011,9 @@ multiple node agents:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -18943,6 +19079,8 @@ multiple node agents:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -20574,6 +20712,9 @@ multiple node agents:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -20614,6 +20755,8 @@ multiple node agents:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -21311,6 +21454,9 @@ multiple node agents:
                   memory: 10Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -21324,6 +21470,8 @@ multiple node agents:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -21724,6 +21872,10 @@ multiple node agents:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -21743,6 +21895,8 @@ multiple node agents:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -22592,6 +22746,9 @@ multiple node agents:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -22655,6 +22812,8 @@ multiple node agents:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -23568,6 +23727,9 @@ relevancy only:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -23592,6 +23754,8 @@ relevancy only:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -24015,6 +24179,9 @@ relevancy only:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -24035,6 +24202,8 @@ relevancy only:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -24865,6 +25034,9 @@ relevancy only:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -24893,6 +25065,8 @@ relevancy only:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -25585,6 +25759,10 @@ relevancy only:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -25604,6 +25782,8 @@ relevancy only:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -230,6 +230,23 @@ global:
     scc:
       enabled: false
 
+  # Default pod security context for all components (can be overridden per component)
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
+
+  # Default container security context for all components (can be overridden per component)
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop: ["ALL"]
+
 # Image scanning configurations
 imageScanning:
   # Provide credentials here when scanning images pulled from private container registries.
@@ -272,6 +289,12 @@ kubescape:
     limits:
       cpu: 600m
       memory: 1Gi
+
+  # Override pod security context for kubescape component (inherits from global if not set)
+  podSecurityContext: {}
+
+  # Override container security context for kubescape component (inherits from global if not set)
+  securityContext: {}
 
   # -- download policies every scan, we recommend it should remain true, you should change to 'false' when running in an air-gapped environment or when scanning with high frequency (when running with Prometheus)
   downloadArtifacts: true
@@ -337,6 +360,12 @@ operator:
       memory: 300Mi
   env: {}
 
+  # Override pod security context for operator component (inherits from global if not set)
+  podSecurityContext: {}
+
+  # Override container security context for operator component (inherits from global if not set)
+  securityContext: {}
+
   podScanGuardTime: "1h"
 
   # Additional volumes to be mounted on the websocket
@@ -389,6 +418,12 @@ kubevuln:
       cpu: 1500m
       memory: 5000Mi
       ephemeral-storage: 10Gi
+
+  # Override pod security context for kubevuln component (inherits from global if not set)
+  podSecurityContext: {}
+
+  # Override container security context for kubevuln component (inherits from global if not set)
+  securityContext: {}
   config:
     maxImageSize: 5368709120 # set the maximum image size for scanning. This refers to the size of the zipped image. If the size of the non-zipped image is larger, increase the ephemeral-storage limits. It is recommended to use the same size as the requested ephemeral-storage
     maxSBOMSize: 20971520
@@ -488,6 +523,12 @@ storage:
       cpu: 1500m
       memory: 1500Mi
 
+  # Override pod security context for storage component (inherits from global if not set)
+  podSecurityContext: {}
+
+  # Override container security context for storage component (inherits from global if not set)
+  securityContext: {}
+
   disableVirtualCRDs: false  # set to true or false to override auto-detection
 
   # -- queue manager configuration
@@ -559,6 +600,16 @@ nodeAgent:
       ruleCooldownAfterCount: 1
       ruleCooldownOnProfileFailure: true
       ruleCooldownMaxSize: 20000
+
+  # Pod security context for node-agent (requires special privileges, defaults to minimal restrictions)
+  podSecurityContext: {}
+
+  # Container security context for node-agent (requires privileged access, overrides global defaults)
+  securityContext:
+    runAsUser: 0
+    privileged: false  # Will be overridden by .Values.nodeAgent.privileged
+    capabilities:
+      add: ["SYS_ADMIN", "SYS_PTRACE", "NET_ADMIN", "SYSLOG", "SYS_RESOURCE", "IPC_LOCK", "NET_RAW"]
 
   # GKE Autopilot allowlist
   gke:
@@ -779,6 +830,12 @@ synchronizer:
     targetPort: 8089
     protocol: TCP
 
+  # Override pod security context for synchronizer component (inherits from global if not set)
+  podSecurityContext: {}
+
+  # Override container security context for synchronizer component (inherits from global if not set)
+  securityContext: {}
+
 # -----------------------------------------------------------------------------------------
 # ------------------------ Microservice - helpers -----------------------------------------
 # -----------------------------------------------------------------------------------------
@@ -815,6 +872,12 @@ otelCollector:
       cpu: 1
       memory: 1Gi
 
+  # Override pod security context for otel-collector component (inherits from global if not set)
+  podSecurityContext: {}
+
+  # Override container security context for otel-collector component (inherits from global if not set)
+  securityContext: {}
+
 # +++++++++++++++++++++++++++++ GrypeOfflineDB ++++++++++++++++++++++++++++++++++++++++++++++++
 
 grypeOfflineDB:
@@ -840,6 +903,12 @@ grypeOfflineDB:
     limits:
       cpu: 150m
       memory: 200Mi
+
+  # Override pod security context for grype-offline-db component (inherits from global if not set)
+  podSecurityContext: {}
+
+  # Override container security context for grype-offline-db component (inherits from global if not set)
+  securityContext: {}
 
 # +++++++++++++++++++++++++++++ Discovery ++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -915,6 +984,12 @@ prometheusExporter:
 
   # Additional volumeMounts to be mounted on the prometheus exporter
   volumeMounts: []
+
+  # Override pod security context for prometheus-exporter component (inherits from global if not set)
+  podSecurityContext: {}
+
+  # Override container security context for prometheus-exporter component (inherits from global if not set)
+  securityContext: {}
 
 # +++++++++++++++++++++++++++++ Upgrader ++++++++++++++++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
This pull request refactors the way Kubernetes security contexts are defined in all Helm chart templates for the Kubescape operator and its components. The main improvement is to allow full customization of both pod-level and container-level `securityContext` via Helm values, replacing hardcoded defaults. This change increases flexibility for users and improves security posture by supporting best practices such as dropping all capabilities and enforcing non-root execution. Snapshot test files are updated to reflect the new, more secure defaults.

This PR is addressing #740 

**Security context templating improvements:**

* All deployment and daemonset templates now use `coalesce` to allow users to override both pod-level and container-level `securityContext` via values such as `.Values.<component>.podSecurityContext` and `.Values.<component>.securityContext`, falling back to global defaults if not set. Hardcoded fields (e.g., `runAsNonRoot`, `allowPrivilegeEscalation`, `seccompProfile`) are removed in favor of user-supplied YAML. 
**Security best practices:**

* Container-level `securityContext` now supports dropping all Linux capabilities (`capabilities: drop: [ALL]`), enforcing `readOnlyRootFilesystem`, and running as non-root by default. These changes are reflected in the updated snapshot test files.

**Component-specific enhancements:**

* The `node-agent` daemonset template now conditionally applies `appArmorProfile` if Kubernetes version is 1.29+, and allows SELinux options and privilege settings to be customized or defaulted based on values. 

**Snapshot test updates:**

* All affected snapshot test files are updated to reflect the new, configurable security context defaults, including dropped capabilities, enforced non-root execution, and group/user settings.

**Generalization and maintainability:**

* By removing hardcoded security settings and using Helm's `coalesce` function, the charts are now easier to maintain and extend, and users can more easily align deployments with organizational security policies.