### PR TITLE
feat: add artifact provenance attestation for Helm chart releases

### DIFF
--- a/.github/workflows/03-helm-release.yaml
+++ b/.github/workflows/03-helm-release.yaml
@@ -54,6 +54,10 @@ jobs:
   helm-chart-release:
     needs: e2e-test
     if: ${{ !cancelled() && (needs.e2e-test.result == 'success' || needs.e2e-test.result == 'skipped') }}
+    permissions:
+      id-token: write      # Required: OIDC token for keyless attestation signing
+      contents: write      # Required: chart-releaser creates GitHub Releases and pushes gh-pages index
+      attestations: write  # Required: upload attestation to GitHub's transparency log
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -75,11 +79,48 @@ jobs:
         # with:
         #   version: v3.4.0
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+      - name: Install chart-releaser CLI
         env:
-          charts_dir: "charts/kubescape-operator"
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_VERSION: "1.6.1"
+        run: |
+          curl -sSLo cr.tar.gz \
+            "https://github.com/helm/chart-releaser/releases/download/v${CR_VERSION}/chart-releaser_${CR_VERSION}_linux_amd64.tar.gz"
+          tar -xzf cr.tar.gz cr
+          sudo install -m 755 cr /usr/local/bin/cr
+          rm -f cr.tar.gz
+
+      - name: Package charts
+        run: |
+          mkdir -p .cr-release-packages/
+          helm package charts/kubescape-operator --destination .cr-release-packages/
+
+      - name: Attest chart provenance
+        if: hashFiles('.cr-release-packages/*.tgz') != ''
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: '.cr-release-packages/*.tgz'
+
+      - name: Publish chart release
+        if: hashFiles('.cr-release-packages/*.tgz') != ''
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          commit="$(git rev-parse HEAD)"
+          cr upload \
+            --owner "${owner}" \
+            --git-repo "${repo}" \
+            --token "${CR_TOKEN}" \
+            --commit "${commit}" \
+            --skip-existing
+          mkdir -p .cr-index/
+          cr index \
+            --owner "${owner}" \
+            --git-repo "${repo}" \
+            --charts-repo "https://${owner}.github.io/${repo}/" \
+            --token "${CR_TOKEN}" \
+            --push
 
       - name: Mark as pre-release
         if: inputs.RELEASE_BRANCH && inputs.RELEASE_BRANCH != 'main'

--- a/.github/workflows/04-helm-release-no-tests.yaml
+++ b/.github/workflows/04-helm-release-no-tests.yaml
@@ -20,13 +20,17 @@ on:
 
 jobs:
   helm-chart-release:
+    permissions:
+      id-token: write      # Required: OIDC token for keyless attestation signing
+      contents: write      # Required: chart-releaser creates GitHub Releases and pushes gh-pages index
+      attestations: write  # Required: upload attestation to GitHub's transparency log
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.COMMIT_REF }}
           fetch-depth: 0
-          # will change to: ref: release
 
       - name: git status
         run: git status
@@ -44,8 +48,45 @@ jobs:
         # with:
         #   version: v3.4.0
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
-        env: 
-          charts_dir: "charts/kubescape-operator"
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Install chart-releaser CLI
+        env:
+          CR_VERSION: "1.6.1"
+        run: |
+          curl -sSLo cr.tar.gz \
+            "https://github.com/helm/chart-releaser/releases/download/v${CR_VERSION}/chart-releaser_${CR_VERSION}_linux_amd64.tar.gz"
+          tar -xzf cr.tar.gz cr
+          sudo install -m 755 cr /usr/local/bin/cr
+          rm -f cr.tar.gz
+
+      - name: Package charts
+        run: |
+          mkdir -p .cr-release-packages/
+          helm package charts/kubescape-operator --destination .cr-release-packages/
+
+      - name: Attest chart provenance
+        if: hashFiles('.cr-release-packages/*.tgz') != ''
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: '.cr-release-packages/*.tgz'
+
+      - name: Publish chart release
+        if: hashFiles('.cr-release-packages/*.tgz') != ''
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          commit="$(git rev-parse HEAD)"
+          cr upload \
+            --owner "${owner}" \
+            --git-repo "${repo}" \
+            --token "${CR_TOKEN}" \
+            --commit "${commit}" \
+            --skip-existing
+          mkdir -p .cr-index/
+          cr index \
+            --owner "${owner}" \
+            --git-repo "${repo}" \
+            --charts-repo "https://${owner}.github.io/${repo}/" \
+            --token "${CR_TOKEN}" \
+            --push

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,3 +3,47 @@
 The Kubescape project manages this document in the central project repository.
 
 Go to the [centralized SECURITY.md](https://github.com/kubescape/project-governance/blob/main/SECURITY.md)
+
+## Artifact Provenance
+
+All Helm chart releases published from this repository include a signed provenance attestation generated using
+[GitHub Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)
+(keyless signing via GitHub OIDC + Sigstore).
+
+### Verifying a release
+
+Download the chart tarball from the [releases page](https://github.com/kubescape/helm-charts/releases),
+then verify its provenance with the [GitHub CLI](https://cli.github.com/):
+
+```bash
+gh attestation verify kubescape-operator-<version>.tgz \
+  --repo kubescape/helm-charts
+```
+
+A successful verification confirms the artifact was built by a GitHub Actions workflow
+within this repository and that the content matches what was produced at build time.
+
+> **What attestation does NOT prove:** Attestation verifies build origin and provenance only.
+> It does not guarantee that all tests passed, that the code was reviewed, or that the release
+> is free of vulnerabilities. Always review the [release notes](https://github.com/kubescape/helm-charts/releases)
+> and the relevant [security advisories](https://github.com/kubescape/helm-charts/security/advisories).
+
+### Stricter verification (specific release workflow)
+
+To additionally confirm the artifact was produced by the specific release workflow
+(not just any workflow in this repository), add `--signer-workflow`:
+
+```bash
+# For standard releases (with E2E tests):
+gh attestation verify kubescape-operator-<version>.tgz \
+  --repo kubescape/helm-charts \
+  --signer-workflow kubescape/helm-charts/.github/workflows/03-helm-release.yaml
+
+# For releases published without E2E tests:
+gh attestation verify kubescape-operator-<version>.tgz \
+  --repo kubescape/helm-charts \
+  --signer-workflow kubescape/helm-charts/.github/workflows/04-helm-release-no-tests.yaml
+```
+
+All attestations are publicly visible at
+[github.com/kubescape/helm-charts/attestations](https://github.com/kubescape/helm-charts/attestations).


### PR DESCRIPTION
Fixes #826 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chart releases now include signed provenance attestations for cryptographic verification of build origin.
  * Release publishing has improved packaging and conditional publishing so only generated artifacts are released.

* **Documentation**
  * Added security guidance for verifying chart provenance with attestations and optional stricter signer verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->