### PR TITLE
fix(storage): allow configuring storage Service exposure

### DIFF
--- a/charts/kubescape-operator/templates/storage/service.yaml
+++ b/charts/kubescape-operator/templates/storage/service.yaml
@@ -7,9 +7,13 @@ metadata:
   namespace: {{ .Values.ksNamespace }}
   annotations:
     {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- with .Values.storage.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:
+  type: {{ .Values.storage.service.type }}
   ports:
   - port: 443
     protocol: TCP

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -5767,6 +5767,7 @@ all capabilities:
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
   92: |
     apiVersion: v1
     kind: ServiceAccount
@@ -14650,6 +14651,7 @@ default capabilities:
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
   66: |
     apiVersion: v1
     kind: ServiceAccount
@@ -18872,6 +18874,7 @@ disable otel:
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
   55: |
     apiVersion: v1
     kind: ServiceAccount
@@ -22920,6 +22923,7 @@ minimal capabilities:
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
   55: |
     apiVersion: v1
     kind: ServiceAccount
@@ -29039,6 +29043,7 @@ multiple node agents:
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
   93: |
     apiVersion: v1
     kind: ServiceAccount
@@ -33400,6 +33405,7 @@ priority class scheduling:
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
   55: |
     apiVersion: v1
     kind: ServiceAccount
@@ -37342,6 +37348,7 @@ relevancy only:
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
   52: |
     apiVersion: v1
     kind: ServiceAccount
@@ -43132,6 +43139,7 @@ skipPersistence enabled:
         app.kubernetes.io/component: storage
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
   92: |
     apiVersion: v1
     kind: ServiceAccount

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -212,6 +212,26 @@ tests:
       kubescape.serviceMonitor.enabled: true
       kubescapeScheduler.scanSchedule: "1 2 3 4 5"
       kubevulnScheduler.scanSchedule: "1 2 3 4 5"
+  - it: storage service configuration
+    template: storage/service.yaml
+    documentSelector:
+      path: metadata.name
+      value: storage
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      storage.service.type: LoadBalancer
+      storage.service.annotations:
+        io.cilium/lb-ipam-ips: 10.103.145.148
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: metadata.annotations["io.cilium/lb-ipam-ips"]
+          value: 10.103.145.148
   - it: with single private registry credentials
     template: configs/private-registries-creds-secret.yaml
     documentSelector:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -491,6 +491,9 @@ storage:
     enabled: true
     certificateValidityInDays: 730
   serverPort: 8443
+  service:
+    type: ClusterIP
+    annotations: {}
 
   # -- source code: https://github.com/kubescape/storage
   image:


### PR DESCRIPTION
## Overview
This updates the storage Service in the `kubescape-operator` chart so clusters that need the aggregated storage API reachable outside the cluster network can override the Service type and attach storage-specific Service annotations.

## Additional Information
The storage Service was the remaining hardcoded `ClusterIP` in the path reported in #806. The chart already exposed similar service configuration for other components, so this change keeps storage aligned without introducing a second target-port source of truth.

## How to Test
1. Run `helm unittest -u charts/kubescape-operator`.
2. Confirm the new `storage service configuration` test passes.
3. Optionally render the chart with `storage.service.type=LoadBalancer` and a storage Service annotation override to verify the generated Service manifest.

## Related issues/PRs:
* Relates #806

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Storage service configuration now supports customizable service type and annotations, enabling flexible deployment options across different environments.

* **Tests**
  * Added snapshot test case for validating storage service configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->