### PR TITLE
Initial proposal

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/daemonset-configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset-configmap.yaml
@@ -1,0 +1,18 @@
+{{- $components := fromYaml (include "components" .) }}
+{{- if and $components.nodeAgent.enabled (not .Values.nodeAgent.multipleDaemonSets.enabled) .Values.nodeAgent.applyViaConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.nodeAgent.name }}-daemonset
+  namespace: {{ .Values.ksNamespace }}
+  annotations:
+    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    kubescape.io/resource-type: daemonset-yaml
+  labels:
+    {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
+    kubescape.io/tier: "core"
+    kubescape.io/apply-resource: "true"
+data:
+  daemonset.yaml: |
+{{ include "node-agent.daemonset" . | indent 4 }}
+{{- end }}

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -1,6 +1,7 @@
+{{- /* Define the shared DaemonSet template */}}
+{{- define "node-agent.daemonset" -}}
 {{- $checksums := fromYaml (include "checksums" .) }}
 {{- $components := fromYaml (include "components" .) }}
-{{- if and $components.nodeAgent.enabled (not .Values.nodeAgent.multipleDaemonSets.enabled) }}
 {{- $no_proxy_envar_list := (include "no_proxy_envar_list" .) -}}
 apiVersion: apps/v1
 {{- if .Values.capabilities.testing.nodeAgentMultiplication.enabled }}
@@ -304,4 +305,10 @@ spec:
       {{- else if .Values.customScheduling.tolerations }}
       {{- toYaml .Values.customScheduling.tolerations | nindent 8 }}
       {{- end }}
+{{- end -}}
+
+{{- /* Use the shared template when applyViaConfigMap is false */}}
+{{- $components := fromYaml (include "components" .) }}
+{{- if and $components.nodeAgent.enabled (not .Values.nodeAgent.multipleDaemonSets.enabled) (not .Values.nodeAgent.applyViaConfigMap) }}
+{{- include "node-agent.daemonset" . }}
 {{- end }}

--- a/charts/kubescape-operator/templates/operator/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/operator/clusterrole.yaml
@@ -22,7 +22,11 @@ rules:
     verbs: ["get", "watch", "list", "create", "update", "delete" ,"patch"]
   - apiGroups: ["apps"]
     resources: ["deployments", "daemonsets", "statefulsets", "replicasets"]
+    {{- if .Values.nodeAgent.applyViaConfigMap }}
+    verbs: ["get", "watch", "list", "create", "update", "delete", "patch"]
+    {{- else }}
     verbs: ["get", "watch", "list"]
+    {{- end }}
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
     resources: ["vulnerabilitymanifests", "vulnerabilitymanifestsummaries", "workloadconfigurationscans", "workloadconfigurationscansummaries", "openvulnerabilityexchangecontainers", "containerprofiles", "sbomsyfts"]
     verbs: ["get", "watch", "list", "delete"]

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -535,6 +535,10 @@ storage:
 
 nodeAgent:
   name: node-agent
+  # -- When enabled, the DaemonSet YAML will be stored in a ConfigMap instead of being applied directly.
+  # The operator can then read this ConfigMap and apply the DaemonSet. Requires operator to have
+  # create/update/delete permissions for daemonsets.
+  applyViaConfigMap: false
   image:
     # -- source code: https://github.com/kubescape/node-agent
     repository: quay.io/kubescape/node-agent


### PR DESCRIPTION
This pull request introduces a new deployment option for the `nodeAgent` DaemonSet by allowing its manifest to be stored in a ConfigMap, which the operator can then apply. This adds flexibility in how the DaemonSet is managed and requires corresponding changes to RBAC permissions and Helm templating logic.

**Deployment method enhancements:**

* Added the `applyViaConfigMap` option to `nodeAgent` in `values.yaml`, allowing users to choose between direct DaemonSet application and deployment via a ConfigMap.
* Created a new Helm template (`daemonset-configmap.yaml`) that generates a ConfigMap containing the DaemonSet manifest when `applyViaConfigMap` is enabled.
* Refactored the DaemonSet Helm template (`daemonset.yaml`) to use a shared template for generating the DaemonSet manifest, supporting both direct application and ConfigMap-based deployment. [[1]](diffhunk://#diff-87cf3c6035cbedc17bdc75a7055fa64e7e38d2e83f4b0a79654a4c37c94f4efdR1-L3) [[2]](diffhunk://#diff-87cf3c6035cbedc17bdc75a7055fa64e7e38d2e83f4b0a79654a4c37c94f4efdR308-R313)

**RBAC (ClusterRole) adjustments:**

* Updated the operator's ClusterRole template to grant additional create/update/delete/patch permissions for DaemonSets when `applyViaConfigMap` is enabled, ensuring the operator can manage DaemonSets from the ConfigMap.