### PR TITLE
Add SecurityException CRDs, RBAC, and riskAcceptance capability

### DIFF
--- a/charts/kubescape-operator/crds/cluster-security-exception.crd.yaml
+++ b/charts/kubescape-operator/crds/cluster-security-exception.crd.yaml
@@ -1,0 +1,121 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clustersecurityexceptions.kubescape.io
+spec:
+  group: kubescape.io
+  names:
+    plural: clustersecurityexceptions
+    singular: clustersecurityexception
+    kind: ClusterSecurityException
+    shortNames:
+      - cse
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                author:
+                  type: string
+                reason:
+                  type: string
+                expiresAt:
+                  type: string
+                  format: date-time
+                match:
+                  type: object
+                  properties:
+                    namespaceSelector:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    objectSelector:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    resources:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - kind
+                        properties:
+                          apiGroup:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                    images:
+                      type: array
+                      items:
+                        type: string
+                vulnerabilities:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - vulnerability
+                      - status
+                    properties:
+                      vulnerability:
+                        type: object
+                        required:
+                          - id
+                        properties:
+                          id:
+                            type: string
+                          aliases:
+                            type: array
+                            items:
+                              type: string
+                      status:
+                        type: string
+                        enum:
+                          - not_affected
+                          - fixed
+                          - under_investigation
+                      justification:
+                        type: string
+                        enum:
+                          - component_not_present
+                          - vulnerable_code_not_present
+                          - vulnerable_code_not_in_execute_path
+                          - vulnerable_code_cannot_be_controlled_by_adversary
+                          - inline_mitigations_already_exist
+                      impactStatement:
+                        type: string
+                      expiredOnFix:
+                        type: boolean
+                posture:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - controlID
+                      - action
+                    properties:
+                      controlID:
+                        type: string
+                      frameworkName:
+                        type: string
+                      action:
+                        type: string
+                        enum:
+                          - ignore
+                          - alert_only
+      additionalPrinterColumns:
+        - name: Reason
+          type: string
+          jsonPath: .spec.reason
+        - name: Expires
+          type: string
+          jsonPath: .spec.expiresAt
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/charts/kubescape-operator/crds/cluster-security-exception.crd.yaml
+++ b/charts/kubescape-operator/crds/cluster-security-exception.crd.yaml
@@ -12,12 +12,13 @@ spec:
       - cse
   scope: Cluster
   versions:
-    - name: v1
+    - name: v1beta1
       served: true
       storage: true
       schema:
         openAPIV3Schema:
           type: object
+          required: ["spec"]
           properties:
             spec:
               type: object
@@ -109,6 +110,8 @@ spec:
                         enum:
                           - ignore
                           - alert_only
+            status:
+              type: object
       additionalPrinterColumns:
         - name: Reason
           type: string
@@ -119,3 +122,5 @@ spec:
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}

--- a/charts/kubescape-operator/crds/security-exception.crd.yaml
+++ b/charts/kubescape-operator/crds/security-exception.crd.yaml
@@ -1,0 +1,118 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: securityexceptions.kubescape.io
+spec:
+  group: kubescape.io
+  names:
+    plural: securityexceptions
+    singular: securityexception
+    kind: SecurityException
+    shortNames:
+      - se
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                author:
+                  type: string
+                reason:
+                  type: string
+                expiresAt:
+                  type: string
+                  format: date-time
+                match:
+                  type: object
+                  properties:
+                    objectSelector:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    resources:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - kind
+                        properties:
+                          apiGroup:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                    images:
+                      type: array
+                      items:
+                        type: string
+                vulnerabilities:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - vulnerability
+                      - status
+                    properties:
+                      vulnerability:
+                        type: object
+                        required:
+                          - id
+                        properties:
+                          id:
+                            type: string
+                          aliases:
+                            type: array
+                            items:
+                              type: string
+                      status:
+                        type: string
+                        enum:
+                          - not_affected
+                          - fixed
+                          - under_investigation
+                      justification:
+                        type: string
+                        enum:
+                          - component_not_present
+                          - vulnerable_code_not_present
+                          - vulnerable_code_not_in_execute_path
+                          - vulnerable_code_cannot_be_controlled_by_adversary
+                          - inline_mitigations_already_exist
+                      impactStatement:
+                        type: string
+                      expiredOnFix:
+                        type: boolean
+                posture:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - controlID
+                      - action
+                    properties:
+                      controlID:
+                        type: string
+                      frameworkName:
+                        type: string
+                      action:
+                        type: string
+                        enum:
+                          - ignore
+                          - alert_only
+      additionalPrinterColumns:
+        - name: Reason
+          type: string
+          jsonPath: .spec.reason
+        - name: Expires
+          type: string
+          jsonPath: .spec.expiresAt
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/charts/kubescape-operator/crds/security-exception.crd.yaml
+++ b/charts/kubescape-operator/crds/security-exception.crd.yaml
@@ -12,12 +12,13 @@ spec:
       - se
   scope: Namespaced
   versions:
-    - name: v1
+    - name: v1beta1
       served: true
       storage: true
       schema:
         openAPIV3Schema:
           type: object
+          required: ["spec"]
           properties:
             spec:
               type: object
@@ -106,6 +107,8 @@ spec:
                         enum:
                           - ignore
                           - alert_only
+            status:
+              type: object
       additionalPrinterColumns:
         - name: Reason
           type: string
@@ -116,3 +119,5 @@ spec:
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}

--- a/charts/kubescape-operator/templates/kubevuln/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/clusterrole.yaml
@@ -15,4 +15,9 @@ rules:
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
     resources: ["containerprofiles"]
     verbs: ["get", "watch", "list"]
+{{- if eq .Values.capabilities.riskAcceptance "enable" }}
+  - apiGroups: ["kubescape.io"]
+    resources: ["securityexceptions", "clustersecurityexceptions"]
+    verbs: ["get", "list", "watch"]
+{{- end }}
 {{- end }}

--- a/charts/kubescape-operator/templates/operator/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/operator/clusterrole.yaml
@@ -41,4 +41,9 @@ rules:
   - apiGroups: ["kubescape.io"]
     resources: ["operatorcommands/status"]
     verbs: ["get", "watch", "list", "update", "patch"]
+{{- if eq .Values.capabilities.riskAcceptance "enable" }}
+  - apiGroups: ["kubescape.io"]
+    resources: ["securityexceptions", "clustersecurityexceptions"]
+    verbs: ["get", "list", "watch"]
+{{- end }}
   {{- end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -299,7 +299,7 @@ all capabilities:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"enable","autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"enable","manageWorkloads":"enable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"enable","relevancy":"enable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"enable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"enable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"enable","autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"enable","manageWorkloads":"enable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"enable","relevancy":"enable","riskAcceptance":"enable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"enable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"enable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":true},"clamAV":{"enabled":true},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":false},"prometheusExporter":{"enabled":true},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":[".containers[*].env[?(@.name==\"KUBECONFIG\")]"],"otelUrl":"otelCollector.svc.monitoring:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -1860,6 +1860,15 @@ all capabilities:
           - get
           - watch
           - list
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - securityexceptions
+          - clustersecurityexceptions
+        verbs:
+          - get
+          - list
+          - watch
   38: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -3868,6 +3877,15 @@ all capabilities:
           - list
           - update
           - patch
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - securityexceptions
+          - clustersecurityexceptions
+        verbs:
+          - get
+          - list
+          - watch
   61: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -3978,7 +3996,7 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: b8bc7b0aa1b20d8eb4ed1c48e5969b2e5d9f70c4506fc495f7dbd33e3098391b
+            checksum/capabilities-config: b0b4eb6ecb26f9be060912ffbe5f36704226a6c2c443b5cffb1049ab3553d740
             checksum/cloud-config: aaeeb6b6b35a5ebbb0893822c4bf9cd860fba6d3df3bc4e77c8dbdd5841db120
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -6864,7 +6882,7 @@ backend-storage enabled disables scanning capabilities:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","backend-storage":"enable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","backend-storage":"enable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":false},"kubescape":{"enabled":false},"kubescapeScheduler":{"enabled":false},"kubevuln":{"enabled":false},"kubevulnScheduler":{"enabled":false},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":false},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":false},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -8470,7 +8488,7 @@ backend-storage enabled disables scanning capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 0676e2566d51852ee5e6ed4cce5a5c8543c921deed9e8fe1baa4ecdfdd722406
+            checksum/capabilities-config: 3010c794c6f0dfdbb330fba2c2e3e3abc826155e21b84389e61983489b61a964
             checksum/cloud-config: a86d5156181591681a79c39bb2816f8428bbaa9e3de0ea3bcdba0d21a148debd
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -10159,7 +10177,7 @@ default capabilities:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"disable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"disable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"disable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"disable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":false},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -13281,7 +13299,7 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: cd48143b0fc590552f7ebfcdc4c072fe00d2d3a113c6cd1245502cf48c0bfe4d
+            checksum/capabilities-config: 3d31ed2e2c7d18155db83bd252b0c42d3398882b194102f4bb936f7131804a45
             checksum/cloud-config: 8e6c3d6c7321da0fccdb7ce24882e7bcf831736b163bb916902ed635fd2809eb
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -15661,7 +15679,7 @@ disable otel:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":false},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -17721,7 +17739,7 @@ disable otel:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: a643b38c6219889bb16d586f6988fd7bb8d39a43c171cdd4e4c4f6a7f3fb17fd
+            checksum/capabilities-config: 61d30cd5e973ad112768a6a808b15f76374a779cff9362a3b6668b6fd65c4255
             checksum/cloud-config: f8f57ee9b7c136ff44014ae152c2ee1d6437058a776ba359547a4d44896626d0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -19828,7 +19846,7 @@ minimal capabilities:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":false},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":"otelCollector.svc.monitoring:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -21797,7 +21815,7 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: afbd6542164d7dc46a393360ec5ad8595641b295a3d4f2b3ddba2242c33b9523
+            checksum/capabilities-config: 894c0fba0437543c0f7ab523984c6741a1669fc2e12c49348a562c18e0483a9b
             checksum/cloud-config: 8f40f001a3e31db9895e7bbb06ab070f25ab66c83b31d1929b273cfd22402097
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -23367,7 +23385,7 @@ multiple node agents:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"enable","autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"enable","manageWorkloads":"enable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"enable","relevancy":"enable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"enable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"enable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"enable","autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"enable","manageWorkloads":"enable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"enable","relevancy":"enable","riskAcceptance":"enable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"enable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"enable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":true},"clamAV":{"enabled":true},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":false},"prometheusExporter":{"enabled":true},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":[".containers[*].env[?(@.name==\"KUBECONFIG\")]"],"otelUrl":"otelCollector.svc.monitoring:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -24928,6 +24946,15 @@ multiple node agents:
           - get
           - watch
           - list
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - securityexceptions
+          - clustersecurityexceptions
+        verbs:
+          - get
+          - list
+          - watch
   38: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -27268,6 +27295,15 @@ multiple node agents:
           - list
           - update
           - patch
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - securityexceptions
+          - clustersecurityexceptions
+        verbs:
+          - get
+          - list
+          - watch
   62: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -27378,7 +27414,7 @@ multiple node agents:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: b8bc7b0aa1b20d8eb4ed1c48e5969b2e5d9f70c4506fc495f7dbd33e3098391b
+            checksum/capabilities-config: b0b4eb6ecb26f9be060912ffbe5f36704226a6c2c443b5cffb1049ab3553d740
             checksum/cloud-config: aaeeb6b6b35a5ebbb0893822c4bf9cd860fba6d3df3bc4e77c8dbdd5841db120
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -30272,7 +30308,7 @@ priority class scheduling:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":false},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -32336,7 +32372,7 @@ priority class scheduling:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 1363515edabb1d011e2c2bd81949305f9e0599f0b1c385120c70e7cf832288b1
+            checksum/capabilities-config: 14a3d2e7673c697ad37106c42861561b8f6cf49667951eeb96a7416211294f1a
             checksum/cloud-config: f8f57ee9b7c136ff44014ae152c2ee1d6437058a776ba359547a4d44896626d0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -34445,7 +34481,7 @@ relevancy only:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"disable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"disable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"disable","networkPolicyService":"disable","nodeProfileService":"disable","nodeSbomGeneration":"disable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","runtimeDetection":"disable","runtimeObservability":"disable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"disable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"disable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"disable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"disable","networkPolicyService":"disable","nodeProfileService":"disable","nodeSbomGeneration":"disable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"disable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"disable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":false},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":"otelCollector.svc.monitoring:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -36294,7 +36330,7 @@ relevancy only:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 069cf0967ae5d3be1467dc9346fa49bb64ae0da3b3cb95db42188d211deaa011
+            checksum/capabilities-config: 239c59df3fce21d6eeb7c9043c7fa53b3b6885314407175c00b21047eab2aeda
             checksum/cloud-config: 8f40f001a3e31db9895e7bbb06ab070f25ab66c83b31d1929b273cfd22402097
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -37855,7 +37891,7 @@ skipPersistence enabled:
     data:
       capabilities: |
         {
-          "capabilities":{"admissionController":"enable","autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"enable","manageWorkloads":"enable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"enable","relevancy":"enable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"enable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"enable","vulnerabilityScan":"enable"},
+          "capabilities":{"admissionController":"enable","autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"enable","manageWorkloads":"enable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"enable","relevancy":"enable","riskAcceptance":"enable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"enable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"enable","vulnerabilityScan":"enable"},
           "components":{"autoUpdater":{"enabled":true},"clamAV":{"enabled":true},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"hostScanner":{"enabled":true},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"otelCollector":{"enabled":false},"prometheusExporter":{"enabled":true},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":[".containers[*].env[?(@.name==\"KUBECONFIG\")]"],"otelUrl":"otelCollector.svc.monitoring:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -39419,6 +39455,15 @@ skipPersistence enabled:
           - get
           - watch
           - list
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - securityexceptions
+          - clustersecurityexceptions
+        verbs:
+          - get
+          - list
+          - watch
   38: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -41427,6 +41472,15 @@ skipPersistence enabled:
           - list
           - update
           - patch
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - securityexceptions
+          - clustersecurityexceptions
+        verbs:
+          - get
+          - list
+          - watch
   61: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -41537,7 +41591,7 @@ skipPersistence enabled:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: b8bc7b0aa1b20d8eb4ed1c48e5969b2e5d9f70c4506fc495f7dbd33e3098391b
+            checksum/capabilities-config: b0b4eb6ecb26f9be060912ffbe5f36704226a6c2c443b5cffb1049ab3553d740
             checksum/cloud-config: aaeeb6b6b35a5ebbb0893822c4bf9cd860fba6d3df3bc4e77c8dbdd5841db120
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -58,6 +58,7 @@ tests:
         manageWorkloads: enable
         networkEventsStreaming: enable
         syncSBOM: enable
+        riskAcceptance: enable
       excludeLabels:
         foo: [bar, baz]
         baz: [qux]
@@ -347,6 +348,7 @@ tests:
         manageWorkloads: enable
         networkEventsStreaming: enable
         syncSBOM: enable
+        riskAcceptance: enable
       excludeLabels:
         foo: [bar, baz]
         baz: [qux]
@@ -484,6 +486,7 @@ tests:
         manageWorkloads: enable
         networkEventsStreaming: enable
         syncSBOM: enable
+        riskAcceptance: enable
       excludeLabels:
         foo: [bar, baz]
         baz: [qux]

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -121,7 +121,7 @@ capabilities:
   syncSBOM: disable
 
   # ====== Risk acceptance ======
-  riskAcceptance: enable
+  riskAcceptance: disable
 
   # ====== Other capabilities ======
   #

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -120,6 +120,9 @@ capabilities:
   manageWorkloads: disable
   syncSBOM: disable
 
+  # ====== Risk acceptance ======
+  riskAcceptance: enable
+
   # ====== Other capabilities ======
   #
   # This is an experimental capability with an elevated security risk. Read the


### PR DESCRIPTION
## Summary

- Adds `SecurityException` (namespaced) and `ClusterSecurityException` (cluster-scoped) CRD YAMLs under `kubescape.io/v1`
- Adds `riskAcceptance: enable` capability (default enabled)
- Grants `get/list/watch` RBAC to kubevuln and operator clusterroles (gated on capability)

Part of NAUT-1258: GitOps-native risk acceptance via SecurityException CRDs.

## Test plan

- [x] `helm template` renders CRD rules in kubevuln/operator ClusterRoles
- [x] `helm template --set capabilities.riskAcceptance=disable` omits CRD rules
- [ ] CRD YAMLs pass `kubectl apply --dry-run=server` on a test cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cluster-scoped and namespace-scoped SecurityException resources to record exceptions with structured metadata (author, reason, expiry, match criteria, vulnerabilities, posture, and status) and improved status/printer display.
  * Introduced a configurable "risk acceptance" capability (defaults to disabled) that enables read access to these exception resources when turned on.

* **Tests**
  * Updated snapshot tests to include the risk acceptance capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->