### PR TITLE
prepare new release

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.30.2
+version: 1.30.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.30.2
+appVersion: 1.30.3
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -1,6 +1,6 @@
 # Kubescape Operator
 
-![Version: 1.30.0](https://img.shields.io/badge/Version-1.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.30.0](https://img.shields.io/badge/AppVersion-v1.30.0-informational?style=flat-square)
+![Version: 1.30.3](https://img.shields.io/badge/Version-1.30.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.30.3](https://img.shields.io/badge/AppVersion-v1.30.3-informational?style=flat-square)
 
 [Kubescape operator documentation](https://kubescape.io/docs/install-operator/)
 

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 all capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.2.
+      Thank you for installing kubescape-operator version 1.30.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -35,8 +35,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -55,8 +55,8 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
-                helm.sh/chart: kubescape-operator-1.30.2
+                app.kubernetes.io/version: 1.30.3
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -112,8 +112,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -167,8 +167,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -192,8 +192,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -218,8 +218,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -239,8 +239,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -286,8 +286,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -314,8 +314,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -335,8 +335,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -358,8 +358,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -379,8 +379,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -397,9 +397,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -420,10 +420,10 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: vuln-scan
                 bar: baz
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -477,8 +477,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -508,9 +508,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
+            app.kubernetes.io/version: 1.30.3
             bar: baz
-            helm.sh/chart: kubescape-operator-1.30.2
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -553,8 +553,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -588,8 +588,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -613,8 +613,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -638,8 +638,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -666,8 +666,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -686,8 +686,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -705,9 +705,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -727,9 +727,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -792,8 +792,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -855,8 +855,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1107,8 +1107,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1132,8 +1132,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1166,8 +1166,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1247,7 +1247,7 @@ all capabilities:
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v3.0.47
+              image: quay.io/kubescape/kubescape:v3.0.48
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -1379,7 +1379,7 @@ all capabilities:
   26: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -1390,8 +1390,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1409,8 +1409,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1497,8 +1497,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1528,8 +1528,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1554,8 +1554,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -1580,8 +1580,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1610,8 +1610,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1628,8 +1628,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -1661,8 +1661,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1680,9 +1680,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1702,9 +1702,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -1767,8 +1767,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -1830,8 +1830,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1871,8 +1871,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1896,8 +1896,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1926,8 +1926,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1964,7 +1964,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.98
+              image: quay.io/kubescape/kubevuln:v0.3.104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -2098,8 +2098,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2166,8 +2166,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -2190,8 +2190,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -2216,8 +2216,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2245,8 +2245,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2263,8 +2263,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2400,8 +2400,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2466,8 +2466,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2522,8 +2522,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2550,9 +2550,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
+            app.kubernetes.io/version: 1.30.3
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.30.2
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -2633,12 +2633,12 @@ all capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.17
+                  value: v0.3.36
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.17
+              image: quay.io/kubescape/node-agent:v0.3.36
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -2852,8 +2852,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -2903,8 +2903,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -3497,8 +3497,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -3562,8 +3562,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -3588,8 +3588,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -3616,8 +3616,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -3634,8 +3634,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -3664,8 +3664,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -3683,8 +3683,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -3731,8 +3731,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3856,8 +3856,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -3912,8 +3912,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3931,8 +3931,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -3967,8 +3967,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -3982,7 +3982,7 @@ all capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -4003,7 +4003,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.121
+              image: quay.io/kubescape/operator:v0.2.126
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -4202,8 +4202,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4290,8 +4290,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4309,8 +4309,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4485,8 +4485,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4504,8 +4504,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4548,8 +4548,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4574,8 +4574,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -4600,8 +4600,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4629,8 +4629,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4646,8 +4646,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4674,8 +4674,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4699,8 +4699,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4725,8 +4725,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -4811,8 +4811,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4880,8 +4880,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4908,8 +4908,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4926,8 +4926,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -4962,8 +4962,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -4981,8 +4981,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -5007,8 +5007,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5073,8 +5073,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -5098,8 +5098,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5136,8 +5136,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5155,8 +5155,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5182,8 +5182,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -5207,7 +5207,7 @@ all capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.237
+              image: quay.io/kubescape/storage:v0.0.239
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -5281,8 +5281,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5351,8 +5351,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -5375,8 +5375,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -5401,8 +5401,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -5427,8 +5427,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -5751,8 +5751,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5779,8 +5779,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5797,8 +5797,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6033,8 +6033,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6330,8 +6330,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6349,8 +6349,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6380,8 +6380,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -6393,7 +6393,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -6414,7 +6414,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.127
+              image: quay.io/kubescape/synchronizer:v0.0.128
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -6537,8 +6537,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6615,8 +6615,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6658,8 +6658,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6683,8 +6683,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -6708,8 +6708,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6736,8 +6736,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6745,7 +6745,7 @@ all capabilities:
 backend-storage enabled disables scanning capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.2.
+      Thank you for installing kubescape-operator version 1.30.3.
 
 
 
@@ -6773,8 +6773,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -6819,8 +6819,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -6847,8 +6847,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6869,8 +6869,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6890,8 +6890,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -6908,8 +6908,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7045,8 +7045,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -7111,8 +7111,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7130,8 +7130,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7156,8 +7156,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -7205,12 +7205,12 @@ backend-storage enabled disables scanning capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.17
+                  value: v0.3.36
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.17
+              image: quay.io/kubescape/node-agent:v0.3.36
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -7402,8 +7402,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -7456,8 +7456,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -8050,8 +8050,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8078,8 +8078,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8096,8 +8096,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -8126,8 +8126,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -8145,8 +8145,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -8193,8 +8193,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8318,8 +8318,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8374,8 +8374,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8393,8 +8393,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8428,8 +8428,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -8443,7 +8443,7 @@ backend-storage enabled disables scanning capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -8458,7 +8458,7 @@ backend-storage enabled disables scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.121
+              image: quay.io/kubescape/operator:v0.2.126
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -8639,8 +8639,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8724,8 +8724,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8809,8 +8809,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8828,8 +8828,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8872,8 +8872,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8898,8 +8898,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8927,8 +8927,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -8949,8 +8949,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -8968,8 +8968,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -9292,8 +9292,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -9459,8 +9459,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -9738,8 +9738,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9757,8 +9757,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9787,8 +9787,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -9800,7 +9800,7 @@ backend-storage enabled disables scanning capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -9815,7 +9815,7 @@ backend-storage enabled disables scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/synchronizer:v0.0.127
+              image: quay.io/kubescape/synchronizer:v0.0.128
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -9915,8 +9915,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -9958,8 +9958,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -9983,8 +9983,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10011,8 +10011,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10020,7 +10020,7 @@ backend-storage enabled disables scanning capabilities:
 default capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.2.
+      Thank you for installing kubescape-operator version 1.30.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -10056,8 +10056,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -10103,8 +10103,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -10131,8 +10131,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10153,8 +10153,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10174,8 +10174,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -10192,8 +10192,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10222,8 +10222,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -10263,8 +10263,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -10298,8 +10298,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -10328,8 +10328,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10347,9 +10347,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10369,9 +10369,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -10431,8 +10431,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -10488,8 +10488,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -10740,8 +10740,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -10765,8 +10765,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10799,8 +10799,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -10849,7 +10849,7 @@ default capabilities:
                   value: "1500"
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v3.0.47
+              image: quay.io/kubescape/kubescape:v3.0.48
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -10977,7 +10977,7 @@ default capabilities:
   16: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -10988,8 +10988,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11007,8 +11007,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11084,8 +11084,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11115,8 +11115,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11141,8 +11141,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11171,8 +11171,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11189,8 +11189,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -11222,8 +11222,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11241,9 +11241,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11263,9 +11263,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11325,8 +11325,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -11382,8 +11382,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11423,8 +11423,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11448,8 +11448,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11478,8 +11478,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -11510,7 +11510,7 @@ default capabilities:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.98
+              image: quay.io/kubescape/kubevuln:v0.3.104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -11639,8 +11639,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11701,8 +11701,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11730,8 +11730,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -11748,8 +11748,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -11885,8 +11885,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -11951,8 +11951,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11970,8 +11970,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11997,8 +11997,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -12046,12 +12046,12 @@ default capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.17
+                  value: v0.3.36
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.17
+              image: quay.io/kubescape/node-agent:v0.3.36
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12264,8 +12264,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -12321,8 +12321,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -12915,8 +12915,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12969,8 +12969,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -12997,8 +12997,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13015,8 +13015,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13140,8 +13140,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13196,8 +13196,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13215,8 +13215,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13251,8 +13251,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -13266,7 +13266,7 @@ default capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -13281,7 +13281,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.121
+              image: quay.io/kubescape/operator:v0.2.126
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -13468,8 +13468,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13553,8 +13553,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13572,8 +13572,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13731,8 +13731,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13750,8 +13750,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13794,8 +13794,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13820,8 +13820,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13849,8 +13849,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13872,8 +13872,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -13891,8 +13891,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -13921,8 +13921,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -13940,8 +13940,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14006,8 +14006,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -14031,8 +14031,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14072,8 +14072,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14091,8 +14091,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14118,8 +14118,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -14141,7 +14141,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.237
+              image: quay.io/kubescape/storage:v0.0.239
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -14218,8 +14218,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14280,8 +14280,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -14304,8 +14304,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -14330,8 +14330,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -14654,8 +14654,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14682,8 +14682,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14700,8 +14700,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -14867,8 +14867,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15146,8 +15146,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15165,8 +15165,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15196,8 +15196,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15209,7 +15209,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -15224,7 +15224,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/synchronizer:v0.0.127
+              image: quay.io/kubescape/synchronizer:v0.0.128
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -15343,8 +15343,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15410,8 +15410,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15453,8 +15453,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15478,8 +15478,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15506,8 +15506,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15515,7 +15515,7 @@ default capabilities:
 disable otel:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.2.
+      Thank you for installing kubescape-operator version 1.30.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -15551,8 +15551,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -15597,8 +15597,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -15625,8 +15625,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15647,8 +15647,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15668,8 +15668,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -15688,8 +15688,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15707,9 +15707,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15729,9 +15729,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -15792,8 +15792,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -16044,8 +16044,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -16069,8 +16069,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16102,8 +16102,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16152,7 +16152,7 @@ disable otel:
                   value: "1500"
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v3.0.47
+              image: quay.io/kubescape/kubescape:v3.0.48
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16262,7 +16262,7 @@ disable otel:
   12: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -16273,8 +16273,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16292,8 +16292,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -16323,8 +16323,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -16349,8 +16349,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -16379,8 +16379,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -16398,8 +16398,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16417,9 +16417,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16439,9 +16439,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -16502,8 +16502,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -16543,8 +16543,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -16568,8 +16568,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16597,8 +16597,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16629,7 +16629,7 @@ disable otel:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.98
+              image: quay.io/kubescape/kubevuln:v0.3.104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16740,8 +16740,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -16769,8 +16769,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -16787,8 +16787,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16924,8 +16924,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16990,8 +16990,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17009,8 +17009,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17036,8 +17036,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17085,12 +17085,12 @@ disable otel:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.17
+                  value: v0.3.36
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.17
+              image: quay.io/kubescape/node-agent:v0.3.36
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -17280,8 +17280,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -17308,8 +17308,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -17326,8 +17326,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -17356,8 +17356,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -17375,8 +17375,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -17423,8 +17423,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17548,8 +17548,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17604,8 +17604,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17623,8 +17623,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17658,8 +17658,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17673,7 +17673,7 @@ disable otel:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -17688,7 +17688,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.121
+              image: quay.io/kubescape/operator:v0.2.126
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -17869,8 +17869,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17954,8 +17954,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18039,8 +18039,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18058,8 +18058,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18102,8 +18102,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18128,8 +18128,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18157,8 +18157,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18175,8 +18175,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -18205,8 +18205,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -18224,8 +18224,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -18290,8 +18290,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -18315,8 +18315,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -18356,8 +18356,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18375,8 +18375,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18402,8 +18402,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18425,7 +18425,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.237
+              image: quay.io/kubescape/storage:v0.0.239
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -18502,8 +18502,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -18526,8 +18526,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -18552,8 +18552,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -18876,8 +18876,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -18904,8 +18904,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -18922,8 +18922,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19089,8 +19089,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19368,8 +19368,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19387,8 +19387,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19417,8 +19417,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19430,7 +19430,7 @@ disable otel:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19445,7 +19445,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/synchronizer:v0.0.127
+              image: quay.io/kubescape/synchronizer:v0.0.128
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19545,8 +19545,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19588,8 +19588,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19613,8 +19613,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19641,8 +19641,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19650,7 +19650,7 @@ disable otel:
 minimal capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.2.
+      Thank you for installing kubescape-operator version 1.30.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -19686,8 +19686,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -19732,8 +19732,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -19760,8 +19760,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19782,8 +19782,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19803,8 +19803,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -19823,8 +19823,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19842,9 +19842,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19864,9 +19864,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -19927,8 +19927,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20179,8 +20179,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20204,8 +20204,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20237,8 +20237,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20287,7 +20287,7 @@ minimal capabilities:
                   value: "1500"
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/kubescape:v3.0.47
+              image: quay.io/kubescape/kubescape:v3.0.48
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -20366,7 +20366,7 @@ minimal capabilities:
   12: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -20377,8 +20377,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20396,8 +20396,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20427,8 +20427,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20453,8 +20453,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20483,8 +20483,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20502,8 +20502,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20521,9 +20521,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20543,9 +20543,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -20606,8 +20606,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -20647,8 +20647,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -20672,8 +20672,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20701,8 +20701,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20735,7 +20735,7 @@ minimal capabilities:
                   value: "1"
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/kubevuln:v0.3.98
+              image: quay.io/kubescape/kubevuln:v0.3.104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -20815,8 +20815,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -20844,8 +20844,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -20862,8 +20862,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -20999,8 +20999,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -21063,8 +21063,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21082,8 +21082,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21109,8 +21109,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21160,12 +21160,12 @@ minimal capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.17
+                  value: v0.3.36
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.17
+              image: quay.io/kubescape/node-agent:v0.3.36
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21325,8 +21325,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -21353,8 +21353,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -21371,8 +21371,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21401,8 +21401,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -21420,8 +21420,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -21468,8 +21468,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -21593,8 +21593,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -21648,8 +21648,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21667,8 +21667,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21702,8 +21702,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21717,7 +21717,7 @@ minimal capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -21734,7 +21734,7 @@ minimal capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/operator:v0.2.121
+              image: quay.io/kubescape/operator:v0.2.126
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21915,8 +21915,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22000,8 +22000,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22085,8 +22085,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22104,8 +22104,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -22148,8 +22148,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -22174,8 +22174,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -22203,8 +22203,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -22221,8 +22221,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -22251,8 +22251,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -22270,8 +22270,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -22336,8 +22336,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -22361,8 +22361,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -22402,8 +22402,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22421,8 +22421,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22448,8 +22448,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22473,7 +22473,7 @@ minimal capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.237
+              image: quay.io/kubescape/storage:v0.0.239
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22550,8 +22550,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -22574,8 +22574,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -22600,8 +22600,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -22924,8 +22924,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -22952,8 +22952,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -22961,7 +22961,7 @@ minimal capabilities:
 multiple node agents:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.2.
+      Thank you for installing kubescape-operator version 1.30.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -22995,8 +22995,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -23015,8 +23015,8 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
-                helm.sh/chart: kubescape-operator-1.30.2
+                app.kubernetes.io/version: 1.30.3
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -23072,8 +23072,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -23127,8 +23127,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -23152,8 +23152,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -23178,8 +23178,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -23199,8 +23199,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -23246,8 +23246,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -23274,8 +23274,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23295,8 +23295,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -23318,8 +23318,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23339,8 +23339,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -23357,9 +23357,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23380,10 +23380,10 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: vuln-scan
                 bar: baz
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -23437,8 +23437,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23468,9 +23468,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
+            app.kubernetes.io/version: 1.30.3
             bar: baz
-            helm.sh/chart: kubescape-operator-1.30.2
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23513,8 +23513,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23548,8 +23548,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23573,8 +23573,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23598,8 +23598,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23626,8 +23626,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23646,8 +23646,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23665,9 +23665,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23687,9 +23687,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -23752,8 +23752,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -23815,8 +23815,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24067,8 +24067,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24092,8 +24092,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24126,8 +24126,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24207,7 +24207,7 @@ multiple node agents:
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v3.0.47
+              image: quay.io/kubescape/kubescape:v3.0.48
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24339,7 +24339,7 @@ multiple node agents:
   26: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -24350,8 +24350,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24369,8 +24369,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24457,8 +24457,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24488,8 +24488,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24514,8 +24514,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -24540,8 +24540,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24570,8 +24570,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24588,8 +24588,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -24621,8 +24621,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24640,9 +24640,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24662,9 +24662,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -24727,8 +24727,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -24790,8 +24790,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -24831,8 +24831,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -24856,8 +24856,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24886,8 +24886,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24924,7 +24924,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.98
+              image: quay.io/kubescape/kubevuln:v0.3.104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -25058,8 +25058,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -25126,8 +25126,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -25150,8 +25150,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -25176,8 +25176,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -25205,8 +25205,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -25223,8 +25223,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25360,8 +25360,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25426,8 +25426,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25482,8 +25482,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25509,9 +25509,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
+            app.kubernetes.io/version: 1.30.3
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.30.2
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -25592,12 +25592,12 @@ multiple node agents:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.17
+                  value: v0.3.36
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.17
+              image: quay.io/kubescape/node-agent:v0.3.36
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -25814,8 +25814,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25841,9 +25841,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
+            app.kubernetes.io/version: 1.30.3
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.30.2
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -25924,12 +25924,12 @@ multiple node agents:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.17
+                  value: v0.3.36
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.17
+              image: quay.io/kubescape/node-agent:v0.3.36
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -26146,8 +26146,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -26197,8 +26197,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -26791,8 +26791,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -26856,8 +26856,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -26882,8 +26882,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -26910,8 +26910,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -26928,8 +26928,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -26958,8 +26958,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -26977,8 +26977,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -27025,8 +27025,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27150,8 +27150,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27206,8 +27206,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27225,8 +27225,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27261,8 +27261,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -27276,7 +27276,7 @@ multiple node agents:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -27297,7 +27297,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.121
+              image: quay.io/kubescape/operator:v0.2.126
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -27496,8 +27496,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27584,8 +27584,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27603,8 +27603,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27779,8 +27779,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27798,8 +27798,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27842,8 +27842,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27868,8 +27868,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -27894,8 +27894,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27923,8 +27923,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27940,8 +27940,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -27968,8 +27968,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -27993,8 +27993,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -28019,8 +28019,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -28105,8 +28105,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -28174,8 +28174,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -28202,8 +28202,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -28220,8 +28220,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -28256,8 +28256,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -28275,8 +28275,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -28301,8 +28301,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28367,8 +28367,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -28392,8 +28392,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28430,8 +28430,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28449,8 +28449,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28476,8 +28476,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -28501,7 +28501,7 @@ multiple node agents:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.237
+              image: quay.io/kubescape/storage:v0.0.239
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -28575,8 +28575,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28645,8 +28645,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -28669,8 +28669,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -28695,8 +28695,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -28721,8 +28721,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -29045,8 +29045,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -29073,8 +29073,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -29091,8 +29091,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29327,8 +29327,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29624,8 +29624,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29643,8 +29643,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29674,8 +29674,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -29687,7 +29687,7 @@ multiple node agents:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -29708,7 +29708,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.127
+              image: quay.io/kubescape/synchronizer:v0.0.128
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -29831,8 +29831,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29909,8 +29909,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29952,8 +29952,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29977,8 +29977,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -30002,8 +30002,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -30030,8 +30030,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -30039,7 +30039,7 @@ multiple node agents:
 relevancy only:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.2.
+      Thank you for installing kubescape-operator version 1.30.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -30074,8 +30074,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -30120,8 +30120,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -30148,8 +30148,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30170,8 +30170,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30191,8 +30191,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -30211,8 +30211,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30230,9 +30230,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30252,9 +30252,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -30315,8 +30315,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30567,8 +30567,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30592,8 +30592,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30625,8 +30625,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -30675,7 +30675,7 @@ relevancy only:
                   value: "1500"
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/kubescape:v3.0.47
+              image: quay.io/kubescape/kubescape:v3.0.48
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -30754,7 +30754,7 @@ relevancy only:
   12: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -30765,8 +30765,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30784,8 +30784,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30815,8 +30815,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30841,8 +30841,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30871,8 +30871,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30890,8 +30890,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30909,9 +30909,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30931,9 +30931,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -30994,8 +30994,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -31035,8 +31035,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -31060,8 +31060,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31089,8 +31089,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -31123,7 +31123,7 @@ relevancy only:
                   value: "1"
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/kubevuln:v0.3.98
+              image: quay.io/kubescape/kubevuln:v0.3.104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -31203,8 +31203,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -31232,8 +31232,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -31250,8 +31250,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31387,8 +31387,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31451,8 +31451,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31470,8 +31470,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31496,8 +31496,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -31547,12 +31547,12 @@ relevancy only:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.17
+                  value: v0.3.36
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.17
+              image: quay.io/kubescape/node-agent:v0.3.36
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -31714,8 +31714,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31742,8 +31742,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31760,8 +31760,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -31885,8 +31885,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -31940,8 +31940,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31959,8 +31959,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31994,8 +31994,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -32009,7 +32009,7 @@ relevancy only:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -32026,7 +32026,7 @@ relevancy only:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/operator:v0.2.121
+              image: quay.io/kubescape/operator:v0.2.126
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -32198,8 +32198,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32283,8 +32283,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32368,8 +32368,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32387,8 +32387,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32431,8 +32431,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32457,8 +32457,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32486,8 +32486,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32504,8 +32504,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -32534,8 +32534,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-ca
@@ -32553,8 +32553,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -32619,8 +32619,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -32644,8 +32644,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -32685,8 +32685,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32704,8 +32704,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32731,8 +32731,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -32756,7 +32756,7 @@ relevancy only:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.237
+              image: quay.io/kubescape/storage:v0.0.239
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -32833,8 +32833,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -32857,8 +32857,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -32883,8 +32883,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -33207,8 +33207,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -33235,8 +33235,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -33244,7 +33244,7 @@ relevancy only:
 skipPersistence enabled:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.2.
+      Thank you for installing kubescape-operator version 1.30.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -33278,8 +33278,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -33298,8 +33298,8 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
-                helm.sh/chart: kubescape-operator-1.30.2
+                app.kubernetes.io/version: 1.30.3
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -33355,8 +33355,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -33410,8 +33410,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -33435,8 +33435,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -33461,8 +33461,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -33482,8 +33482,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -33529,8 +33529,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -33557,8 +33557,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33578,8 +33578,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -33601,8 +33601,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33622,8 +33622,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -33640,9 +33640,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33663,10 +33663,10 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: vuln-scan
                 bar: baz
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -33720,8 +33720,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33751,9 +33751,9 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
+            app.kubernetes.io/version: 1.30.3
             bar: baz
-            helm.sh/chart: kubescape-operator-1.30.2
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -33796,8 +33796,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -33831,8 +33831,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -33856,8 +33856,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -33881,8 +33881,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -33909,8 +33909,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -33929,8 +33929,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33948,9 +33948,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33970,9 +33970,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -34035,8 +34035,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -34098,8 +34098,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34350,8 +34350,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34375,8 +34375,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34409,8 +34409,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -34490,7 +34490,7 @@ skipPersistence enabled:
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v3.0.47
+              image: quay.io/kubescape/kubescape:v3.0.48
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -34622,7 +34622,7 @@ skipPersistence enabled:
   26: |
     apiVersion: v1
     data:
-      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
+      host-scanner-yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: host-scanner\n  namespace: kubescape\n  annotations:\n    \n    argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n    argocd.argoproj.io/sync-options: \"Prune=false\"\n  labels:\n    helm.sh/chart: kubescape-operator-1.30.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: host-scanner\n    app.kubernetes.io/version: \"1.30.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: host-scanner\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: host-scanner\n  template:\n    metadata:\n      annotations:\n        \n        argocd.argoproj.io/compare-options: \"IgnoreExtraneous\"\n        argocd.argoproj.io/sync-options: \"Prune=false\"\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: host-scanner\n        app.kubernetes.io/version: \"1.30.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: host-scanner\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        name: host-scanner\n    spec:\n      nodeSelector:\n        kubernetes.io/os: linux\n      affinity:\n      tolerations:\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/control-plane\n          operator: Exists\n        - effect: NoSchedule\n          key: node-role.kubernetes.io/master\n          operator: Exists\n      imagePullSecrets:\n      - name: foo\n      - name: bar\n      containers:\n      - name: host-sensor\n        image: \"quay.io/kubescape/host-scanner:v1.0.78\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: true\n          privileged: true\n          readOnlyRootFilesystem: true\n        env:\n        - name: KS_LOGGER_LEVEL\n          value: \"info\"\n        - name: KS_LOGGER_NAME\n          value: \"zap\"\n        - name: OTEL_COLLECTOR_SVC\n          value: otelCollector.svc.monitoring:4317\n        ports:\n          - name: scanner # Do not change port name\n            containerPort: 7888\n            protocol: TCP\n        resources:\n          limits:\n            cpu: 0.4m\n            memory: 400Mi\n          requests:\n            cpu: 0.1m\n            memory: 200Mi\n        volumeMounts:\n        - mountPath: /host_fs\n          name: host-filesystem\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          failureThreshold: 30\n          periodSeconds: 1\n        livenessProbe:\n          httpGet:\n            path: /healthz\n            port: 7888\n          periodSeconds: 10\n      terminationGracePeriodSeconds: 120\n      dnsPolicy: ClusterFirstWithHostNet\n      serviceAccountName: node-agent\n      automountServiceAccountToken: false\n      volumes:\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      hostPID: true\n      hostIPC: true"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -34633,8 +34633,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34652,8 +34652,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34740,8 +34740,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34771,8 +34771,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34797,8 +34797,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -34823,8 +34823,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34853,8 +34853,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34871,8 +34871,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -34907,8 +34907,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34926,9 +34926,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
+        app.kubernetes.io/version: 1.30.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.2
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34948,9 +34948,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.2
+                app.kubernetes.io/version: 1.30.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.2
+                helm.sh/chart: kubescape-operator-1.30.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -35013,8 +35013,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -35076,8 +35076,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -35117,8 +35117,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -35142,8 +35142,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35172,8 +35172,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -35210,7 +35210,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.98
+              image: quay.io/kubescape/kubevuln:v0.3.104
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -35344,8 +35344,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -35412,8 +35412,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -35436,8 +35436,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -35462,8 +35462,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -35491,8 +35491,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -35509,8 +35509,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -35646,8 +35646,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -35712,8 +35712,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35768,8 +35768,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35795,9 +35795,9 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
+            app.kubernetes.io/version: 1.30.3
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.30.2
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -35878,12 +35878,12 @@ skipPersistence enabled:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.17
+                  value: v0.3.36
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.17
+              image: quay.io/kubescape/node-agent:v0.3.36
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -36099,8 +36099,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -36150,8 +36150,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -36744,8 +36744,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -36809,8 +36809,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -36835,8 +36835,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -36863,8 +36863,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -36881,8 +36881,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -36911,8 +36911,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook.kubescape.svc-kubescape-tls-pair
@@ -36930,8 +36930,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: validation
@@ -36978,8 +36978,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37103,8 +37103,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37159,8 +37159,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37178,8 +37178,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37214,8 +37214,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -37229,7 +37229,7 @@ skipPersistence enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -37250,7 +37250,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.121
+              image: quay.io/kubescape/operator:v0.2.126
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -37449,8 +37449,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37537,8 +37537,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37556,8 +37556,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37732,8 +37732,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37751,8 +37751,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37795,8 +37795,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37821,8 +37821,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -37847,8 +37847,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37876,8 +37876,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37893,8 +37893,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -37921,8 +37921,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -37946,8 +37946,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -37972,8 +37972,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -38058,8 +38058,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -38127,8 +38127,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -38155,8 +38155,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -38173,8 +38173,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -38209,8 +38209,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -38228,8 +38228,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -38254,8 +38254,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -38320,8 +38320,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -38345,8 +38345,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -38383,8 +38383,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38402,8 +38402,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38429,8 +38429,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -38454,7 +38454,7 @@ skipPersistence enabled:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.237
+              image: quay.io/kubescape/storage:v0.0.239
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -38528,8 +38528,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -38598,8 +38598,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -38622,8 +38622,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -38648,8 +38648,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -38674,8 +38674,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -38998,8 +38998,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -39026,8 +39026,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -39044,8 +39044,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -39280,8 +39280,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -39577,8 +39577,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39596,8 +39596,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39627,8 +39627,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.2
-            helm.sh/chart: kubescape-operator-1.30.2
+            app.kubernetes.io/version: 1.30.3
+            helm.sh/chart: kubescape-operator-1.30.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -39640,7 +39640,7 @@ skipPersistence enabled:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.2
+                  value: kubescape-operator-1.30.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -39661,7 +39661,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.127
+              image: quay.io/kubescape/synchronizer:v0.0.128
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -39784,8 +39784,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -39862,8 +39862,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -39905,8 +39905,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -39930,8 +39930,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -39955,8 +39955,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -39983,8 +39983,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -40012,8 +40012,8 @@ with multiple private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets
@@ -40050,8 +40050,8 @@ with single private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.2
-        helm.sh/chart: kubescape-operator-1.30.2
+        app.kubernetes.io/version: 1.30.3
+        helm.sh/chart: kubescape-operator-1.30.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -264,7 +264,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v3.0.47
+    tag: v3.0.48
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -324,7 +324,7 @@ operator:
   image:
     # -- source code: https://github.com/kubescape/operator
     repository: quay.io/kubescape/operator
-    tag: v0.2.121
+    tag: v0.2.126
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -372,7 +372,7 @@ kubevuln:
   image:
     # -- source code: https://github.com/kubescape/kubevuln
     repository: quay.io/kubescape/kubevuln
-    tag: v0.3.98
+    tag: v0.3.104
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -479,7 +479,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: quay.io/kubescape/storage
-    tag: v0.0.237
+    tag: v0.0.239
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -543,7 +543,7 @@ nodeAgent:
   image:
     # -- source code: https://github.com/kubescape/node-agent
     repository: quay.io/kubescape/node-agent
-    tag: v0.3.17
+    tag: v0.3.36
     pullPolicy: IfNotPresent
 
   config:
@@ -797,7 +797,7 @@ synchronizer:
   image:
     # -- source code: https://github.com/kubescape/synchronizer
     repository: quay.io/kubescape/synchronizer
-    tag: v0.0.127
+    tag: v0.0.128
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart version to 1.30.3
  * Updated component image versions across multiple services: kubescape, operator, kubevuln, storage, node-agent, and synchronizer to their latest patch releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->