### PR TITLE
refactor(templates): remove redundant GOMAXPROCS

### DIFF
--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -129,11 +129,6 @@ spec:
             resourceFieldRef:
               resource: limits.memory
               divisor: '1'
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-              divisor: '1'
         - name: KS_LOGGER_LEVEL
           value: "{{ .Values.logger.level }}"
         - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -135,8 +135,6 @@ spec:
           value: "{{ .Values.logger.name }}"
         - name: KS_DOWNLOAD_ARTIFACTS  # When set to true the artifacts will be downloaded every scan execution
           value: "{{ .Values.kubescape.downloadArtifacts }}"
-        - name: RULE_PROCESSING_GOMAXPROCS
-          value: "{{ .Values.kubescape.ruleProcessingConcurrency }}"
         - name: KS_DEFAULT_CONFIGMAP_NAME
           value: "{{ .Values.kubescape.name }}-config"
         - name: KS_DEFAULT_CONFIGMAP_NAMESPACE

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -118,11 +118,6 @@ spec:
                 resourceFieldRef:
                   resource: limits.memory
                   divisor: '1'
-            - name: GOMAXPROCS
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.cpu
-                  divisor: '1'
             - name: KS_LOGGER_LEVEL
               value: "{{ .Values.logger.level }}"
             - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/templates/node-agent/_node-agent.tpl
+++ b/charts/kubescape-operator/templates/node-agent/_node-agent.tpl
@@ -38,11 +38,6 @@ Parameters:
     resourceFieldRef:
       resource: limits.memory
       divisor: '1'
-- name: GOMAXPROCS
-  valueFrom:
-    resourceFieldRef:
-      resource: limits.cpu
-      divisor: '1'
 - name: HOST_ROOT
   value: "/host"
 - name: KS_LOGGER_LEVEL

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -106,11 +106,6 @@ spec:
                 resourceFieldRef:
                   resource: limits.memory
                   divisor: '1'
-            - name: GOMAXPROCS
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.cpu
-                  divisor: '1'
             - name: KS_LOGGER_LEVEL
               value: "{{ .Values.logger.level }}"
             - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/templates/otel-collector/deployment.yaml
+++ b/charts/kubescape-operator/templates/otel-collector/deployment.yaml
@@ -82,11 +82,6 @@ spec:
             resourceFieldRef:
               resource: limits.memory
               divisor: '1'
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-              divisor: '1'
         - name: GOGC
           value: "80"
         {{- if ne .Values.global.httpsProxy "" }}

--- a/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
@@ -70,11 +70,6 @@ spec:
                 resourceFieldRef:
                   resource: limits.memory
                   divisor: '1'
-            - name: GOMAXPROCS
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.cpu
-                  divisor: '1'
             - name: KS_LOGGER_LEVEL
               value: "{{ .Values.logger.level }}"
             - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -71,11 +71,6 @@ spec:
               resourceFieldRef:
                 resource: limits.memory
                 divisor: '1'
-          - name: GOMAXPROCS
-            valueFrom:
-              resourceFieldRef:
-                resource: limits.cpu
-                divisor: '1'
           - name: KS_LOGGER_LEVEL
             value: "{{ .Values.logger.level }}"
           - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -115,11 +115,6 @@ spec:
                 resourceFieldRef:
                   resource: limits.memory
                   divisor: '1'
-            - name: GOMAXPROCS
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.cpu
-                  divisor: '1'
             - name: KS_LOGGER_LEVEL
               value: "{{ .Values.logger.level }}"
             - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1184,11 +1184,6 @@ all capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -1955,11 +1950,6 @@ all capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -2607,11 +2597,6 @@ all capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: HOST_ROOT
                   value: /host
                 - name: KS_LOGGER_LEVEL
@@ -4030,11 +4015,6 @@ all capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -4781,11 +4761,6 @@ all capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -5238,11 +5213,6 @@ all capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -6449,11 +6419,6 @@ all capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -7230,11 +7195,6 @@ backend-storage enabled disables scanning capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: HOST_ROOT
                   value: /host
                 - name: KS_LOGGER_LEVEL
@@ -8521,11 +8481,6 @@ backend-storage enabled disables scanning capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -9867,11 +9822,6 @@ backend-storage enabled disables scanning capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -10878,11 +10828,6 @@ default capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -11559,11 +11504,6 @@ default capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -12083,11 +12023,6 @@ default capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: HOST_ROOT
                   value: /host
                 - name: KS_LOGGER_LEVEL
@@ -13333,11 +13268,6 @@ default capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -14193,11 +14123,6 @@ default capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -15284,11 +15209,6 @@ default capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -16189,11 +16109,6 @@ disable otel:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -16686,11 +16601,6 @@ disable otel:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -17129,11 +17039,6 @@ disable otel:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: HOST_ROOT
                   value: /host
                 - name: KS_LOGGER_LEVEL
@@ -17772,11 +17677,6 @@ disable otel:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -18509,11 +18409,6 @@ disable otel:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -19537,11 +19432,6 @@ disable otel:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -20356,11 +20246,6 @@ minimal capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -20822,11 +20707,6 @@ minimal capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -21234,11 +21114,6 @@ minimal capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: HOST_ROOT
                   value: /host
                 - name: KS_LOGGER_LEVEL
@@ -21848,11 +21723,6 @@ minimal capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -22587,11 +22457,6 @@ minimal capabilities:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -24270,11 +24135,6 @@ multiple node agents:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -25041,11 +24901,6 @@ multiple node agents:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -25693,11 +25548,6 @@ multiple node agents:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: HOST_ROOT
                   value: /host
                 - name: KS_LOGGER_LEVEL
@@ -26024,11 +25874,6 @@ multiple node agents:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: HOST_ROOT
                   value: /host
                 - name: KS_LOGGER_LEVEL
@@ -27448,11 +27293,6 @@ multiple node agents:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -28199,11 +28039,6 @@ multiple node agents:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -28656,11 +28491,6 @@ multiple node agents:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -29867,11 +29697,6 @@ multiple node agents:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -30819,11 +30644,6 @@ priority class scheduling:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -31318,11 +31138,6 @@ priority class scheduling:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -31762,11 +31577,6 @@ priority class scheduling:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: HOST_ROOT
                   value: /host
                 - name: KS_LOGGER_LEVEL
@@ -32405,11 +32215,6 @@ priority class scheduling:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -33143,11 +32948,6 @@ priority class scheduling:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -34172,11 +33972,6 @@ priority class scheduling:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -34991,11 +34786,6 @@ relevancy only:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -35457,11 +35247,6 @@ relevancy only:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -35869,11 +35654,6 @@ relevancy only:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: HOST_ROOT
                   value: /host
                 - name: KS_LOGGER_LEVEL
@@ -36363,11 +36143,6 @@ relevancy only:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -37093,11 +36868,6 @@ relevancy only:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -38776,11 +38546,6 @@ skipPersistence enabled:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -39550,11 +39315,6 @@ skipPersistence enabled:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -40202,11 +39962,6 @@ skipPersistence enabled:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: HOST_ROOT
                   value: /host
                 - name: KS_LOGGER_LEVEL
@@ -41625,11 +41380,6 @@ skipPersistence enabled:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -42376,11 +42126,6 @@ skipPersistence enabled:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -42833,11 +42578,6 @@ skipPersistence enabled:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -44044,11 +43784,6 @@ skipPersistence enabled:
                     resourceFieldRef:
                       divisor: "1"
                       resource: limits.memory
-                - name: GOMAXPROCS
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.cpu
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1190,8 +1190,6 @@ all capabilities:
                   value: zap
                 - name: KS_DOWNLOAD_ARTIFACTS
                   value: "true"
-                - name: RULE_PROCESSING_GOMAXPROCS
-                  value: ""
                 - name: KS_DEFAULT_CONFIGMAP_NAME
                   value: kubescape-config
                 - name: KS_DEFAULT_CONFIGMAP_NAMESPACE
@@ -10834,8 +10832,6 @@ default capabilities:
                   value: zap
                 - name: KS_DOWNLOAD_ARTIFACTS
                   value: "true"
-                - name: RULE_PROCESSING_GOMAXPROCS
-                  value: ""
                 - name: KS_DEFAULT_CONFIGMAP_NAME
                   value: kubescape-config
                 - name: KS_DEFAULT_CONFIGMAP_NAMESPACE
@@ -16115,8 +16111,6 @@ disable otel:
                   value: zap
                 - name: KS_DOWNLOAD_ARTIFACTS
                   value: "true"
-                - name: RULE_PROCESSING_GOMAXPROCS
-                  value: ""
                 - name: KS_DEFAULT_CONFIGMAP_NAME
                   value: kubescape-config
                 - name: KS_DEFAULT_CONFIGMAP_NAMESPACE
@@ -20252,8 +20246,6 @@ minimal capabilities:
                   value: zap
                 - name: KS_DOWNLOAD_ARTIFACTS
                   value: "true"
-                - name: RULE_PROCESSING_GOMAXPROCS
-                  value: ""
                 - name: KS_DEFAULT_CONFIGMAP_NAME
                   value: kubescape-config
                 - name: KS_DEFAULT_CONFIGMAP_NAMESPACE
@@ -24141,8 +24133,6 @@ multiple node agents:
                   value: zap
                 - name: KS_DOWNLOAD_ARTIFACTS
                   value: "true"
-                - name: RULE_PROCESSING_GOMAXPROCS
-                  value: ""
                 - name: KS_DEFAULT_CONFIGMAP_NAME
                   value: kubescape-config
                 - name: KS_DEFAULT_CONFIGMAP_NAMESPACE
@@ -30650,8 +30640,6 @@ priority class scheduling:
                   value: zap
                 - name: KS_DOWNLOAD_ARTIFACTS
                   value: "true"
-                - name: RULE_PROCESSING_GOMAXPROCS
-                  value: ""
                 - name: KS_DEFAULT_CONFIGMAP_NAME
                   value: kubescape-config
                 - name: KS_DEFAULT_CONFIGMAP_NAMESPACE
@@ -34792,8 +34780,6 @@ relevancy only:
                   value: zap
                 - name: KS_DOWNLOAD_ARTIFACTS
                   value: "true"
-                - name: RULE_PROCESSING_GOMAXPROCS
-                  value: ""
                 - name: KS_DEFAULT_CONFIGMAP_NAME
                   value: kubescape-config
                 - name: KS_DEFAULT_CONFIGMAP_NAMESPACE
@@ -38552,8 +38538,6 @@ skipPersistence enabled:
                   value: zap
                 - name: KS_DOWNLOAD_ARTIFACTS
                   value: "true"
-                - name: RULE_PROCESSING_GOMAXPROCS
-                  value: ""
                 - name: KS_DEFAULT_CONFIGMAP_NAME
                   value: kubescape-config
                 - name: KS_DEFAULT_CONFIGMAP_NAMESPACE


### PR DESCRIPTION
## Overview
This PR removes the `GOMAXPROCS` environment variable from all Kubescape deployment templates (`operator`, `kubevuln`, `synchronizer`, `storage`, `prometheus-exporter`, `otel-collector`, `node-agent` and `kubescape`). 

## Additional Information
*  `RULE_PROCESSING_GOMAXPROCS`: Dropped this variable in the `kubescape` deployment template per @matthyx feedback.

## How to Test
1. Run `helm template charts/kubescape-operator` locally and verify that the `GOMAXPROCS` environment variable is no longer rendered in any of the container specs.
2. The `helm-unittest` snapshot files have been regenerated in this PR. You can verify consistency by running `helm unittest charts/kubescape-operator/` locally.

## Examples/Screenshots

## Related issues/PRs:
* Task of #780

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `GOMAXPROCS` environment variable from eight containers in the Helm chart deployments (kubescape, kubevuln, node-agent, operator, otel-collector, prometheus-exporter, storage, and synchronizer). The Go runtime will now automatically determine the maximum processor count based on available container resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->