### PR TITLE
prepare new release

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.30.7
+version: 1.40.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.30.7
+appVersion: 1.40.0
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -1,6 +1,6 @@
 # Kubescape Operator
 
-![Version: 1.30.7](https://img.shields.io/badge/Version-1.30.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.30.7](https://img.shields.io/badge/AppVersion-v1.30.7-informational?style=flat-square)
+![Version: 1.40.0](https://img.shields.io/badge/Version-1.40.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.40.0](https://img.shields.io/badge/AppVersion-v1.40.0-informational?style=flat-square)
 
 [Kubescape operator documentation](https://kubescape.io/docs/install-operator/)
 

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 all capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.7.
+      Thank you for installing kubescape-operator version 1.40.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -35,8 +35,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -55,8 +55,8 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
-                helm.sh/chart: kubescape-operator-1.30.7
+                app.kubernetes.io/version: 1.40.0
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -112,8 +112,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -167,8 +167,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -192,8 +192,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -218,8 +218,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -239,8 +239,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -286,8 +286,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -314,8 +314,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -335,8 +335,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -358,8 +358,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -379,8 +379,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -397,9 +397,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -420,10 +420,10 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
                 bar: baz
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -477,8 +477,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -508,9 +508,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
+            app.kubernetes.io/version: 1.40.0
             bar: baz
-            helm.sh/chart: kubescape-operator-1.30.7
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -553,8 +553,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -588,8 +588,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -613,8 +613,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -638,8 +638,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -666,8 +666,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -686,8 +686,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -705,9 +705,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -727,9 +727,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -792,8 +792,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -855,8 +855,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1125,8 +1125,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1150,8 +1150,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1183,8 +1183,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1257,7 +1257,7 @@ all capabilities:
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v3.0.48
+              image: quay.io/kubescape/kubescape:v4.0.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -1400,8 +1400,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1419,8 +1419,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1507,8 +1507,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1538,8 +1538,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1564,8 +1564,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -1590,8 +1590,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1620,8 +1620,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1638,8 +1638,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -1671,8 +1671,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1690,9 +1690,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1712,9 +1712,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -1777,8 +1777,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -1840,8 +1840,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1890,8 +1890,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1915,8 +1915,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1945,8 +1945,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1975,7 +1975,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.134
+              image: quay.io/kubescape/kubevuln:v0.3.136
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -2109,8 +2109,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2177,8 +2177,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -2201,8 +2201,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -2227,8 +2227,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2256,8 +2256,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2643,8 +2643,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2800,8 +2800,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2868,8 +2868,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2924,8 +2924,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2952,9 +2952,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
+            app.kubernetes.io/version: 1.40.0
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.30.7
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -3027,12 +3027,12 @@ all capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.108
+                  value: v0.3.111
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.108
+              image: quay.io/kubescape/node-agent:v0.3.111
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -3250,8 +3250,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -3301,8 +3301,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -3983,8 +3983,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -4048,8 +4048,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -4074,8 +4074,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -4102,8 +4102,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -4120,8 +4120,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -4147,8 +4147,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -4199,8 +4199,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -4222,8 +4222,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -4241,8 +4241,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4375,8 +4375,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4432,8 +4432,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4451,8 +4451,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4487,8 +4487,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -4502,7 +4502,7 @@ all capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -4717,8 +4717,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4805,8 +4805,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4824,8 +4824,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5000,8 +5000,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5019,8 +5019,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5063,8 +5063,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5089,8 +5089,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -5115,8 +5115,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5144,8 +5144,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5161,8 +5161,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5189,8 +5189,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5214,8 +5214,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5240,8 +5240,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -5321,8 +5321,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5390,8 +5390,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5418,8 +5418,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5436,8 +5436,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5472,8 +5472,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -5491,8 +5491,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -5517,8 +5517,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5583,8 +5583,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -5608,8 +5608,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5646,8 +5646,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5665,8 +5665,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5691,8 +5691,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -5711,7 +5711,7 @@ all capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -5785,8 +5785,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5855,8 +5855,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -5879,8 +5879,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -5905,8 +5905,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -5931,8 +5931,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -6255,8 +6255,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -6284,8 +6284,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -6302,8 +6302,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6539,8 +6539,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6842,8 +6842,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6861,8 +6861,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6892,8 +6892,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -6905,7 +6905,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -7044,8 +7044,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7122,8 +7122,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7165,8 +7165,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7190,8 +7190,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -7215,8 +7215,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7243,8 +7243,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7252,7 +7252,7 @@ all capabilities:
 autoscaler mode with sbom sidecar:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.7.
+      Thank you for installing kubescape-operator version 1.40.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -7288,8 +7288,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -7334,8 +7334,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -7362,8 +7362,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7384,8 +7384,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7405,8 +7405,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -7425,8 +7425,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7444,9 +7444,9 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7466,9 +7466,9 @@ autoscaler mode with sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -7529,8 +7529,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7799,8 +7799,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7824,8 +7824,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7856,8 +7856,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -7899,7 +7899,7 @@ autoscaler mode with sbom sidecar:
                   value: "1500"
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v3.0.48
+              image: quay.io/kubescape/kubescape:v4.0.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -8020,8 +8020,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8039,8 +8039,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -8070,8 +8070,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -8096,8 +8096,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -8126,8 +8126,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -8145,8 +8145,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8164,9 +8164,9 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8186,9 +8186,9 @@ autoscaler mode with sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -8249,8 +8249,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8290,8 +8290,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8315,8 +8315,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8344,8 +8344,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -8368,7 +8368,7 @@ autoscaler mode with sbom sidecar:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.134
+              image: quay.io/kubescape/kubevuln:v0.3.136
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -8479,8 +8479,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8508,8 +8508,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8895,8 +8895,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -9052,8 +9052,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -9120,8 +9120,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9139,8 +9139,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -9167,8 +9167,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -9176,7 +9176,7 @@ autoscaler mode with sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.7\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.30.7\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 921a39bfca3fd64ae481a3b3b37e9c48df1332841321f999bd0cf0896ae88136\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: f8f57ee9b7c136ff44014ae152c2ee1d6437058a776ba359547a4d44896626d0\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.7\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.30.7\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      initContainers:\n      \n      - name: url-discovery\n        image: \"quay.io/kubescape/http-request:v0.2.19\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: false\n          readOnlyRootFilesystem: true\n        resources:\n          limits:\n            cpu: 100m\n            memory: 50Mi\n          requests:\n            cpu: 10m\n            memory: 10Mi\n        env:\n        args:\n          - -method=get\n          - -scheme=https\n          - -host=api.armosec.io\n          - -path=api/v3/servicediscovery\n          - -path-output=/data/services.json\n        volumeMounts:\n          - name: services\n            mountPath: /data\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      - name: \"services\"\n        emptyDir: {}\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.108\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.108\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.108\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: \"services\"\n            mountPath: /etc/config/services.json\n            readOnly: true\n            subPath: \"services.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n        node.kubernetes.io/instance-type: \"{{ .NodeGroupLabel }}\"\n      affinity:\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 921a39bfca3fd64ae481a3b3b37e9c48df1332841321f999bd0cf0896ae88136\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: f8f57ee9b7c136ff44014ae152c2ee1d6437058a776ba359547a4d44896626d0\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      initContainers:\n      \n      - name: url-discovery\n        image: \"quay.io/kubescape/http-request:v0.2.19\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: false\n          readOnlyRootFilesystem: true\n        resources:\n          limits:\n            cpu: 100m\n            memory: 50Mi\n          requests:\n            cpu: 10m\n            memory: 10Mi\n        env:\n        args:\n          - -method=get\n          - -scheme=https\n          - -host=api.armosec.io\n          - -path=api/v3/servicediscovery\n          - -path-output=/data/services.json\n        volumeMounts:\n          - name: services\n            mountPath: /data\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      - name: \"services\"\n        emptyDir: {}\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.111\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.111\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.111\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: \"services\"\n            mountPath: /etc/config/services.json\n            readOnly: true\n            subPath: \"services.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n        node.kubernetes.io/instance-type: \"{{ .NodeGroupLabel }}\"\n      affinity:\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -9187,8 +9187,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9206,8 +9206,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -9233,8 +9233,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -9285,8 +9285,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -9308,8 +9308,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -9327,8 +9327,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9452,8 +9452,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9509,8 +9509,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9528,8 +9528,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9563,8 +9563,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -9578,7 +9578,7 @@ autoscaler mode with sbom sidecar:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -9775,8 +9775,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9860,8 +9860,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9945,8 +9945,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9964,8 +9964,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -10020,8 +10020,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -10046,8 +10046,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -10075,8 +10075,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -10093,8 +10093,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -10123,8 +10123,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -10146,8 +10146,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -10165,8 +10165,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10231,8 +10231,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -10256,8 +10256,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10297,8 +10297,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10316,8 +10316,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10342,8 +10342,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -10360,7 +10360,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -10437,8 +10437,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -10461,8 +10461,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -10487,8 +10487,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -10811,8 +10811,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10840,8 +10840,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10858,8 +10858,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11026,8 +11026,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11311,8 +11311,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11330,8 +11330,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11360,8 +11360,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -11373,7 +11373,7 @@ autoscaler mode with sbom sidecar:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -11483,8 +11483,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11526,8 +11526,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11551,8 +11551,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11579,8 +11579,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11588,7 +11588,7 @@ autoscaler mode with sbom sidecar:
 autoscaler mode without sbom sidecar:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.7.
+      Thank you for installing kubescape-operator version 1.40.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -11624,8 +11624,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -11670,8 +11670,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -11698,8 +11698,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11720,8 +11720,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11741,8 +11741,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -11761,8 +11761,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11780,9 +11780,9 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11802,9 +11802,9 @@ autoscaler mode without sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11865,8 +11865,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12135,8 +12135,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12160,8 +12160,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12192,8 +12192,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -12235,7 +12235,7 @@ autoscaler mode without sbom sidecar:
                   value: "1500"
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v3.0.48
+              image: quay.io/kubescape/kubescape:v4.0.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12356,8 +12356,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12375,8 +12375,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12406,8 +12406,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12432,8 +12432,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12462,8 +12462,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12481,8 +12481,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12500,9 +12500,9 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12522,9 +12522,9 @@ autoscaler mode without sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -12585,8 +12585,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12626,8 +12626,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12651,8 +12651,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12680,8 +12680,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -12704,7 +12704,7 @@ autoscaler mode without sbom sidecar:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.134
+              image: quay.io/kubescape/kubevuln:v0.3.136
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12815,8 +12815,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12844,8 +12844,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -13231,8 +13231,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13388,8 +13388,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13456,8 +13456,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13475,8 +13475,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13503,8 +13503,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13512,7 +13512,7 @@ autoscaler mode without sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.30.7\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.30.7\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 921a39bfca3fd64ae481a3b3b37e9c48df1332841321f999bd0cf0896ae88136\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: f8f57ee9b7c136ff44014ae152c2ee1d6437058a776ba359547a4d44896626d0\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.30.7\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.30.7\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      initContainers:\n      \n      - name: url-discovery\n        image: \"quay.io/kubescape/http-request:v0.2.19\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: false\n          readOnlyRootFilesystem: true\n        resources:\n          limits:\n            cpu: 100m\n            memory: 50Mi\n          requests:\n            cpu: 10m\n            memory: 10Mi\n        env:\n        args:\n          - -method=get\n          - -scheme=https\n          - -host=api.armosec.io\n          - -path=api/v3/servicediscovery\n          - -path-output=/data/services.json\n        volumeMounts:\n          - name: services\n            mountPath: /data\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      - name: \"services\"\n        emptyDir: {}\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.108\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.108\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: \"services\"\n            mountPath: /etc/config/services.json\n            readOnly: true\n            subPath: \"services.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n        node.kubernetes.io/instance-type: \"{{ .NodeGroupLabel }}\"\n      affinity:\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.0\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.0\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 921a39bfca3fd64ae481a3b3b37e9c48df1332841321f999bd0cf0896ae88136\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: f8f57ee9b7c136ff44014ae152c2ee1d6437058a776ba359547a4d44896626d0\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.0\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.0\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      initContainers:\n      \n      - name: url-discovery\n        image: \"quay.io/kubescape/http-request:v0.2.19\"\n        imagePullPolicy: IfNotPresent\n        securityContext:\n          allowPrivilegeEscalation: false\n          readOnlyRootFilesystem: true\n        resources:\n          limits:\n            cpu: 100m\n            memory: 50Mi\n          requests:\n            cpu: 10m\n            memory: 10Mi\n        env:\n        args:\n          - -method=get\n          - -scheme=https\n          - -host=api.armosec.io\n          - -path=api/v3/servicediscovery\n          - -path-output=/data/services.json\n        volumeMounts:\n          - name: services\n            mountPath: /data\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      - name: \"services\"\n        emptyDir: {}\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.111\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.111\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: \"services\"\n            mountPath: /etc/config/services.json\n            readOnly: true\n            subPath: \"services.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n        node.kubernetes.io/instance-type: \"{{ .NodeGroupLabel }}\"\n      affinity:\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -13523,8 +13523,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13542,8 +13542,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -13569,8 +13569,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -13621,8 +13621,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -13644,8 +13644,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -13663,8 +13663,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13788,8 +13788,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13845,8 +13845,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13864,8 +13864,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13899,8 +13899,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -13914,7 +13914,7 @@ autoscaler mode without sbom sidecar:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -14111,8 +14111,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14196,8 +14196,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14281,8 +14281,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14300,8 +14300,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14356,8 +14356,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14382,8 +14382,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14411,8 +14411,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14429,8 +14429,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -14459,8 +14459,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -14482,8 +14482,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -14501,8 +14501,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14567,8 +14567,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -14592,8 +14592,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14633,8 +14633,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14652,8 +14652,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14678,8 +14678,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -14696,7 +14696,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -14773,8 +14773,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -14797,8 +14797,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -14823,8 +14823,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -15147,8 +15147,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -15176,8 +15176,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -15194,8 +15194,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15362,8 +15362,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15647,8 +15647,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15666,8 +15666,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15696,8 +15696,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15709,7 +15709,7 @@ autoscaler mode without sbom sidecar:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -15819,8 +15819,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15862,8 +15862,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15887,8 +15887,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15915,8 +15915,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15924,7 +15924,7 @@ autoscaler mode without sbom sidecar:
 backend-storage enabled disables scanning capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.7.
+      Thank you for installing kubescape-operator version 1.40.0.
 
 
 
@@ -15952,8 +15952,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -15998,8 +15998,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -16026,8 +16026,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16048,8 +16048,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16069,8 +16069,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -16456,8 +16456,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16613,8 +16613,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16681,8 +16681,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16700,8 +16700,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16727,8 +16727,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16768,12 +16768,12 @@ backend-storage enabled disables scanning capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.108
+                  value: v0.3.111
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.108
+              image: quay.io/kubescape/node-agent:v0.3.111
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16967,8 +16967,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -17021,8 +17021,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -17703,8 +17703,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -17731,8 +17731,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -17749,8 +17749,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -17776,8 +17776,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -17828,8 +17828,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -17851,8 +17851,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -17870,8 +17870,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17995,8 +17995,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18052,8 +18052,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18071,8 +18071,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18106,8 +18106,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18121,7 +18121,7 @@ backend-storage enabled disables scanning capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -18312,8 +18312,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18397,8 +18397,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18482,8 +18482,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18501,8 +18501,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18545,8 +18545,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18571,8 +18571,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18600,8 +18600,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18622,8 +18622,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -18645,8 +18645,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -18664,8 +18664,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -18988,8 +18988,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19156,8 +19156,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19423,8 +19423,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19442,8 +19442,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19472,8 +19472,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19485,7 +19485,7 @@ backend-storage enabled disables scanning capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19595,8 +19595,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19638,8 +19638,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19663,8 +19663,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19691,8 +19691,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19710,8 +19710,8 @@ cert strategy hook, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19745,8 +19745,8 @@ cert strategy hook, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19760,7 +19760,7 @@ cert strategy hook, admission disabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19876,8 +19876,8 @@ cert strategy hook, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -19902,8 +19902,8 @@ cert strategy hook, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19928,8 +19928,8 @@ cert strategy hook, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19946,7 +19946,7 @@ cert strategy hook, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -20018,8 +20018,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20053,8 +20053,8 @@ cert strategy hook, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20068,7 +20068,7 @@ cert strategy hook, admission disabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -20184,8 +20184,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -20211,8 +20211,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -20239,8 +20239,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -20266,8 +20266,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-create
@@ -20282,8 +20282,8 @@ cert strategy hook, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: storage-certgen-create
@@ -20330,8 +20330,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-patch
@@ -20346,8 +20346,8 @@ cert strategy hook, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: storage-certgen-patch
@@ -20394,8 +20394,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -20422,8 +20422,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -20450,8 +20450,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -20468,8 +20468,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20494,8 +20494,8 @@ cert strategy hook, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20512,7 +20512,7 @@ cert strategy hook, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -20590,8 +20590,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20639,8 +20639,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -20667,8 +20667,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -20694,8 +20694,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-create
@@ -20710,8 +20710,8 @@ cert strategy hook, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: kubescape-admission-webhook-create
@@ -20758,8 +20758,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-patch
@@ -20774,8 +20774,8 @@ cert strategy hook, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: kubescape-admission-webhook-patch
@@ -20821,8 +20821,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20849,8 +20849,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20877,8 +20877,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20895,8 +20895,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20930,8 +20930,8 @@ cert strategy hook, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20945,7 +20945,7 @@ cert strategy hook, admission enabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -21070,8 +21070,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -21096,8 +21096,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21122,8 +21122,8 @@ cert strategy hook, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21140,7 +21140,7 @@ cert strategy hook, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21212,8 +21212,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21261,8 +21261,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -21289,8 +21289,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -21316,8 +21316,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-create
@@ -21332,8 +21332,8 @@ cert strategy hook, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: kubescape-admission-webhook-create
@@ -21380,8 +21380,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-patch
@@ -21396,8 +21396,8 @@ cert strategy hook, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: kubescape-admission-webhook-patch
@@ -21443,8 +21443,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21471,8 +21471,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21499,8 +21499,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21517,8 +21517,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21552,8 +21552,8 @@ cert strategy hook, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21567,7 +21567,7 @@ cert strategy hook, admission enabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -21692,8 +21692,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -21719,8 +21719,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -21747,8 +21747,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -21774,8 +21774,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-create
@@ -21790,8 +21790,8 @@ cert strategy hook, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: storage-certgen-create
@@ -21838,8 +21838,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-patch
@@ -21854,8 +21854,8 @@ cert strategy hook, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: storage-certgen-patch
@@ -21902,8 +21902,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -21930,8 +21930,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -21958,8 +21958,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -21976,8 +21976,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22002,8 +22002,8 @@ cert strategy hook, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22020,7 +22020,7 @@ cert strategy hook, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22098,8 +22098,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22133,8 +22133,8 @@ cert strategy template, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22148,7 +22148,7 @@ cert strategy template, admission disabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -22264,8 +22264,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -22290,8 +22290,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22316,8 +22316,8 @@ cert strategy template, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22334,7 +22334,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22406,8 +22406,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22441,8 +22441,8 @@ cert strategy template, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22456,7 +22456,7 @@ cert strategy template, admission disabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -22572,8 +22572,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -22602,8 +22602,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -22625,8 +22625,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -22644,8 +22644,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22670,8 +22670,8 @@ cert strategy template, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22688,7 +22688,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22766,8 +22766,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22818,8 +22818,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -22841,8 +22841,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -22860,8 +22860,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22895,8 +22895,8 @@ cert strategy template, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22910,7 +22910,7 @@ cert strategy template, admission enabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -23035,8 +23035,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -23061,8 +23061,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23087,8 +23087,8 @@ cert strategy template, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23105,7 +23105,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23177,8 +23177,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -23229,8 +23229,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -23252,8 +23252,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -23271,8 +23271,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23306,8 +23306,8 @@ cert strategy template, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23321,7 +23321,7 @@ cert strategy template, admission enabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -23446,8 +23446,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -23476,8 +23476,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -23499,8 +23499,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -23518,8 +23518,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23544,8 +23544,8 @@ cert strategy template, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23562,7 +23562,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23630,7 +23630,7 @@ cert strategy template, admission enabled, mtls enabled:
 default capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.7.
+      Thank you for installing kubescape-operator version 1.40.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -23666,8 +23666,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -23713,8 +23713,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -23741,8 +23741,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23763,8 +23763,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23784,8 +23784,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -23802,8 +23802,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23832,8 +23832,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23873,8 +23873,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23908,8 +23908,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23938,8 +23938,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23957,9 +23957,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23979,9 +23979,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -24041,8 +24041,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -24098,8 +24098,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24368,8 +24368,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24393,8 +24393,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24426,8 +24426,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24469,7 +24469,7 @@ default capabilities:
                   value: "1500"
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v3.0.48
+              image: quay.io/kubescape/kubescape:v4.0.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24608,8 +24608,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24627,8 +24627,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24704,8 +24704,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24735,8 +24735,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24761,8 +24761,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24791,8 +24791,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24809,8 +24809,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -24842,8 +24842,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24861,9 +24861,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24883,9 +24883,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -24945,8 +24945,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -25002,8 +25002,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -25043,8 +25043,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -25068,8 +25068,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25098,8 +25098,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -25122,7 +25122,7 @@ default capabilities:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.134
+              image: quay.io/kubescape/kubevuln:v0.3.136
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -25251,8 +25251,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -25313,8 +25313,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -25342,8 +25342,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -25729,8 +25729,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25886,8 +25886,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25954,8 +25954,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25973,8 +25973,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26001,8 +26001,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -26042,12 +26042,12 @@ default capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.108
+                  value: v0.3.111
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.108
+              image: quay.io/kubescape/node-agent:v0.3.111
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -26262,8 +26262,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -26319,8 +26319,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -27001,8 +27001,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -27055,8 +27055,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -27083,8 +27083,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -27101,8 +27101,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27226,8 +27226,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27283,8 +27283,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27302,8 +27302,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27338,8 +27338,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -27353,7 +27353,7 @@ default capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -27550,8 +27550,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27635,8 +27635,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27654,8 +27654,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27813,8 +27813,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27832,8 +27832,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27876,8 +27876,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27902,8 +27902,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27931,8 +27931,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27954,8 +27954,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -27973,8 +27973,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -28003,8 +28003,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -28026,8 +28026,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -28045,8 +28045,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28111,8 +28111,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -28136,8 +28136,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28177,8 +28177,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28196,8 +28196,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28222,8 +28222,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -28240,7 +28240,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -28317,8 +28317,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28379,8 +28379,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -28403,8 +28403,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -28429,8 +28429,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -28753,8 +28753,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28782,8 +28782,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28800,8 +28800,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -28968,8 +28968,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29253,8 +29253,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29272,8 +29272,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29303,8 +29303,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -29316,7 +29316,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -29445,8 +29445,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29512,8 +29512,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29555,8 +29555,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29580,8 +29580,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29608,8 +29608,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29617,7 +29617,7 @@ default capabilities:
 disable otel:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.7.
+      Thank you for installing kubescape-operator version 1.40.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -29653,8 +29653,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -29699,8 +29699,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -29727,8 +29727,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29749,8 +29749,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29770,8 +29770,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -29790,8 +29790,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29809,9 +29809,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29831,9 +29831,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -29894,8 +29894,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30164,8 +30164,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30189,8 +30189,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30221,8 +30221,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -30264,7 +30264,7 @@ disable otel:
                   value: "1500"
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v3.0.48
+              image: quay.io/kubescape/kubescape:v4.0.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -30385,8 +30385,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30404,8 +30404,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30435,8 +30435,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30461,8 +30461,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30491,8 +30491,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30510,8 +30510,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30529,9 +30529,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30551,9 +30551,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -30614,8 +30614,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30655,8 +30655,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30680,8 +30680,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30709,8 +30709,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -30733,7 +30733,7 @@ disable otel:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.134
+              image: quay.io/kubescape/kubevuln:v0.3.136
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -30844,8 +30844,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30873,8 +30873,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -31260,8 +31260,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31417,8 +31417,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31485,8 +31485,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31504,8 +31504,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31531,8 +31531,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -31572,12 +31572,12 @@ disable otel:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.108
+                  value: v0.3.111
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.108
+              image: quay.io/kubescape/node-agent:v0.3.111
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -31771,8 +31771,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31799,8 +31799,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31817,8 +31817,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -31844,8 +31844,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -31896,8 +31896,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -31919,8 +31919,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -31938,8 +31938,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32063,8 +32063,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32120,8 +32120,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32139,8 +32139,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32174,8 +32174,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -32189,7 +32189,7 @@ disable otel:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -32380,8 +32380,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32465,8 +32465,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32550,8 +32550,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32569,8 +32569,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32613,8 +32613,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32639,8 +32639,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32668,8 +32668,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32686,8 +32686,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -32716,8 +32716,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -32739,8 +32739,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -32758,8 +32758,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -32824,8 +32824,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -32849,8 +32849,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -32890,8 +32890,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32909,8 +32909,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32935,8 +32935,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -32953,7 +32953,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -33030,8 +33030,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -33054,8 +33054,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -33080,8 +33080,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -33404,8 +33404,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -33433,8 +33433,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -33451,8 +33451,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33619,8 +33619,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33904,8 +33904,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33923,8 +33923,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33953,8 +33953,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -33966,7 +33966,7 @@ disable otel:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -34076,8 +34076,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -34119,8 +34119,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -34144,8 +34144,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -34172,8 +34172,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -34181,7 +34181,7 @@ disable otel:
 minimal capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.7.
+      Thank you for installing kubescape-operator version 1.40.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -34217,8 +34217,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -34263,8 +34263,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -34291,8 +34291,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34313,8 +34313,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34334,8 +34334,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -34354,8 +34354,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34373,9 +34373,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34395,9 +34395,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -34458,8 +34458,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34728,8 +34728,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34753,8 +34753,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34785,8 +34785,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -34828,7 +34828,7 @@ minimal capabilities:
                   value: "1500"
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/kubescape:v3.0.48
+              image: quay.io/kubescape/kubescape:v4.0.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -34918,8 +34918,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34937,8 +34937,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34968,8 +34968,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34994,8 +34994,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -35024,8 +35024,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -35043,8 +35043,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35062,9 +35062,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35084,9 +35084,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -35147,8 +35147,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -35188,8 +35188,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -35213,8 +35213,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35242,8 +35242,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -35268,7 +35268,7 @@ minimal capabilities:
                   value: "1"
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/kubevuln:v0.3.134
+              image: quay.io/kubescape/kubevuln:v0.3.136
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -35348,8 +35348,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -35377,8 +35377,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -35764,8 +35764,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -35921,8 +35921,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -35987,8 +35987,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36006,8 +36006,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36033,8 +36033,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -36076,12 +36076,12 @@ minimal capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.108
+                  value: v0.3.111
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.108
+              image: quay.io/kubescape/node-agent:v0.3.111
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -36245,8 +36245,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -36273,8 +36273,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -36291,8 +36291,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -36318,8 +36318,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -36370,8 +36370,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -36393,8 +36393,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -36412,8 +36412,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -36537,8 +36537,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -36593,8 +36593,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36612,8 +36612,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36647,8 +36647,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -36662,7 +36662,7 @@ minimal capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -36855,8 +36855,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36940,8 +36940,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37025,8 +37025,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37044,8 +37044,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37088,8 +37088,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37114,8 +37114,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37143,8 +37143,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37161,8 +37161,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -37191,8 +37191,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -37214,8 +37214,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -37233,8 +37233,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -37299,8 +37299,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -37324,8 +37324,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -37365,8 +37365,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37384,8 +37384,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37410,8 +37410,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -37430,7 +37430,7 @@ minimal capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -37507,8 +37507,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -37531,8 +37531,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -37557,8 +37557,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -37881,8 +37881,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -37910,8 +37910,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -37919,7 +37919,7 @@ minimal capabilities:
 multiple node agents:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.7.
+      Thank you for installing kubescape-operator version 1.40.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -37953,8 +37953,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -37973,8 +37973,8 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
-                helm.sh/chart: kubescape-operator-1.30.7
+                app.kubernetes.io/version: 1.40.0
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -38030,8 +38030,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -38085,8 +38085,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -38110,8 +38110,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -38136,8 +38136,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -38157,8 +38157,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -38204,8 +38204,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -38232,8 +38232,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38253,8 +38253,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -38276,8 +38276,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38297,8 +38297,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -38315,9 +38315,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38338,10 +38338,10 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
                 bar: baz
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -38395,8 +38395,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38426,9 +38426,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
+            app.kubernetes.io/version: 1.40.0
             bar: baz
-            helm.sh/chart: kubescape-operator-1.30.7
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -38471,8 +38471,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -38506,8 +38506,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -38531,8 +38531,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -38556,8 +38556,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -38584,8 +38584,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -38604,8 +38604,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38623,9 +38623,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38645,9 +38645,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -38710,8 +38710,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -38773,8 +38773,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -39043,8 +39043,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -39068,8 +39068,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39101,8 +39101,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -39175,7 +39175,7 @@ multiple node agents:
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v3.0.48
+              image: quay.io/kubescape/kubescape:v4.0.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -39318,8 +39318,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39337,8 +39337,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -39425,8 +39425,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -39456,8 +39456,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -39482,8 +39482,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -39508,8 +39508,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -39538,8 +39538,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -39556,8 +39556,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -39589,8 +39589,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39608,9 +39608,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39630,9 +39630,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -39695,8 +39695,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -39758,8 +39758,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -39808,8 +39808,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -39833,8 +39833,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39863,8 +39863,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -39893,7 +39893,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.134
+              image: quay.io/kubescape/kubevuln:v0.3.136
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -40027,8 +40027,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -40095,8 +40095,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -40119,8 +40119,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -40145,8 +40145,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -40174,8 +40174,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -40561,8 +40561,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -40718,8 +40718,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -40786,8 +40786,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40842,8 +40842,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40870,9 +40870,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
+            app.kubernetes.io/version: 1.40.0
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.30.7
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -40945,12 +40945,12 @@ multiple node agents:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.108
+                  value: v0.3.111
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.108
+              image: quay.io/kubescape/node-agent:v0.3.111
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -41169,8 +41169,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -41197,9 +41197,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
+            app.kubernetes.io/version: 1.40.0
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.30.7
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -41272,12 +41272,12 @@ multiple node agents:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.108
+                  value: v0.3.111
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.108
+              image: quay.io/kubescape/node-agent:v0.3.111
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -41496,8 +41496,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -41547,8 +41547,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -42229,8 +42229,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -42294,8 +42294,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -42320,8 +42320,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -42348,8 +42348,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -42366,8 +42366,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -42393,8 +42393,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -42445,8 +42445,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -42468,8 +42468,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -42487,8 +42487,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42621,8 +42621,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42678,8 +42678,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42697,8 +42697,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42733,8 +42733,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -42748,7 +42748,7 @@ multiple node agents:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -42963,8 +42963,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43051,8 +43051,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43070,8 +43070,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -43246,8 +43246,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43265,8 +43265,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -43309,8 +43309,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -43335,8 +43335,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -43361,8 +43361,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -43390,8 +43390,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -43407,8 +43407,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -43435,8 +43435,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -43460,8 +43460,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -43486,8 +43486,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -43567,8 +43567,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -43636,8 +43636,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -43664,8 +43664,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -43682,8 +43682,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -43718,8 +43718,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -43737,8 +43737,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -43763,8 +43763,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -43829,8 +43829,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -43854,8 +43854,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -43892,8 +43892,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43911,8 +43911,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43937,8 +43937,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -43957,7 +43957,7 @@ multiple node agents:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -44031,8 +44031,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -44101,8 +44101,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -44125,8 +44125,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -44151,8 +44151,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -44177,8 +44177,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -44501,8 +44501,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -44530,8 +44530,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -44548,8 +44548,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44785,8 +44785,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -45088,8 +45088,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45107,8 +45107,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45138,8 +45138,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -45151,7 +45151,7 @@ multiple node agents:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -45290,8 +45290,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -45368,8 +45368,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -45411,8 +45411,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -45436,8 +45436,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -45461,8 +45461,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -45489,8 +45489,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -45498,7 +45498,7 @@ multiple node agents:
 priority class scheduling:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.7.
+      Thank you for installing kubescape-operator version 1.40.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -45534,8 +45534,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -45580,8 +45580,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -45608,8 +45608,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45630,8 +45630,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45651,8 +45651,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -45671,8 +45671,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45690,9 +45690,9 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45712,9 +45712,9 @@ priority class scheduling:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -45776,8 +45776,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -46046,8 +46046,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -46071,8 +46071,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46103,8 +46103,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -46146,7 +46146,7 @@ priority class scheduling:
                   value: "1500"
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v3.0.48
+              image: quay.io/kubescape/kubescape:v4.0.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -46268,8 +46268,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46287,8 +46287,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -46318,8 +46318,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -46344,8 +46344,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -46374,8 +46374,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -46393,8 +46393,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46412,9 +46412,9 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46434,9 +46434,9 @@ priority class scheduling:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -46498,8 +46498,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -46539,8 +46539,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -46564,8 +46564,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46593,8 +46593,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -46617,7 +46617,7 @@ priority class scheduling:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.134
+              image: quay.io/kubescape/kubevuln:v0.3.136
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -46729,8 +46729,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -46758,8 +46758,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -47145,8 +47145,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -47302,8 +47302,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -47370,8 +47370,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47389,8 +47389,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47416,8 +47416,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -47457,12 +47457,12 @@ priority class scheduling:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.108
+                  value: v0.3.111
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.108
+              image: quay.io/kubescape/node-agent:v0.3.111
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -47656,8 +47656,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -47684,8 +47684,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -47702,8 +47702,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -47729,8 +47729,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -47781,8 +47781,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -47804,8 +47804,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -47823,8 +47823,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47948,8 +47948,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -48005,8 +48005,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48024,8 +48024,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48059,8 +48059,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -48074,7 +48074,7 @@ priority class scheduling:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -48266,8 +48266,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48351,8 +48351,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48436,8 +48436,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48455,8 +48455,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -48499,8 +48499,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -48525,8 +48525,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -48554,8 +48554,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -48572,8 +48572,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -48602,8 +48602,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -48625,8 +48625,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -48644,8 +48644,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -48710,8 +48710,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -48735,8 +48735,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -48776,8 +48776,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48795,8 +48795,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48821,8 +48821,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -48839,7 +48839,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -48917,8 +48917,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -48941,8 +48941,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -48967,8 +48967,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -49291,8 +49291,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -49320,8 +49320,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -49338,8 +49338,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -49506,8 +49506,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -49791,8 +49791,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49810,8 +49810,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49840,8 +49840,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -49853,7 +49853,7 @@ priority class scheduling:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -49964,8 +49964,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50007,8 +50007,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50032,8 +50032,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50060,8 +50060,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50069,7 +50069,7 @@ priority class scheduling:
 relevancy only:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.7.
+      Thank you for installing kubescape-operator version 1.40.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -50104,8 +50104,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -50150,8 +50150,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -50178,8 +50178,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50200,8 +50200,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50221,8 +50221,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -50241,8 +50241,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50260,9 +50260,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50282,9 +50282,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -50345,8 +50345,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50615,8 +50615,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50640,8 +50640,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50672,8 +50672,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -50715,7 +50715,7 @@ relevancy only:
                   value: "1500"
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/kubescape:v3.0.48
+              image: quay.io/kubescape/kubescape:v4.0.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -50805,8 +50805,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50824,8 +50824,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50855,8 +50855,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50881,8 +50881,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50911,8 +50911,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50930,8 +50930,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50949,9 +50949,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50971,9 +50971,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -51034,8 +51034,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -51075,8 +51075,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -51100,8 +51100,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51129,8 +51129,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -51155,7 +51155,7 @@ relevancy only:
                   value: "1"
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/kubevuln:v0.3.134
+              image: quay.io/kubescape/kubevuln:v0.3.136
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -51235,8 +51235,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -51264,8 +51264,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -51651,8 +51651,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -51808,8 +51808,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -51874,8 +51874,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51893,8 +51893,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51920,8 +51920,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -51963,12 +51963,12 @@ relevancy only:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.108
+                  value: v0.3.111
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.108
+              image: quay.io/kubescape/node-agent:v0.3.111
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -52132,8 +52132,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -52160,8 +52160,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -52178,8 +52178,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52303,8 +52303,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52359,8 +52359,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52378,8 +52378,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52413,8 +52413,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -52428,7 +52428,7 @@ relevancy only:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -52612,8 +52612,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52697,8 +52697,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52782,8 +52782,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52801,8 +52801,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52845,8 +52845,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52871,8 +52871,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52900,8 +52900,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52918,8 +52918,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -52948,8 +52948,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -52971,8 +52971,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -52990,8 +52990,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -53056,8 +53056,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -53081,8 +53081,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -53122,8 +53122,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53141,8 +53141,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53167,8 +53167,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -53187,7 +53187,7 @@ relevancy only:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -53264,8 +53264,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -53288,8 +53288,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -53314,8 +53314,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -53638,8 +53638,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -53667,8 +53667,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -53676,7 +53676,7 @@ relevancy only:
 skipPersistence enabled:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.30.7.
+      Thank you for installing kubescape-operator version 1.40.0.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -53710,8 +53710,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -53730,8 +53730,8 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
-                helm.sh/chart: kubescape-operator-1.30.7
+                app.kubernetes.io/version: 1.40.0
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -53787,8 +53787,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -53842,8 +53842,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -53867,8 +53867,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -53893,8 +53893,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -53914,8 +53914,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -53961,8 +53961,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -53989,8 +53989,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54010,8 +54010,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -54033,8 +54033,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54054,8 +54054,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -54072,9 +54072,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54095,10 +54095,10 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
                 bar: baz
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -54152,8 +54152,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54183,9 +54183,9 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
+            app.kubernetes.io/version: 1.40.0
             bar: baz
-            helm.sh/chart: kubescape-operator-1.30.7
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -54228,8 +54228,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -54263,8 +54263,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -54288,8 +54288,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -54313,8 +54313,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -54341,8 +54341,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -54361,8 +54361,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54380,9 +54380,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54402,9 +54402,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -54467,8 +54467,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -54530,8 +54530,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54800,8 +54800,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54825,8 +54825,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54858,8 +54858,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -54932,7 +54932,7 @@ skipPersistence enabled:
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v3.0.48
+              image: quay.io/kubescape/kubescape:v4.0.6
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -55075,8 +55075,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55094,8 +55094,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -55182,8 +55182,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -55213,8 +55213,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -55239,8 +55239,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -55265,8 +55265,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -55295,8 +55295,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -55313,8 +55313,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -55349,8 +55349,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55368,9 +55368,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
+        app.kubernetes.io/version: 1.40.0
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.30.7
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55390,9 +55390,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.30.7
+                app.kubernetes.io/version: 1.40.0
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.30.7
+                helm.sh/chart: kubescape-operator-1.40.0
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -55455,8 +55455,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -55518,8 +55518,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -55568,8 +55568,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -55593,8 +55593,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55623,8 +55623,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -55653,7 +55653,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.134
+              image: quay.io/kubescape/kubevuln:v0.3.136
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -55787,8 +55787,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -55855,8 +55855,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -55879,8 +55879,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -55905,8 +55905,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -55934,8 +55934,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -56321,8 +56321,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -56478,8 +56478,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -56546,8 +56546,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -56602,8 +56602,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -56630,9 +56630,9 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
+            app.kubernetes.io/version: 1.40.0
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.30.7
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -56705,12 +56705,12 @@ skipPersistence enabled:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.108
+                  value: v0.3.111
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.108
+              image: quay.io/kubescape/node-agent:v0.3.111
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -56928,8 +56928,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -56979,8 +56979,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -57661,8 +57661,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -57726,8 +57726,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -57752,8 +57752,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -57780,8 +57780,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -57798,8 +57798,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -57825,8 +57825,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -57877,8 +57877,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -57900,8 +57900,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -57919,8 +57919,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58053,8 +58053,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58110,8 +58110,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58129,8 +58129,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58165,8 +58165,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -58180,7 +58180,7 @@ skipPersistence enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -58395,8 +58395,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58483,8 +58483,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58502,8 +58502,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58678,8 +58678,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58697,8 +58697,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58741,8 +58741,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58767,8 +58767,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -58793,8 +58793,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58822,8 +58822,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58839,8 +58839,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58867,8 +58867,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58892,8 +58892,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58918,8 +58918,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -58999,8 +58999,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59068,8 +59068,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59096,8 +59096,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59114,8 +59114,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59150,8 +59150,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -59169,8 +59169,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -59195,8 +59195,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -59261,8 +59261,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -59286,8 +59286,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -59324,8 +59324,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -59343,8 +59343,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -59369,8 +59369,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -59389,7 +59389,7 @@ skipPersistence enabled:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/storage:v0.0.272
+              image: quay.io/kubescape/storage:v0.0.274
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -59463,8 +59463,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -59533,8 +59533,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -59557,8 +59557,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -59583,8 +59583,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -59609,8 +59609,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -59933,8 +59933,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -59962,8 +59962,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -59980,8 +59980,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -60217,8 +60217,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -60520,8 +60520,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -60539,8 +60539,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -60570,8 +60570,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.30.7
-            helm.sh/chart: kubescape-operator-1.30.7
+            app.kubernetes.io/version: 1.40.0
+            helm.sh/chart: kubescape-operator-1.40.0
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -60583,7 +60583,7 @@ skipPersistence enabled:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.30.7
+                  value: kubescape-operator-1.40.0
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -60722,8 +60722,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -60800,8 +60800,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -60843,8 +60843,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -60868,8 +60868,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -60893,8 +60893,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -60921,8 +60921,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -60950,8 +60950,8 @@ with multiple private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets
@@ -60988,8 +60988,8 @@ with single private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.30.7
-        helm.sh/chart: kubescape-operator-1.30.7
+        app.kubernetes.io/version: 1.40.0
+        helm.sh/chart: kubescape-operator-1.40.0
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -275,7 +275,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v3.0.48
+    tag: v4.0.6
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -426,7 +426,7 @@ kubevuln:
   image:
     # -- source code: https://github.com/kubescape/kubevuln
     repository: quay.io/kubescape/kubevuln
-    tag: v0.3.134
+    tag: v0.3.136
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -529,7 +529,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: quay.io/kubescape/storage
-    tag: v0.0.272
+    tag: v0.0.274
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -598,7 +598,7 @@ nodeAgent:
   image:
     # -- source code: https://github.com/kubescape/node-agent
     repository: quay.io/kubescape/node-agent
-    tag: v0.3.108
+    tag: v0.3.111
     pullPolicy: IfNotPresent
 
   config:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released Kubescape operator Helm chart version 1.40.0
  * Updated container image versions for kubescape, kubevuln, storage, and node-agent components to latest versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->