### PR TITLE
fix: add liveness and readiness probes to grype-offline-db deployment

### DIFF
--- a/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
@@ -54,6 +54,16 @@ spec:
           ports:
           - containerPort: 8080
             protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
           resources:
 {{ toYaml .Values.grypeOfflineDB.resources | indent 12 }}
       nodeSelector:

--- a/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
@@ -55,12 +55,14 @@ spec:
           - containerPort: 8080
             protocol: TCP
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /databases
               port: 8080
             initialDelaySeconds: 3
             periodSeconds: 3
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /databases
               port: 8080
             initialDelaySeconds: 3
             periodSeconds: 3

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -519,19 +519,21 @@ all capabilities:
             - image: quay.io/kubescape/grype-offline-db:latest
               imagePullPolicy: Always
               livenessProbe:
+                httpGet:
+                  path: /databases
+                  port: 8080
                 initialDelaySeconds: 3
                 periodSeconds: 3
-                tcpSocket:
-                  port: 8080
               name: grype-offline-db
               ports:
                 - containerPort: 8080
                   protocol: TCP
               readinessProbe:
+                httpGet:
+                  path: /databases
+                  port: 8080
                 initialDelaySeconds: 3
                 periodSeconds: 3
-                tcpSocket:
-                  port: 8080
               resources:
                 limits:
                   cpu: 150m
@@ -23483,19 +23485,21 @@ default capabilities:
             - image: quay.io/kubescape/grype-offline-db@sha256:56468cbe92622770860f5c2f96b43aca836f6466c1c95116a107d461f8de8592
               imagePullPolicy: Always
               livenessProbe:
+                httpGet:
+                  path: /databases
+                  port: 8080
                 initialDelaySeconds: 3
                 periodSeconds: 3
-                tcpSocket:
-                  port: 8080
               name: grype-offline-db
               ports:
                 - containerPort: 8080
                   protocol: TCP
               readinessProbe:
+                httpGet:
+                  path: /databases
+                  port: 8080
                 initialDelaySeconds: 3
                 periodSeconds: 3
-                tcpSocket:
-                  port: 8080
               resources:
                 limits:
                   cpu: 150m
@@ -37865,19 +37869,21 @@ multiple node agents:
             - image: quay.io/kubescape/grype-offline-db:latest
               imagePullPolicy: Always
               livenessProbe:
+                httpGet:
+                  path: /databases
+                  port: 8080
                 initialDelaySeconds: 3
                 periodSeconds: 3
-                tcpSocket:
-                  port: 8080
               name: grype-offline-db
               ports:
                 - containerPort: 8080
                   protocol: TCP
               readinessProbe:
+                httpGet:
+                  path: /databases
+                  port: 8080
                 initialDelaySeconds: 3
                 periodSeconds: 3
-                tcpSocket:
-                  port: 8080
               resources:
                 limits:
                   cpu: 150m
@@ -53340,19 +53346,21 @@ skipPersistence enabled:
             - image: quay.io/kubescape/grype-offline-db:latest
               imagePullPolicy: Always
               livenessProbe:
+                httpGet:
+                  path: /databases
+                  port: 8080
                 initialDelaySeconds: 3
                 periodSeconds: 3
-                tcpSocket:
-                  port: 8080
               name: grype-offline-db
               ports:
                 - containerPort: 8080
                   protocol: TCP
               readinessProbe:
+                httpGet:
+                  path: /databases
+                  port: 8080
                 initialDelaySeconds: 3
                 periodSeconds: 3
-                tcpSocket:
-                  port: 8080
               resources:
                 limits:
                   cpu: 150m

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -518,10 +518,20 @@ all capabilities:
           containers:
             - image: quay.io/kubescape/grype-offline-db:latest
               imagePullPolicy: Always
+              livenessProbe:
+                initialDelaySeconds: 3
+                periodSeconds: 3
+                tcpSocket:
+                  port: 8080
               name: grype-offline-db
               ports:
                 - containerPort: 8080
                   protocol: TCP
+              readinessProbe:
+                initialDelaySeconds: 3
+                periodSeconds: 3
+                tcpSocket:
+                  port: 8080
               resources:
                 limits:
                   cpu: 150m
@@ -23472,10 +23482,20 @@ default capabilities:
           containers:
             - image: quay.io/kubescape/grype-offline-db@sha256:56468cbe92622770860f5c2f96b43aca836f6466c1c95116a107d461f8de8592
               imagePullPolicy: Always
+              livenessProbe:
+                initialDelaySeconds: 3
+                periodSeconds: 3
+                tcpSocket:
+                  port: 8080
               name: grype-offline-db
               ports:
                 - containerPort: 8080
                   protocol: TCP
+              readinessProbe:
+                initialDelaySeconds: 3
+                periodSeconds: 3
+                tcpSocket:
+                  port: 8080
               resources:
                 limits:
                   cpu: 150m
@@ -37844,10 +37864,20 @@ multiple node agents:
           containers:
             - image: quay.io/kubescape/grype-offline-db:latest
               imagePullPolicy: Always
+              livenessProbe:
+                initialDelaySeconds: 3
+                periodSeconds: 3
+                tcpSocket:
+                  port: 8080
               name: grype-offline-db
               ports:
                 - containerPort: 8080
                   protocol: TCP
+              readinessProbe:
+                initialDelaySeconds: 3
+                periodSeconds: 3
+                tcpSocket:
+                  port: 8080
               resources:
                 limits:
                   cpu: 150m
@@ -53309,10 +53339,20 @@ skipPersistence enabled:
           containers:
             - image: quay.io/kubescape/grype-offline-db:latest
               imagePullPolicy: Always
+              livenessProbe:
+                initialDelaySeconds: 3
+                periodSeconds: 3
+                tcpSocket:
+                  port: 8080
               name: grype-offline-db
               ports:
                 - containerPort: 8080
                   protocol: TCP
+              readinessProbe:
+                initialDelaySeconds: 3
+                periodSeconds: 3
+                tcpSocket:
+                  port: 8080
               resources:
                 limits:
                   cpu: 150m


### PR DESCRIPTION
## Overview
The `grype-offline-db` deployment was missing both `livenessProbe` and `readinessProbe`, while every other deployment in the chart defines them. Since `grype-offline-db` runs an HTTP file server on port 8080 that `kubevuln` depends on for vulnerability database fetches, a crashed or hung server process goes undetected — Kubernetes keeps the pod as Running and kubevuln silently fails to fetch the DB, producing incomplete scan results.

Added `livenessProbe` and `readinessProbe` using `tcpSocket` on port 8080, consistent with the `prometheus-exporter` component which uses the same probe type.

## How to Test
```bash
helm template charts/kubescape-operator/ \
  --set clusterName=test \
  --set grypeOfflineDB.enabled=true \
  | grep -A10 "livenessProbe\|readinessProbe"
```

Snapshot tests:
```bash
docker run --rm -v "$(pwd)":/apps helmunittest/helm-unittest charts/kubescape-operator/
```
Expect 23/23 tests, 974/974 snapshots passing.

## Related issues/PRs
Closes #840

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment stability with health monitoring probes that enable faster detection and automatic recovery of container failures for enhanced service reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/helm-charts/pull/841)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->