### PR TITLE
Enable setting admission service type, and service annotations

### DIFF
--- a/charts/kubescape-operator/templates/kubescape/service.yaml
+++ b/charts/kubescape-operator/templates/kubescape/service.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   annotations:
     {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with .Values.kubescape.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubescape.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/kubevuln/service.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/service.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   annotations:
     {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with .Values.kubevuln.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubevuln.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/operator/admission-service.yaml
+++ b/charts/kubescape-operator/templates/operator/admission-service.yaml
@@ -8,14 +8,17 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   annotations:
     {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with .Values.operator.admissionService.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:
   ports:
-    - port: 443
-      targetPort: 8443
+    - port: {{ .Values.operator.admissionService.port }}
+      targetPort: {{ .Values.operator.admissionService.targetPort }}
   selector:
     {{- include "kubescape-operator.selectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name) | nindent 6 }}
-  type: ClusterIP  # Or use LoadBalancer or NodePort if needed
+  type: {{ .Values.operator.admissionService.type }}
 {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/operator/service.yaml
+++ b/charts/kubescape-operator/templates/operator/service.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   annotations:
     {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with .Values.operator.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/synchronizer/service.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/service.yaml
@@ -5,6 +5,11 @@ kind: Service
 metadata:
   name: {{ .Values.synchronizer.name }}
   namespace: {{ .Values.ksNamespace }}
+  annotations:
+    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with .Values.synchronizer.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.synchronizer.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/synchronizer/service.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/service.yaml
@@ -5,11 +5,11 @@ kind: Service
 metadata:
   name: {{ .Values.synchronizer.name }}
   namespace: {{ .Values.ksNamespace }}
+  {{- $annotations := merge (default dict .Values.additionalAnnotations) (default dict .Values.synchronizer.service.annotations) }}
+  {{- with $annotations }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
-    {{- with .Values.synchronizer.service.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.synchronizer.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -291,6 +291,7 @@ kubescape:
   service:
     type: ClusterIP
     port: 8080
+    annotations: {}
 
   # deploy a service monitor for prometheus (operator) integration
   serviceMonitor:
@@ -338,6 +339,13 @@ operator:
     port: 4002
     targetPort: 4002
     protocol: TCP
+    annotations: {}
+
+  admissionService:
+    type: ClusterIP
+    port: 443
+    targetPort: 8443
+    annotations: {}
 
   podAnnotations: {}
   podLabels: {}
@@ -389,6 +397,7 @@ kubevuln:
     port: 8080
     targetPort: 8080
     protocol: TCP
+    annotations: {}
 
   podAnnotations: {}
   podLabels: {}
@@ -865,6 +874,7 @@ synchronizer:
     port: 8089
     targetPort: 8089
     protocol: TCP
+    annotations: {}
 
 # -----------------------------------------------------------------------------------------
 # ------------------------ Microservice - helpers -----------------------------------------


### PR DESCRIPTION
To better support Cilium loadbalancer services in BGP clusters. Issue: #812

## Overview
Enable setting the service type for the admission controller service.
Enable settings service annotations for all services currently in values.yaml

## Additional Information
To support cilium bgp clusters where the masters are not in the clusters as nodes, needing loadbalancer services for admission controllers.

<!--
## How to Test
Not tested yet. will share results. 
Searching feedback on best way to include annotations from specific values. 
<!--
## Examples/Screenshots
None yet

<!-- 
## Related issues/PRs:
* Resolved #812 
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `main` branch**

-->
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service annotations can now be configured for kubescape, kubevuln, operator, and synchronizer; when provided they are rendered into each Service’s metadata.
  * Admission service endpoint is now configurable: service type, port, and target port can be customized via chart values, with sensible defaults included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->