### PR TITLE
fix: make grype-offline-db CronJob history limits configurable via values.yaml

### DIFF
--- a/charts/kubescape-operator/templates/grype-offline-db/cronjob.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/cronjob.yaml
@@ -15,8 +15,8 @@ metadata:
     kubescape.io/tier: "core"
 spec:
   schedule: "5 0 * * *"
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: {{ .Values.grypeOfflineDB.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.grypeOfflineDB.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -959,6 +959,9 @@ grypeOfflineDB:
 
   name: grype-offline-db
 
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+
   image:
     repository: quay.io/kubescape/grype-offline-db
     tag: "" # use v6-latest for weekly updates, it will overwrite the sha if specified


### PR DESCRIPTION
```
## Overview
The `grype-offline-db` CronJob hardcoded `successfulJobsHistoryLimit: 3` and `failedJobsHistoryLimit: 1` directly in the template, unlike every other CronJob in the chart which reads these values from `values.yaml`. This fix adds both fields to the `grypeOfflineDB` section in `values.yaml` and references them in the template, making them configurable via `--set` or values overrides.

## How to Test
1. Override the values during install:
   ```
   helm install kubescape kubescape/kubescape-operator --set grypeOfflineDB.enabled=true --set grypeOfflineDB.successfulJobsHistoryLimit=5 --set grypeOfflineDB.failedJobsHistoryLimit=2
   ```
2. Verify the CronJob reflects the overridden values:
   ```
   kubectl get cronjob grype-offline-db -o yaml | grep HistoryLimit
   ```

## Related issues/PRs
* Resolved #836

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grype Offline Database job history retention limits are now configurable through Helm values, allowing customization of successful and failed job history counts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/helm-charts/pull/837)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->