### PR TITLE
Update operator image tag to v0.2.121

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.30.0
+version: 1.30.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.30.0
+appVersion: 1.30.1
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 all capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.0.
+      Thank you for installing kubescape-operator version 1.30.1.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -35,8 +35,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -55,8 +55,8 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
-                helm.sh/chart: kubescape-operator-1.30.0
+                app.kubernetes.io/version: 1.30.1
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -112,8 +112,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -167,8 +167,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -192,8 +192,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -218,8 +218,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -239,8 +239,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -286,8 +286,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -314,8 +314,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -335,8 +335,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -358,8 +358,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -379,8 +379,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -397,9 +397,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -420,10 +420,10 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: vuln-scan
                 bar: baz
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -477,8 +477,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -508,9 +508,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
+            app.kubernetes.io/version: 1.30.1
             bar: baz
-            helm.sh/chart: kubescape-operator-1.30.0
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -553,8 +553,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -588,8 +588,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -613,8 +613,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -638,8 +638,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -666,8 +666,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -686,8 +686,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -705,9 +705,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -727,9 +727,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -792,8 +792,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -855,8 +855,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1107,8 +1107,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1132,8 +1132,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1166,8 +1166,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1379,7 +1379,7 @@ all capabilities:
   26: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.30.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.1\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.1\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.30.1\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.1\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -1390,8 +1390,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1409,8 +1409,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1497,8 +1497,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1528,8 +1528,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1554,8 +1554,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -1580,8 +1580,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1610,8 +1610,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1628,8 +1628,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -1661,8 +1661,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1680,9 +1680,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1702,9 +1702,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -1767,8 +1767,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -1830,8 +1830,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1871,8 +1871,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1896,8 +1896,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1926,8 +1926,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -2098,8 +2098,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2166,8 +2166,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -2190,8 +2190,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -2216,8 +2216,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2245,8 +2245,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2263,8 +2263,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2393,8 +2393,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2458,8 +2458,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2514,8 +2514,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2542,9 +2542,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
+            app.kubernetes.io/version: 1.30.1
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.30.0
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -2839,8 +2839,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -2890,8 +2890,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -3458,8 +3458,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -3523,8 +3523,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -3549,8 +3549,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -3577,8 +3577,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -3595,8 +3595,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -3625,8 +3625,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -3644,8 +3644,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -3692,8 +3692,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3817,8 +3817,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3873,8 +3873,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3892,8 +3892,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3928,8 +3928,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -3943,7 +3943,7 @@ all capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.0
+                  value: kubescape-operator-1.30.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -3964,7 +3964,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.119
+              image: quay.io/kubescape/operator:v0.2.121
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -4163,8 +4163,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4251,8 +4251,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4270,8 +4270,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4446,8 +4446,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4465,8 +4465,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4509,8 +4509,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4535,8 +4535,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -4561,8 +4561,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4590,8 +4590,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4607,8 +4607,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4635,8 +4635,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4660,8 +4660,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4686,8 +4686,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -4772,8 +4772,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4841,8 +4841,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4869,8 +4869,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4887,8 +4887,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4923,8 +4923,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -4942,8 +4942,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -4968,8 +4968,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5034,8 +5034,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -5059,8 +5059,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5096,8 +5096,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5115,8 +5115,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5142,8 +5142,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -5241,8 +5241,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5311,8 +5311,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -5335,8 +5335,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -5361,8 +5361,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -5387,8 +5387,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5415,8 +5415,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5433,8 +5433,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5669,8 +5669,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -5966,8 +5966,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5985,8 +5985,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6016,8 +6016,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -6029,7 +6029,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.0
+                  value: kubescape-operator-1.30.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -6173,8 +6173,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6251,8 +6251,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6294,8 +6294,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6319,8 +6319,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -6344,8 +6344,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6372,8 +6372,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6381,7 +6381,7 @@ all capabilities:
 backend-storage enabled disables scanning capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.0.
+      Thank you for installing kubescape-operator version 1.30.1.
 
 
 
@@ -6409,8 +6409,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -6455,8 +6455,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -6483,8 +6483,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6505,8 +6505,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6526,8 +6526,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -6544,8 +6544,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -6674,8 +6674,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -6739,8 +6739,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6758,8 +6758,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6784,8 +6784,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -7025,8 +7025,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -7079,8 +7079,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -7647,8 +7647,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7675,8 +7675,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7693,8 +7693,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -7723,8 +7723,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -7742,8 +7742,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -7790,8 +7790,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -7915,8 +7915,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -7971,8 +7971,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7990,8 +7990,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8025,8 +8025,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -8040,7 +8040,7 @@ backend-storage enabled disables scanning capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.0
+                  value: kubescape-operator-1.30.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -8055,7 +8055,7 @@ backend-storage enabled disables scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.119
+              image: quay.io/kubescape/operator:v0.2.121
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -8236,8 +8236,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8321,8 +8321,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8406,8 +8406,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8425,8 +8425,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8469,8 +8469,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8495,8 +8495,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8524,8 +8524,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8546,8 +8546,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -8565,8 +8565,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -8732,8 +8732,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -9011,8 +9011,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9030,8 +9030,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9060,8 +9060,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -9073,7 +9073,7 @@ backend-storage enabled disables scanning capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.0
+                  value: kubescape-operator-1.30.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -9188,8 +9188,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -9231,8 +9231,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -9256,8 +9256,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -9284,8 +9284,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -9293,7 +9293,7 @@ backend-storage enabled disables scanning capabilities:
 default capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.0.
+      Thank you for installing kubescape-operator version 1.30.1.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -9329,8 +9329,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -9376,8 +9376,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -9404,8 +9404,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9426,8 +9426,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9447,8 +9447,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -9465,8 +9465,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9495,8 +9495,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -9536,8 +9536,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -9571,8 +9571,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -9601,8 +9601,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9620,9 +9620,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9642,9 +9642,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -9704,8 +9704,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -9761,8 +9761,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -10013,8 +10013,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -10038,8 +10038,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10072,8 +10072,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -10250,7 +10250,7 @@ default capabilities:
   16: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.30.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.1\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.1\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.30.1\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.1\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -10261,8 +10261,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10280,8 +10280,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -10357,8 +10357,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -10388,8 +10388,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -10414,8 +10414,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -10444,8 +10444,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -10462,8 +10462,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -10495,8 +10495,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10514,9 +10514,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10536,9 +10536,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -10598,8 +10598,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -10655,8 +10655,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -10696,8 +10696,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -10721,8 +10721,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10751,8 +10751,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -10912,8 +10912,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -10974,8 +10974,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11003,8 +11003,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11021,8 +11021,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -11151,8 +11151,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -11216,8 +11216,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11235,8 +11235,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11262,8 +11262,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -11524,8 +11524,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -11581,8 +11581,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -12149,8 +12149,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12203,8 +12203,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12231,8 +12231,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12249,8 +12249,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12374,8 +12374,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12430,8 +12430,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12449,8 +12449,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12485,8 +12485,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -12500,7 +12500,7 @@ default capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.0
+                  value: kubescape-operator-1.30.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -12515,7 +12515,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.119
+              image: quay.io/kubescape/operator:v0.2.121
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12702,8 +12702,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12787,8 +12787,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12806,8 +12806,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -12965,8 +12965,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12984,8 +12984,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13028,8 +13028,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13054,8 +13054,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13083,8 +13083,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13106,8 +13106,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -13125,8 +13125,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -13155,8 +13155,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -13174,8 +13174,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13240,8 +13240,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -13265,8 +13265,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13305,8 +13305,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13324,8 +13324,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13351,8 +13351,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -13451,8 +13451,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13513,8 +13513,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -13537,8 +13537,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -13563,8 +13563,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13591,8 +13591,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -13609,8 +13609,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -13776,8 +13776,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14055,8 +14055,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14074,8 +14074,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14105,8 +14105,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -14118,7 +14118,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.0
+                  value: kubescape-operator-1.30.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -14252,8 +14252,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14319,8 +14319,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14362,8 +14362,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14387,8 +14387,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14415,8 +14415,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14424,7 +14424,7 @@ default capabilities:
 disable otel:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.0.
+      Thank you for installing kubescape-operator version 1.30.1.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -14460,8 +14460,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -14506,8 +14506,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -14534,8 +14534,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14556,8 +14556,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14577,8 +14577,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -14597,8 +14597,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14616,9 +14616,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14638,9 +14638,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -14701,8 +14701,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -14953,8 +14953,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -14978,8 +14978,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15011,8 +15011,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15171,7 +15171,7 @@ disable otel:
   12: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.30.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.1\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.1\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.30.1\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.1\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -15182,8 +15182,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15201,8 +15201,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15232,8 +15232,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15258,8 +15258,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15288,8 +15288,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -15307,8 +15307,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15326,9 +15326,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15348,9 +15348,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -15411,8 +15411,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15452,8 +15452,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15477,8 +15477,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15506,8 +15506,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15649,8 +15649,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15678,8 +15678,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -15696,8 +15696,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -15826,8 +15826,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -15891,8 +15891,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15910,8 +15910,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15937,8 +15937,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16176,8 +16176,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16204,8 +16204,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16222,8 +16222,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -16252,8 +16252,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -16271,8 +16271,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -16319,8 +16319,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16444,8 +16444,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16500,8 +16500,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16519,8 +16519,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16554,8 +16554,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16569,7 +16569,7 @@ disable otel:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.0
+                  value: kubescape-operator-1.30.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -16584,7 +16584,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.119
+              image: quay.io/kubescape/operator:v0.2.121
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16765,8 +16765,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16850,8 +16850,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16935,8 +16935,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16954,8 +16954,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -16998,8 +16998,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17024,8 +17024,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17053,8 +17053,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17071,8 +17071,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -17101,8 +17101,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -17120,8 +17120,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17186,8 +17186,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -17211,8 +17211,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17251,8 +17251,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17270,8 +17270,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17297,8 +17297,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17397,8 +17397,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -17421,8 +17421,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -17447,8 +17447,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17475,8 +17475,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -17493,8 +17493,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -17660,8 +17660,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -17939,8 +17939,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17958,8 +17958,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17988,8 +17988,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18001,7 +18001,7 @@ disable otel:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.0
+                  value: kubescape-operator-1.30.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -18116,8 +18116,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -18159,8 +18159,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -18184,8 +18184,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -18212,8 +18212,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -18221,7 +18221,7 @@ disable otel:
 minimal capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.0.
+      Thank you for installing kubescape-operator version 1.30.1.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -18257,8 +18257,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -18303,8 +18303,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -18331,8 +18331,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18353,8 +18353,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18374,8 +18374,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -18394,8 +18394,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18413,9 +18413,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18435,9 +18435,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -18498,8 +18498,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18750,8 +18750,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18775,8 +18775,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18808,8 +18808,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18937,7 +18937,7 @@ minimal capabilities:
   12: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.30.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.1\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.1\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.30.1\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.1\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -18948,8 +18948,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18967,8 +18967,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -18998,8 +18998,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -19024,8 +19024,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -19054,8 +19054,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -19073,8 +19073,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19092,9 +19092,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19114,9 +19114,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -19177,8 +19177,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -19218,8 +19218,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -19243,8 +19243,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19272,8 +19272,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19386,8 +19386,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -19415,8 +19415,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -19433,8 +19433,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -19563,8 +19563,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -19626,8 +19626,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19645,8 +19645,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19672,8 +19672,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19883,8 +19883,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -19911,8 +19911,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -19929,8 +19929,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -19959,8 +19959,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -19978,8 +19978,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -20026,8 +20026,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -20151,8 +20151,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -20206,8 +20206,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20225,8 +20225,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20260,8 +20260,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20275,7 +20275,7 @@ minimal capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.0
+                  value: kubescape-operator-1.30.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -20292,7 +20292,7 @@ minimal capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/operator:v0.2.119
+              image: quay.io/kubescape/operator:v0.2.121
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -20473,8 +20473,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20558,8 +20558,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20643,8 +20643,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20662,8 +20662,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -20706,8 +20706,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -20732,8 +20732,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -20761,8 +20761,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -20779,8 +20779,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -20809,8 +20809,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -20828,8 +20828,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -20894,8 +20894,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -20919,8 +20919,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -20959,8 +20959,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20978,8 +20978,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21005,8 +21005,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21107,8 +21107,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -21131,8 +21131,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -21157,8 +21157,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -21185,8 +21185,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -21194,7 +21194,7 @@ minimal capabilities:
 multiple node agents:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.0.
+      Thank you for installing kubescape-operator version 1.30.1.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -21228,8 +21228,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -21248,8 +21248,8 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
-                helm.sh/chart: kubescape-operator-1.30.0
+                app.kubernetes.io/version: 1.30.1
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -21305,8 +21305,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -21360,8 +21360,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -21385,8 +21385,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -21411,8 +21411,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -21432,8 +21432,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -21479,8 +21479,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -21507,8 +21507,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21528,8 +21528,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -21551,8 +21551,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21572,8 +21572,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -21590,9 +21590,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21613,10 +21613,10 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: vuln-scan
                 bar: baz
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -21670,8 +21670,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21701,9 +21701,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
+            app.kubernetes.io/version: 1.30.1
             bar: baz
-            helm.sh/chart: kubescape-operator-1.30.0
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21746,8 +21746,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -21781,8 +21781,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -21806,8 +21806,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -21831,8 +21831,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -21859,8 +21859,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -21879,8 +21879,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21898,9 +21898,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21920,9 +21920,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -21985,8 +21985,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -22048,8 +22048,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -22300,8 +22300,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -22325,8 +22325,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22359,8 +22359,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22572,7 +22572,7 @@ multiple node agents:
   26: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.30.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.1\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.1\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.30.1\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.1\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -22583,8 +22583,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22602,8 +22602,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -22690,8 +22690,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -22721,8 +22721,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -22747,8 +22747,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -22773,8 +22773,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -22803,8 +22803,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -22821,8 +22821,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -22854,8 +22854,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22873,9 +22873,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22895,9 +22895,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -22960,8 +22960,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -23023,8 +23023,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -23064,8 +23064,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -23089,8 +23089,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23119,8 +23119,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23291,8 +23291,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -23359,8 +23359,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -23383,8 +23383,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -23409,8 +23409,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -23438,8 +23438,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -23456,8 +23456,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -23586,8 +23586,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -23651,8 +23651,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23707,8 +23707,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23734,9 +23734,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
+            app.kubernetes.io/version: 1.30.1
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.30.0
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24034,8 +24034,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24061,9 +24061,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
+            app.kubernetes.io/version: 1.30.1
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.30.0
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24361,8 +24361,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -24412,8 +24412,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -24980,8 +24980,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25045,8 +25045,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -25071,8 +25071,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25099,8 +25099,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25117,8 +25117,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -25147,8 +25147,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -25166,8 +25166,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -25214,8 +25214,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -25339,8 +25339,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -25395,8 +25395,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25414,8 +25414,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25450,8 +25450,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -25465,7 +25465,7 @@ multiple node agents:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.0
+                  value: kubescape-operator-1.30.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -25486,7 +25486,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.119
+              image: quay.io/kubescape/operator:v0.2.121
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -25685,8 +25685,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25773,8 +25773,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25792,8 +25792,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -25968,8 +25968,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25987,8 +25987,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -26031,8 +26031,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -26057,8 +26057,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -26083,8 +26083,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -26112,8 +26112,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -26129,8 +26129,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -26157,8 +26157,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -26182,8 +26182,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -26208,8 +26208,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -26294,8 +26294,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -26363,8 +26363,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -26391,8 +26391,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -26409,8 +26409,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -26445,8 +26445,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -26464,8 +26464,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -26490,8 +26490,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -26556,8 +26556,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -26581,8 +26581,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -26618,8 +26618,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26637,8 +26637,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26664,8 +26664,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -26763,8 +26763,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -26833,8 +26833,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -26857,8 +26857,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -26883,8 +26883,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -26909,8 +26909,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -26937,8 +26937,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -26955,8 +26955,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -27191,8 +27191,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -27488,8 +27488,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27507,8 +27507,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27538,8 +27538,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -27551,7 +27551,7 @@ multiple node agents:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.0
+                  value: kubescape-operator-1.30.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -27695,8 +27695,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -27773,8 +27773,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -27816,8 +27816,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -27841,8 +27841,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -27866,8 +27866,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -27894,8 +27894,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -27903,7 +27903,7 @@ multiple node agents:
 relevancy only:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.0.
+      Thank you for installing kubescape-operator version 1.30.1.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -27938,8 +27938,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -27984,8 +27984,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -28012,8 +28012,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28034,8 +28034,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28055,8 +28055,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -28075,8 +28075,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28094,9 +28094,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28116,9 +28116,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -28179,8 +28179,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -28431,8 +28431,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -28456,8 +28456,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28489,8 +28489,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -28618,7 +28618,7 @@ relevancy only:
   12: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.30.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.1\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.1\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n      labels:\n        helm.sh/chart: kubescape-operator-1.30.1\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.1\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -28629,8 +28629,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28648,8 +28648,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -28679,8 +28679,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -28705,8 +28705,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -28735,8 +28735,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -28754,8 +28754,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28773,9 +28773,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
+        app.kubernetes.io/version: 1.30.1
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.0
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28795,9 +28795,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.0
+                app.kubernetes.io/version: 1.30.1
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.0
+                helm.sh/chart: kubescape-operator-1.30.1
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -28858,8 +28858,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -28899,8 +28899,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -28924,8 +28924,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28953,8 +28953,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -29067,8 +29067,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -29096,8 +29096,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -29114,8 +29114,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -29244,8 +29244,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -29307,8 +29307,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29326,8 +29326,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29352,8 +29352,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -29565,8 +29565,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -29593,8 +29593,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -29611,8 +29611,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -29736,8 +29736,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -29791,8 +29791,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29810,8 +29810,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29845,8 +29845,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -29860,7 +29860,7 @@ relevancy only:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.0
+                  value: kubescape-operator-1.30.1
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -29877,7 +29877,7 @@ relevancy only:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/operator:v0.2.119
+              image: quay.io/kubescape/operator:v0.2.121
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -30049,8 +30049,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30134,8 +30134,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30219,8 +30219,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30238,8 +30238,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -30282,8 +30282,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -30308,8 +30308,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -30337,8 +30337,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -30355,8 +30355,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -30385,8 +30385,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -30404,8 +30404,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -30470,8 +30470,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -30495,8 +30495,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -30535,8 +30535,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30554,8 +30554,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30581,8 +30581,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.0
-            helm.sh/chart: kubescape-operator-1.30.0
+            app.kubernetes.io/version: 1.30.1
+            helm.sh/chart: kubescape-operator-1.30.1
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -30683,8 +30683,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -30707,8 +30707,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -30733,8 +30733,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -30761,8 +30761,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -30790,8 +30790,8 @@ with multiple private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets
@@ -30828,8 +30828,8 @@ with single private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.0
-        helm.sh/chart: kubescape-operator-1.30.0
+        app.kubernetes.io/version: 1.30.1
+        helm.sh/chart: kubescape-operator-1.30.1
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -319,7 +319,7 @@ operator:
   image:
     # -- source code: https://github.com/kubescape/operator
     repository: quay.io/kubescape/operator
-    tag: v0.2.119
+    tag: v0.2.121
     pullPolicy: IfNotPresent
 
   nodeSelector:


### PR DESCRIPTION
This PR updates the kubescape operator image tag from v0.2.119 to v0.2.121 (latest release).

### Changes
- Updated `operator.image.tag` in `charts/kubescape-operator/values.yaml` from `v0.2.119` to `v0.2.121`

### Testing
- [ ] Verify the new image tag exists in the registry
- [ ] Deploy and test the updated helm chart