### PR TITLE
Update use of global annotations to not include empty line in output

### DIFF
--- a/charts/kubescape-operator/assets/host-scanner-definition.yaml
+++ b/charts/kubescape-operator/assets/host-scanner-definition.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ .Values.hostScanner.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
     argocd.argoproj.io/compare-options: "IgnoreExtraneous"
     argocd.argoproj.io/sync-options: "Prune=false"
   labels:

--- a/charts/kubescape-operator/templates/autoupdater/cronjob.yaml
+++ b/charts/kubescape-operator/templates/autoupdater/cronjob.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.helmReleaseUpgrader.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
     "helm.sh/resource-policy": keep
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.helmReleaseUpgrader.name "tier" .Values.global.namespaceTier) | nindent 4 }}

--- a/charts/kubescape-operator/templates/autoupdater/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/autoupdater/serviceaccount.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   name: {{ .Values.helmReleaseUpgrader.name }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
     "helm.sh/resource-policy": keep
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.helmReleaseUpgrader.name "tier" .Values.global.namespaceTier) | nindent 4 }}

--- a/charts/kubescape-operator/templates/configs/cloud-secret.yaml
+++ b/charts/kubescape-operator/templates/configs/cloud-secret.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ $components.cloudSecret.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" $components.cloudSecret.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/infra: credentials

--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.global.cloudConfig }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.global.cloudConfig "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/configs/components-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/components-configmap.yaml
@@ -4,7 +4,9 @@ metadata:
   name: ks-capabilities
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" "ks-capabilities" "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/configs/custom-ca-certificates.yaml
+++ b/charts/kubescape-operator/templates/configs/custom-ca-certificates.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ $components.customCaCertificates.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" $components.customCaCertificates.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/infra: credentials

--- a/charts/kubescape-operator/templates/configs/matchingRules-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/matchingRules-configmap.yaml
@@ -4,7 +4,9 @@ metadata:
   name: {{ .Values.continuousScanning.configMapName }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.ksLabel "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/configs/priority-class.yaml
+++ b/charts/kubescape-operator/templates/configs/priority-class.yaml
@@ -4,7 +4,9 @@ kind: PriorityClass
 metadata:
   name: kubescape-critical
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" "kubescape-critical" "tier" .Values.global.namespaceTier) | nindent 4 }}
 value: {{ .Values.configurations.priorityClass.daemonset }}

--- a/charts/kubescape-operator/templates/configs/private-registries-creds-secret.yaml
+++ b/charts/kubescape-operator/templates/configs/private-registries-creds-secret.yaml
@@ -6,7 +6,9 @@ metadata:
   name: kubescape-registry-scan-secrets
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" "kubescape-registry-scan-secrets" "tier" .Values.global.namespaceTier) | nindent 4 }}
 type: Opaque

--- a/charts/kubescape-operator/templates/grype-offline-db/cronjob.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/cronjob.yaml
@@ -8,7 +8,9 @@ metadata:
   name: {{ .Values.grypeOfflineDB.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.grypeOfflineDB.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     armo.tier: "vuln-scan"

--- a/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ .Values.grypeOfflineDB.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.grypeOfflineDB.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/kubescape-scheduler/configmap.yaml
+++ b/charts/kubescape-operator/templates/kubescape-scheduler/configmap.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.kubescapeScheduler.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubescapeScheduler.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml
+++ b/charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml
@@ -10,7 +10,9 @@ metadata:
   name: {{ .Values.kubescapeScheduler.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubescapeScheduler.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     armo.tier: "kubescape-scan"

--- a/charts/kubescape-operator/templates/kubescape/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/kubescape/clusterrole.yaml
@@ -5,7 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kubescape.name }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubescape.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 rules:

--- a/charts/kubescape-operator/templates/kubescape/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/kubescape/clusterrolebinding.yaml
@@ -5,7 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kubescape.name }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubescape.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 roleRef:

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -9,7 +9,9 @@ metadata:
   name: {{ .Values.kubescape.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubescape.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/kubescape/host-scanner-definition-configmap.yaml
+++ b/charts/kubescape-operator/templates/kubescape/host-scanner-definition-configmap.yaml
@@ -6,7 +6,9 @@ metadata:
   name: host-scanner-definition
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.global.cloudConfig "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/kubescape/networkpolicy.yaml
+++ b/charts/kubescape-operator/templates/kubescape/networkpolicy.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.kubescape.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubescape.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/kubescape/role.yaml
+++ b/charts/kubescape-operator/templates/kubescape/role.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.kubescape.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubescape.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 rules:

--- a/charts/kubescape-operator/templates/kubescape/rolebinding.yaml
+++ b/charts/kubescape-operator/templates/kubescape/rolebinding.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.kubescape.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubescape.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 roleRef:

--- a/charts/kubescape-operator/templates/kubescape/scc-rolebinding.yaml
+++ b/charts/kubescape-operator/templates/kubescape/scc-rolebinding.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ printf "%s-scc" .Values.kubescape.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubescape.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 roleRef:

--- a/charts/kubescape-operator/templates/kubescape/service.yaml
+++ b/charts/kubescape-operator/templates/kubescape/service.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.kubescape.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubescape.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/kubescape/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/kubescape/serviceaccount.yaml
@@ -4,7 +4,9 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
 {{- if .Values.cloudProviderMetadata.awsIamRoleArn }}
     eks.amazonaws.com/role-arn: {{ .Values.cloudProviderMetadata.awsIamRoleArn }}
   {{- else if .Values.cloudProviderMetadata.gkeServiceAccount }}

--- a/charts/kubescape-operator/templates/kubescape/servicemonitor.yaml
+++ b/charts/kubescape-operator/templates/kubescape/servicemonitor.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.kubescape.name }}-monitor
   namespace: {{ .Values.kubescape.serviceMonitor.namespace | default .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubescape.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     {{- with .Values.kubescape.serviceMonitor.additionalLabels }}

--- a/charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml
+++ b/charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml
@@ -10,7 +10,9 @@ metadata:
   name: {{ .Values.kubevulnScheduler.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubevulnScheduler.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     armo.tier: "vuln-scan"

--- a/charts/kubescape-operator/templates/kubevuln/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/clusterrole.yaml
@@ -5,7 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kubevuln.name }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubevuln.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 rules:

--- a/charts/kubescape-operator/templates/kubevuln/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/clusterrolebinding.yaml
@@ -5,7 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.kubevuln.name }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubevuln.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 roleRef:

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -8,7 +8,9 @@ metadata:
   name: {{ .Values.kubevuln.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubevuln.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/kubevuln/networkpolicy.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/networkpolicy.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.kubevuln.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubevuln.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/kubevuln/pvc.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/pvc.yaml
@@ -6,7 +6,9 @@ metadata:
   name: kubescape-{{ .Values.kubevuln.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubevuln.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/kubevuln/scc-rolebinding.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/scc-rolebinding.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ printf "%s-scc" .Values.kubevuln.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubevuln.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 roleRef:

--- a/charts/kubescape-operator/templates/kubevuln/service.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/service.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.kubevuln.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.kubevuln.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/kubevuln/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/serviceaccount.yaml
@@ -4,7 +4,9 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
 {{- if .Values.cloudProviderMetadata.awsIamRoleArn }}
     eks.amazonaws.com/role-arn: {{ .Values.cloudProviderMetadata.awsIamRoleArn }}
 {{- else if .Values.cloudProviderMetadata.gkeServiceAccount }}

--- a/charts/kubescape-operator/templates/node-agent/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/node-agent/clusterrole.yaml
@@ -5,7 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.nodeAgent.name }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 rules:

--- a/charts/kubescape-operator/templates/node-agent/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/node-agent/clusterrolebinding.yaml
@@ -5,7 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.nodeAgent.name }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 subjects:

--- a/charts/kubescape-operator/templates/node-agent/configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/configmap.yaml
@@ -13,7 +13,9 @@ metadata:
   name: {{ .Values.nodeAgent.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/node-agent/daemonset.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonset.yaml
@@ -12,7 +12,9 @@ metadata:
   name: {{ .Values.nodeAgent.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/node-agent/daemonsets.yaml
+++ b/charts/kubescape-operator/templates/node-agent/daemonsets.yaml
@@ -15,7 +15,9 @@ metadata:
   name: {{ $daemonsetName }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/node-agent/default-rule-binding-namespaced.yaml
+++ b/charts/kubescape-operator/templates/node-agent/default-rule-binding-namespaced.yaml
@@ -5,7 +5,9 @@ metadata:
   name: all-rules-default-namespace
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/node-agent/default-rule-binding.yaml
+++ b/charts/kubescape-operator/templates/node-agent/default-rule-binding.yaml
@@ -4,7 +4,9 @@ kind: RuntimeRuleAlertBinding
 metadata:
   name: all-rules-all-pods
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/node-agent/default-rules.yaml
+++ b/charts/kubescape-operator/templates/node-agent/default-rules.yaml
@@ -5,7 +5,9 @@ metadata:
   name: default-rules
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/node-agent/networkpolicy.yaml
+++ b/charts/kubescape-operator/templates/node-agent/networkpolicy.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.nodeAgent.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/node-agent/scc-rolebinding.yaml
+++ b/charts/kubescape-operator/templates/node-agent/scc-rolebinding.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ printf "%s-scc" .Values.nodeAgent.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 roleRef:

--- a/charts/kubescape-operator/templates/node-agent/service.yaml
+++ b/charts/kubescape-operator/templates/node-agent/service.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.nodeAgent.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/node-agent/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/node-agent/serviceaccount.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.nodeAgent.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 {{- end }}

--- a/charts/kubescape-operator/templates/node-agent/servicemonitor.yaml
+++ b/charts/kubescape-operator/templates/node-agent/servicemonitor.yaml
@@ -6,7 +6,9 @@ metadata:
   name: runtime-monitor
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" "runtime-monitor" "tier" .Values.global.namespaceTier) | nindent 4 }}
     {{- with .Values.nodeAgent.serviceMonitor.additionalLabels }}

--- a/charts/kubescape-operator/templates/node-agent/template-configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/template-configmap.yaml
@@ -8,7 +8,9 @@ metadata:
   name: node-agent-daemonset-template
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/operator/admission-service.yaml
+++ b/charts/kubescape-operator/templates/operator/admission-service.yaml
@@ -7,7 +7,9 @@ metadata:
   name: "kubescape-admission-webhook"
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/operator/admission-webhook.yaml
+++ b/charts/kubescape-operator/templates/operator/admission-webhook.yaml
@@ -12,7 +12,9 @@ metadata:
   name: {{ $svcName }}-kubescape-tls-pair
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 type: kubernetes.io/tls
@@ -25,7 +27,9 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 webhooks:

--- a/charts/kubescape-operator/templates/operator/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/operator/clusterrole.yaml
@@ -5,7 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.operator.name }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 rules:

--- a/charts/kubescape-operator/templates/operator/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/operator/clusterrolebinding.yaml
@@ -5,7 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.operator.name }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 subjects:

--- a/charts/kubescape-operator/templates/operator/configmap.yaml
+++ b/charts/kubescape-operator/templates/operator/configmap.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.operator.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -9,7 +9,9 @@ metadata:
   name: {{ .Values.operator.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/operator/ks-recurring-cronjob-configmap.yaml
+++ b/charts/kubescape-operator/templates/operator/ks-recurring-cronjob-configmap.yaml
@@ -9,7 +9,9 @@ metadata:
   name: kubescape-cronjob-template
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.global.cloudConfig "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/operator/kv-recurring-cronjob-configmap.yaml
+++ b/charts/kubescape-operator/templates/operator/kv-recurring-cronjob-configmap.yaml
@@ -9,7 +9,9 @@ metadata:
   name: kubevuln-cronjob-template # TODO: update template name
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.global.cloudConfig "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/operator/networkpolicy.yaml
+++ b/charts/kubescape-operator/templates/operator/networkpolicy.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.operator.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/operator/registry-scan-recurring-cronjob-configmap.yaml
+++ b/charts/kubescape-operator/templates/operator/registry-scan-recurring-cronjob-configmap.yaml
@@ -8,7 +8,9 @@ kind: ConfigMap
 metadata:
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.global.cloudConfig "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/operator/role.yaml
+++ b/charts/kubescape-operator/templates/operator/role.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.operator.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 rules:

--- a/charts/kubescape-operator/templates/operator/rolebinding.yaml
+++ b/charts/kubescape-operator/templates/operator/rolebinding.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.operator.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 roleRef:

--- a/charts/kubescape-operator/templates/operator/scc-rolebinding.yaml
+++ b/charts/kubescape-operator/templates/operator/scc-rolebinding.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ printf "%s-scc" .Values.operator.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 roleRef:

--- a/charts/kubescape-operator/templates/operator/service.yaml
+++ b/charts/kubescape-operator/templates/operator/service.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.operator.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.operator.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/operator/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/operator/serviceaccount.yaml
@@ -4,7 +4,9 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
 {{- if .Values.cloudProviderMetadata.awsIamRoleArn }}
     eks.amazonaws.com/role-arn: {{ .Values.cloudProviderMetadata.awsIamRoleArn }}
   {{- else if .Values.cloudProviderMetadata.gkeServiceAccount }}

--- a/charts/kubescape-operator/templates/otel-collector/configmap.yaml
+++ b/charts/kubescape-operator/templates/otel-collector/configmap.yaml
@@ -6,7 +6,9 @@ metadata:
   name: otel-collector-config
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.global.cloudConfig "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/otel-collector/deployment.yaml
+++ b/charts/kubescape-operator/templates/otel-collector/deployment.yaml
@@ -8,7 +8,9 @@ metadata:
   name: {{ .Values.otelCollector.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.otelCollector.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
@@ -7,7 +7,9 @@ metadata:
   name: {{ .Values.prometheusExporter.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.prometheusExporter.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/prometheus-exporter/networkpolicy.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/networkpolicy.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.prometheusExporter.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.prometheusExporter.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/prometheus-exporter/servicemonitor.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/servicemonitor.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.prometheusExporter.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.prometheusExporter.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     {{- with .Values.kubescape.serviceMonitor.additionalLabels }}

--- a/charts/kubescape-operator/templates/storage/apiservice.yaml
+++ b/charts/kubescape-operator/templates/storage/apiservice.yaml
@@ -5,7 +5,9 @@ kind: APIService
 metadata:
   name: "v1beta1.spdx.softwarecomposition.kubescape.io"
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/storage/ca-secret.yaml
+++ b/charts/kubescape-operator/templates/storage/ca-secret.yaml
@@ -7,7 +7,9 @@ metadata:
   name: {{ .Values.storage.name }}-ca
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 type: kubernetes.io/tls

--- a/charts/kubescape-operator/templates/storage/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/storage/clusterrole.yaml
@@ -5,7 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.storage.name }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 rules:

--- a/charts/kubescape-operator/templates/storage/clusterrolebinding.yaml
+++ b/charts/kubescape-operator/templates/storage/clusterrolebinding.yaml
@@ -5,7 +5,9 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "storage.authDelegatorClusterRoleBindingName" . | quote }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 roleRef:
@@ -22,7 +24,9 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.storage.name }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 roleRef:

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -7,7 +7,9 @@ metadata:
   name: {{ .Values.storage.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/storage/networkpolicy.yaml
+++ b/charts/kubescape-operator/templates/storage/networkpolicy.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.storage.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/storage/pvc.yaml
+++ b/charts/kubescape-operator/templates/storage/pvc.yaml
@@ -6,7 +6,9 @@ metadata:
   name: kubescape-{{ .Values.storage.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/storage/rolebinding.yaml
+++ b/charts/kubescape-operator/templates/storage/rolebinding.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ include "storage.authReaderRoleBindingName" . | quote }}
   namespace: kube-system
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 roleRef:

--- a/charts/kubescape-operator/templates/storage/scc-rolebinding.yaml
+++ b/charts/kubescape-operator/templates/storage/scc-rolebinding.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ printf "%s-scc" .Values.storage.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 roleRef:

--- a/charts/kubescape-operator/templates/storage/seccompprofile-crd.yaml
+++ b/charts/kubescape-operator/templates/storage/seccompprofile-crd.yaml
@@ -4,7 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   name: seccompprofiles.kubescape.io
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" "seccompprofile" "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/storage/service.yaml
+++ b/charts/kubescape-operator/templates/storage/service.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.storage.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/templates/storage/serviceaccount.yaml
+++ b/charts/kubescape-operator/templates/storage/serviceaccount.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.storage.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 {{- end }}

--- a/charts/kubescape-operator/templates/storage/tests/test-connection.yaml
+++ b/charts/kubescape-operator/templates/storage/tests/test-connection.yaml
@@ -3,7 +3,9 @@ kind: Pod
 metadata:
   name: "{{ .Values.storage.name }}-test-connection"
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": test
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}

--- a/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
@@ -5,7 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.synchronizer.name }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.synchronizer.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 rules:

--- a/charts/kubescape-operator/templates/synchronizer/configmap.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/configmap.yaml
@@ -7,7 +7,9 @@ metadata:
   name: {{ .Values.synchronizer.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.synchronizer.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -8,7 +8,9 @@ metadata:
   name: {{ .Values.synchronizer.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.synchronizer.name "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"

--- a/charts/kubescape-operator/templates/synchronizer/networkpolicy.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/networkpolicy.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.synchronizer.name }}
   namespace: {{ .Values.ksNamespace }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with (include "kubescape-operator.annotations" (dict "Values" .Values)) }}
+    {{ . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.synchronizer.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:


### PR DESCRIPTION
No functional changes, only slightly cleaner helm output. Closes #814

## Overview
Update usage of global annotations to not include empty lines in output. 


## Additional Information
No functional changes, only cleaning up the helm output. 
Would be even better to not add `annotations:` is there are none. Maybe something to fix after #813, currently clashes.

## How to Test
With a local helm build.

Before:
```
# Source: kubescape-operator/templates/operator/admission-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: "kubescape-admission-webhook"
  namespace: kubescape
  annotations:
    
  labels:
    helm.sh/chart: kubescape-operator-1.30.6
    app.kubernetes.io/name: kubescape-operator
    app.kubernetes.io/instance: my-release
    app.kubernetes.io/component: operator
    app.kubernetes.io/version: "1.30.6"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: kubescape
    app: operator
    tier: ks-control-plane
    kubescape.io/ignore: "true"
spec:
  ports:
    - port: 443
      targetPort: 8443
  selector:
      app.kubernetes.io/name: kubescape-operator
      app.kubernetes.io/instance: my-release
      app.kubernetes.io/component: operator
  type: ClusterIP  # Or use LoadBalancer or NodePort if needed
---
```
After: 
```
# Source: kubescape-operator/templates/operator/admission-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: "kubescape-admission-webhook"
  namespace: kubescape
  annotations:
  labels:
    helm.sh/chart: kubescape-operator-1.30.6
    app.kubernetes.io/name: kubescape-operator
    app.kubernetes.io/instance: my-release
    app.kubernetes.io/component: operator
    app.kubernetes.io/version: "1.30.6"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: kubescape
    app: operator
    tier: ks-control-plane
    kubescape.io/ignore: "true"
spec:
  ports:
    - port: 443
      targetPort: 8443
  selector:
      app.kubernetes.io/name: kubescape-operator
      app.kubernetes.io/instance: my-release
      app.kubernetes.io/component: operator
  type: ClusterIP  # Or use LoadBalancer or NodePort if needed
```
Already tested, annotations is now empty where before it included an empty line with indent 4.


## Related issues/PRs:
* Resolved #814 


<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `main` branch**

-->
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated Helm template annotation rendering across all Kubernetes manifests to conditionally emit annotations only when configured, preventing unnecessary empty annotation blocks in generated resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->