### PR TITLE
fix: make grype-offline-db CronJob schedule configurable via values.yaml

### DIFF
--- a/charts/kubescape-operator/templates/grype-offline-db/cronjob.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/cronjob.yaml
@@ -14,7 +14,7 @@ metadata:
     armo.tier: "vuln-scan"
     kubescape.io/tier: "core"
 spec:
-  schedule: "5 0 * * *"
+  schedule: {{ .Values.grypeOfflineDB.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.grypeOfflineDB.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.grypeOfflineDB.failedJobsHistoryLimit }}
   jobTemplate:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -961,6 +961,8 @@ grypeOfflineDB:
 
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
+  # -- Cron schedule for the grype-offline-db rollout CronJob
+  schedule: "5 0 * * *"
 
   image:
     repository: quay.io/kubescape/grype-offline-db


### PR DESCRIPTION
## Overview
The `grype-offline-db` CronJob had its schedule hardcoded as `"5 0 * * *"` directly in the template, unlike every other CronJob in the chart which reads its schedule from `values.yaml`. This meant users could not override it via `--set` or a custom values file.

This fix adds `schedule: "5 0 * * *"` to the `grypeOfflineDB` section in `values.yaml` and replaces the hardcoded value in the template with `{{ .Values.grypeOfflineDB.schedule | quote }}`, consistent with `helmReleaseUpgrader` and all other schedulers.

## How to Test
Render with default values and confirm schedule is `5 0 * * *`:

helm template kubescape charts/kubescape-operator/ \
  --set grypeOfflineDB.enabled=true \
  --set grypeOfflineDB.image.tag=latest \
  | grep -A5 "grype-offline-db/cronjob" | grep schedule

Override and confirm it is respected:

helm template kubescape charts/kubescape-operator/ \
  --set grypeOfflineDB.enabled=true \
  --set grypeOfflineDB.image.tag=latest \
  --set grypeOfflineDB.schedule="0 3 * * *" \
  | grep schedule

Snapshot tests: 23/23 passed, 974/974 snapshots passing.

## Related issues/PRs
* Resolves #838

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes