### PR TITLE
prepare release 1.40.2

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -9,14 +9,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.40.1
+version: 1.40.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.40.1
+appVersion: 1.40.2
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -1,6 +1,6 @@
 # Kubescape Operator
 
-![Version: 1.40.1](https://img.shields.io/badge/Version-1.40.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.40.1](https://img.shields.io/badge/AppVersion-v1.40.1-informational?style=flat-square)
+![Version: 1.40.2](https://img.shields.io/badge/Version-1.40.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.40.2](https://img.shields.io/badge/AppVersion-v1.40.2-informational?style=flat-square)
 
 [Kubescape operator documentation](https://kubescape.io/docs/install-operator/)
 

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 all capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.1.
+      Thank you for installing kubescape-operator version 1.40.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -35,8 +35,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -55,8 +55,8 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
-                helm.sh/chart: kubescape-operator-1.40.1
+                app.kubernetes.io/version: 1.40.2
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -112,8 +112,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -167,8 +167,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -192,8 +192,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -218,8 +218,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -239,8 +239,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -287,8 +287,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -315,8 +315,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -336,8 +336,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -359,8 +359,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -380,8 +380,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -398,9 +398,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -420,9 +420,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -436,7 +436,7 @@ all capabilities:
                   command:
                     - /bin/sh
                     - -c
-                  image: quay.io/kubescape/kubectl:1.30.3
+                  image: quay.io/kubescape/kubectl:1.36.1
                   imagePullPolicy: IfNotPresent
                   name: grype-offline-db
                   resources:
@@ -476,8 +476,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -507,9 +507,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
+            app.kubernetes.io/version: 1.40.2
             bar: baz
-            helm.sh/chart: kubescape-operator-1.40.1
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -565,8 +565,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -600,8 +600,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -625,8 +625,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -650,8 +650,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -678,8 +678,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -698,8 +698,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -717,9 +717,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -739,9 +739,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -804,8 +804,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -867,8 +867,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1137,8 +1137,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1162,8 +1162,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1195,8 +1195,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1376,8 +1376,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1395,8 +1395,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1483,8 +1483,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1514,8 +1514,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1540,8 +1540,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -1566,8 +1566,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1596,8 +1596,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1614,8 +1614,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -1647,8 +1647,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1666,9 +1666,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1688,9 +1688,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -1753,8 +1753,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -1816,8 +1816,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1866,8 +1866,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1891,8 +1891,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1921,8 +1921,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1953,7 +1953,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.138
+              image: quay.io/kubescape/kubevuln:v0.3.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -2049,8 +2049,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2117,8 +2117,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -2141,8 +2141,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -2167,8 +2167,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2196,8 +2196,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2583,8 +2583,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2740,8 +2740,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2808,8 +2808,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2864,8 +2864,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2892,9 +2892,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
+            app.kubernetes.io/version: 1.40.2
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.1
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -2967,14 +2967,14 @@ all capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.112
+                  value: v0.3.119
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.112
+              image: quay.io/kubescape/node-agent:v0.3.119
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -3155,8 +3155,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -3206,8 +3206,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -3888,8 +3888,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -3953,8 +3953,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -3979,8 +3979,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -4007,8 +4007,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -4025,8 +4025,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -4052,8 +4052,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -4104,8 +4104,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -4127,8 +4127,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -4146,8 +4146,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4280,8 +4280,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4337,8 +4337,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4356,8 +4356,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4392,8 +4392,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -4407,7 +4407,7 @@ all capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -4423,7 +4423,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -4622,8 +4622,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4710,8 +4710,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4729,8 +4729,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4905,8 +4905,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4924,8 +4924,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4968,8 +4968,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4994,8 +4994,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -5020,8 +5020,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5049,8 +5049,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5066,8 +5066,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5094,8 +5094,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5119,8 +5119,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5145,8 +5145,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -5226,8 +5226,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5295,8 +5295,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5323,8 +5323,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5341,8 +5341,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5377,8 +5377,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -5396,8 +5396,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -5422,8 +5422,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5488,8 +5488,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -5513,8 +5513,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5551,8 +5551,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5570,8 +5570,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5596,8 +5596,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -5690,8 +5690,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5760,8 +5760,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -5784,8 +5784,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -5810,8 +5810,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -5836,8 +5836,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -6160,8 +6160,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -6189,8 +6189,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -6207,8 +6207,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6444,8 +6444,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6747,8 +6747,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6766,8 +6766,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6797,8 +6797,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -6810,7 +6810,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -6828,7 +6828,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.144
+              image: quay.io/kubescape/synchronizer:v0.0.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -6913,8 +6913,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6991,8 +6991,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7034,8 +7034,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7059,8 +7059,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -7084,8 +7084,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7112,8 +7112,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7121,7 +7121,7 @@ all capabilities:
 autoscaler mode with sbom sidecar:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.1.
+      Thank you for installing kubescape-operator version 1.40.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -7157,8 +7157,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -7204,8 +7204,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -7232,8 +7232,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7254,8 +7254,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7275,8 +7275,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -7295,8 +7295,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7314,9 +7314,9 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7336,9 +7336,9 @@ autoscaler mode with sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -7399,8 +7399,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7669,8 +7669,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7694,8 +7694,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7726,8 +7726,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -7861,8 +7861,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7880,8 +7880,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7911,8 +7911,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7937,8 +7937,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7967,8 +7967,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7986,8 +7986,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8005,9 +8005,9 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8027,9 +8027,9 @@ autoscaler mode with sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -8090,8 +8090,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8131,8 +8131,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8156,8 +8156,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8185,8 +8185,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -8211,7 +8211,7 @@ autoscaler mode with sbom sidecar:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.138
+              image: quay.io/kubescape/kubevuln:v0.3.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -8291,8 +8291,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8320,8 +8320,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8707,8 +8707,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8864,8 +8864,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8932,8 +8932,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8951,8 +8951,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8979,8 +8979,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8988,7 +8988,7 @@ autoscaler mode with sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.1\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.1\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 921a39bfca3fd64ae481a3b3b37e9c48df1332841321f999bd0cf0896ae88136\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: f7a445313c8a4c7668278b23c4aa82e5179084364812bb863962a5cc129e608b\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.1\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.1\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.112\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.112\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.112\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n        node.kubernetes.io/instance-type: \"{{ .NodeGroupLabel }}\"\n      affinity:\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 921a39bfca3fd64ae481a3b3b37e9c48df1332841321f999bd0cf0896ae88136\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: f7a445313c8a4c7668278b23c4aa82e5179084364812bb863962a5cc129e608b\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.119\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.119\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.119\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n        node.kubernetes.io/instance-type: \"{{ .NodeGroupLabel }}\"\n      affinity:\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -8999,8 +8999,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9018,8 +9018,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -9045,8 +9045,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -9097,8 +9097,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -9120,8 +9120,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -9139,8 +9139,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9264,8 +9264,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9321,8 +9321,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9340,8 +9340,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9375,8 +9375,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -9390,7 +9390,7 @@ autoscaler mode with sbom sidecar:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -9400,7 +9400,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -9587,8 +9587,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9672,8 +9672,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9757,8 +9757,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9776,8 +9776,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9832,8 +9832,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9858,8 +9858,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9887,8 +9887,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9905,8 +9905,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -9935,8 +9935,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -9958,8 +9958,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -9977,8 +9977,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10043,8 +10043,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -10068,8 +10068,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10109,8 +10109,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10128,8 +10128,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10154,8 +10154,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -10249,8 +10249,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -10273,8 +10273,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -10299,8 +10299,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -10623,8 +10623,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10652,8 +10652,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10670,8 +10670,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10838,8 +10838,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11123,8 +11123,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11142,8 +11142,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11172,8 +11172,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -11185,7 +11185,7 @@ autoscaler mode with sbom sidecar:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -11197,7 +11197,7 @@ autoscaler mode with sbom sidecar:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.144
+              image: quay.io/kubescape/synchronizer:v0.0.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -11266,8 +11266,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11309,8 +11309,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11334,8 +11334,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11362,8 +11362,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11371,7 +11371,7 @@ autoscaler mode with sbom sidecar:
 autoscaler mode without sbom sidecar:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.1.
+      Thank you for installing kubescape-operator version 1.40.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -11407,8 +11407,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -11454,8 +11454,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -11482,8 +11482,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11504,8 +11504,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11525,8 +11525,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -11545,8 +11545,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11564,9 +11564,9 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11586,9 +11586,9 @@ autoscaler mode without sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11649,8 +11649,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11919,8 +11919,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11944,8 +11944,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11976,8 +11976,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -12111,8 +12111,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12130,8 +12130,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12161,8 +12161,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12187,8 +12187,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12217,8 +12217,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12236,8 +12236,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12255,9 +12255,9 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12277,9 +12277,9 @@ autoscaler mode without sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -12340,8 +12340,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12381,8 +12381,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12406,8 +12406,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12435,8 +12435,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -12461,7 +12461,7 @@ autoscaler mode without sbom sidecar:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.138
+              image: quay.io/kubescape/kubevuln:v0.3.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12541,8 +12541,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12570,8 +12570,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12957,8 +12957,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13114,8 +13114,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13182,8 +13182,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13201,8 +13201,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13229,8 +13229,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13238,7 +13238,7 @@ autoscaler mode without sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.1\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.1\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 921a39bfca3fd64ae481a3b3b37e9c48df1332841321f999bd0cf0896ae88136\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: f7a445313c8a4c7668278b23c4aa82e5179084364812bb863962a5cc129e608b\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.1\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.1\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.112\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.112\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n        node.kubernetes.io/instance-type: \"{{ .NodeGroupLabel }}\"\n      affinity:\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 921a39bfca3fd64ae481a3b3b37e9c48df1332841321f999bd0cf0896ae88136\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: f7a445313c8a4c7668278b23c4aa82e5179084364812bb863962a5cc129e608b\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.119\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.119\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n        node.kubernetes.io/instance-type: \"{{ .NodeGroupLabel }}\"\n      affinity:\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -13249,8 +13249,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13268,8 +13268,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -13295,8 +13295,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -13347,8 +13347,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -13370,8 +13370,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -13389,8 +13389,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13514,8 +13514,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13571,8 +13571,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13590,8 +13590,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13625,8 +13625,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -13640,7 +13640,7 @@ autoscaler mode without sbom sidecar:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -13650,7 +13650,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -13837,8 +13837,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13922,8 +13922,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14007,8 +14007,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14026,8 +14026,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14082,8 +14082,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14108,8 +14108,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14137,8 +14137,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14155,8 +14155,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -14185,8 +14185,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -14208,8 +14208,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -14227,8 +14227,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14293,8 +14293,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -14318,8 +14318,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14359,8 +14359,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14378,8 +14378,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14404,8 +14404,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -14499,8 +14499,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -14523,8 +14523,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -14549,8 +14549,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -14873,8 +14873,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14902,8 +14902,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14920,8 +14920,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15088,8 +15088,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15373,8 +15373,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15392,8 +15392,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15422,8 +15422,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15435,7 +15435,7 @@ autoscaler mode without sbom sidecar:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -15447,7 +15447,7 @@ autoscaler mode without sbom sidecar:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.144
+              image: quay.io/kubescape/synchronizer:v0.0.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -15516,8 +15516,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15559,8 +15559,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15584,8 +15584,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15612,8 +15612,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15621,7 +15621,7 @@ autoscaler mode without sbom sidecar:
 backend-storage enabled disables scanning capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.1.
+      Thank you for installing kubescape-operator version 1.40.2.
 
 
 
@@ -15649,8 +15649,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -15696,8 +15696,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -15724,8 +15724,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15746,8 +15746,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15767,8 +15767,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -16154,8 +16154,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16311,8 +16311,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16379,8 +16379,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16398,8 +16398,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16425,8 +16425,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16466,14 +16466,14 @@ backend-storage enabled disables scanning capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.112
+                  value: v0.3.119
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.112
+              image: quay.io/kubescape/node-agent:v0.3.119
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16637,8 +16637,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -16691,8 +16691,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -17373,8 +17373,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -17401,8 +17401,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -17419,8 +17419,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -17446,8 +17446,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -17498,8 +17498,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -17521,8 +17521,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -17540,8 +17540,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17665,8 +17665,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17722,8 +17722,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17741,8 +17741,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17776,8 +17776,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17791,7 +17791,7 @@ backend-storage enabled disables scanning capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -17801,7 +17801,7 @@ backend-storage enabled disables scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -17982,8 +17982,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18067,8 +18067,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18152,8 +18152,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18171,8 +18171,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18215,8 +18215,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18241,8 +18241,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18270,8 +18270,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18292,8 +18292,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -18315,8 +18315,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -18334,8 +18334,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -18658,8 +18658,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -18826,8 +18826,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19093,8 +19093,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19112,8 +19112,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19142,8 +19142,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19155,7 +19155,7 @@ backend-storage enabled disables scanning capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19167,7 +19167,7 @@ backend-storage enabled disables scanning capabilities:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.144
+              image: quay.io/kubescape/synchronizer:v0.0.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19236,8 +19236,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19279,8 +19279,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19304,8 +19304,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19332,8 +19332,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19351,8 +19351,8 @@ cert strategy hook, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19386,8 +19386,8 @@ cert strategy hook, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19401,7 +19401,7 @@ cert strategy hook, admission disabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19411,7 +19411,7 @@ cert strategy hook, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19517,8 +19517,8 @@ cert strategy hook, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -19543,8 +19543,8 @@ cert strategy hook, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19569,8 +19569,8 @@ cert strategy hook, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19659,8 +19659,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19694,8 +19694,8 @@ cert strategy hook, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19709,7 +19709,7 @@ cert strategy hook, admission disabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19719,7 +19719,7 @@ cert strategy hook, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19825,8 +19825,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -19852,8 +19852,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -19880,8 +19880,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -19907,8 +19907,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-create
@@ -19923,8 +19923,8 @@ cert strategy hook, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: storage-certgen-create
@@ -19971,8 +19971,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-patch
@@ -19987,8 +19987,8 @@ cert strategy hook, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: storage-certgen-patch
@@ -20035,8 +20035,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -20063,8 +20063,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -20091,8 +20091,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -20109,8 +20109,8 @@ cert strategy hook, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20135,8 +20135,8 @@ cert strategy hook, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20231,8 +20231,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20280,8 +20280,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -20308,8 +20308,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -20335,8 +20335,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-create
@@ -20351,8 +20351,8 @@ cert strategy hook, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: kubescape-admission-webhook-create
@@ -20399,8 +20399,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-patch
@@ -20415,8 +20415,8 @@ cert strategy hook, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: kubescape-admission-webhook-patch
@@ -20462,8 +20462,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20490,8 +20490,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20518,8 +20518,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20536,8 +20536,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20571,8 +20571,8 @@ cert strategy hook, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20586,7 +20586,7 @@ cert strategy hook, admission enabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -20596,7 +20596,7 @@ cert strategy hook, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -20711,8 +20711,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -20737,8 +20737,8 @@ cert strategy hook, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20763,8 +20763,8 @@ cert strategy hook, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20853,8 +20853,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20902,8 +20902,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -20930,8 +20930,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -20957,8 +20957,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-create
@@ -20973,8 +20973,8 @@ cert strategy hook, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: kubescape-admission-webhook-create
@@ -21021,8 +21021,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-patch
@@ -21037,8 +21037,8 @@ cert strategy hook, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: kubescape-admission-webhook-patch
@@ -21084,8 +21084,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21112,8 +21112,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21140,8 +21140,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21158,8 +21158,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21193,8 +21193,8 @@ cert strategy hook, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21208,7 +21208,7 @@ cert strategy hook, admission enabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -21218,7 +21218,7 @@ cert strategy hook, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21333,8 +21333,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -21360,8 +21360,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -21388,8 +21388,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -21415,8 +21415,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-create
@@ -21431,8 +21431,8 @@ cert strategy hook, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: storage-certgen-create
@@ -21479,8 +21479,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-patch
@@ -21495,8 +21495,8 @@ cert strategy hook, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             tier: ks-control-plane
           name: storage-certgen-patch
@@ -21543,8 +21543,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -21571,8 +21571,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -21599,8 +21599,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -21617,8 +21617,8 @@ cert strategy hook, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21643,8 +21643,8 @@ cert strategy hook, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21739,8 +21739,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21774,8 +21774,8 @@ cert strategy template, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21789,7 +21789,7 @@ cert strategy template, admission disabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -21799,7 +21799,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21905,8 +21905,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -21931,8 +21931,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21957,8 +21957,8 @@ cert strategy template, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22047,8 +22047,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22082,8 +22082,8 @@ cert strategy template, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22097,7 +22097,7 @@ cert strategy template, admission disabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -22107,7 +22107,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22213,8 +22213,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -22243,8 +22243,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -22266,8 +22266,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -22285,8 +22285,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22311,8 +22311,8 @@ cert strategy template, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22407,8 +22407,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22459,8 +22459,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -22482,8 +22482,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -22501,8 +22501,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22536,8 +22536,8 @@ cert strategy template, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22551,7 +22551,7 @@ cert strategy template, admission enabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -22561,7 +22561,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22676,8 +22676,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -22702,8 +22702,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22728,8 +22728,8 @@ cert strategy template, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22818,8 +22818,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22870,8 +22870,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -22893,8 +22893,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -22912,8 +22912,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22947,8 +22947,8 @@ cert strategy template, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22962,7 +22962,7 @@ cert strategy template, admission enabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -22972,7 +22972,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23087,8 +23087,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -23117,8 +23117,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -23140,8 +23140,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -23159,8 +23159,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23185,8 +23185,8 @@ cert strategy template, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23271,7 +23271,7 @@ cert strategy template, admission enabled, mtls enabled:
 default capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.1.
+      Thank you for installing kubescape-operator version 1.40.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -23307,8 +23307,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -23355,8 +23355,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -23383,8 +23383,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23405,8 +23405,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23426,8 +23426,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -23444,8 +23444,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23474,8 +23474,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23528,8 +23528,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23563,8 +23563,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23591,8 +23591,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23611,8 +23611,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23630,9 +23630,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23652,9 +23652,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -23714,8 +23714,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -23771,8 +23771,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24041,8 +24041,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24066,8 +24066,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24099,8 +24099,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24249,8 +24249,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24268,8 +24268,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24345,8 +24345,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24376,8 +24376,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24402,8 +24402,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24432,8 +24432,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24450,8 +24450,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -24483,8 +24483,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24502,9 +24502,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24524,9 +24524,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -24586,8 +24586,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -24643,8 +24643,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -24684,8 +24684,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -24709,8 +24709,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24739,8 +24739,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24765,7 +24765,7 @@ default capabilities:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.138
+              image: quay.io/kubescape/kubevuln:v0.3.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24860,8 +24860,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -24922,8 +24922,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -24951,8 +24951,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -25338,8 +25338,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25495,8 +25495,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25563,8 +25563,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25582,8 +25582,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25610,8 +25610,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -25651,14 +25651,14 @@ default capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.112
+                  value: v0.3.119
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.112
+              image: quay.io/kubescape/node-agent:v0.3.119
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -25840,8 +25840,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -25897,8 +25897,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -26579,8 +26579,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -26633,8 +26633,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -26661,8 +26661,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -26679,8 +26679,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -26804,8 +26804,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -26861,8 +26861,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26880,8 +26880,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26916,8 +26916,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -26931,7 +26931,7 @@ default capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -26941,7 +26941,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -27128,8 +27128,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27213,8 +27213,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27232,8 +27232,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27391,8 +27391,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27410,8 +27410,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27454,8 +27454,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27480,8 +27480,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27509,8 +27509,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27532,8 +27532,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -27551,8 +27551,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -27581,8 +27581,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -27604,8 +27604,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -27623,8 +27623,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -27689,8 +27689,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -27714,8 +27714,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -27755,8 +27755,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27774,8 +27774,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27800,8 +27800,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -27895,8 +27895,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -27957,8 +27957,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -27981,8 +27981,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -28007,8 +28007,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -28331,8 +28331,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28360,8 +28360,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28378,8 +28378,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -28546,8 +28546,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -28831,8 +28831,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28850,8 +28850,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28881,8 +28881,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -28894,7 +28894,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -28906,7 +28906,7 @@ default capabilities:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.144
+              image: quay.io/kubescape/synchronizer:v0.0.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -28991,8 +28991,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29058,8 +29058,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29101,8 +29101,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29126,8 +29126,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29154,8 +29154,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29163,7 +29163,7 @@ default capabilities:
 disable otel:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.1.
+      Thank you for installing kubescape-operator version 1.40.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -29199,8 +29199,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -29246,8 +29246,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -29274,8 +29274,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29296,8 +29296,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29317,8 +29317,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -29337,8 +29337,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29356,9 +29356,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29378,9 +29378,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -29441,8 +29441,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -29711,8 +29711,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -29736,8 +29736,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29768,8 +29768,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -29903,8 +29903,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29922,8 +29922,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -29953,8 +29953,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -29979,8 +29979,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30009,8 +30009,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30028,8 +30028,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30047,9 +30047,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30069,9 +30069,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -30132,8 +30132,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30173,8 +30173,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30198,8 +30198,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30227,8 +30227,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -30253,7 +30253,7 @@ disable otel:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.138
+              image: quay.io/kubescape/kubevuln:v0.3.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -30333,8 +30333,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30362,8 +30362,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30749,8 +30749,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -30906,8 +30906,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -30974,8 +30974,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30993,8 +30993,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31020,8 +31020,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -31061,14 +31061,14 @@ disable otel:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.112
+                  value: v0.3.119
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.112
+              image: quay.io/kubescape/node-agent:v0.3.119
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -31232,8 +31232,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31260,8 +31260,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31278,8 +31278,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -31305,8 +31305,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -31357,8 +31357,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -31380,8 +31380,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -31399,8 +31399,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -31524,8 +31524,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -31581,8 +31581,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31600,8 +31600,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31635,8 +31635,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -31650,7 +31650,7 @@ disable otel:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -31660,7 +31660,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -31841,8 +31841,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31926,8 +31926,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32011,8 +32011,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32030,8 +32030,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32074,8 +32074,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32100,8 +32100,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32129,8 +32129,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32147,8 +32147,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -32177,8 +32177,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -32200,8 +32200,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -32219,8 +32219,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -32285,8 +32285,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -32310,8 +32310,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -32351,8 +32351,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32370,8 +32370,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32396,8 +32396,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -32491,8 +32491,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -32515,8 +32515,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -32541,8 +32541,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -32865,8 +32865,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -32894,8 +32894,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -32912,8 +32912,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33080,8 +33080,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33365,8 +33365,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33384,8 +33384,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33414,8 +33414,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -33427,7 +33427,7 @@ disable otel:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -33439,7 +33439,7 @@ disable otel:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.144
+              image: quay.io/kubescape/synchronizer:v0.0.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -33508,8 +33508,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33551,8 +33551,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33576,8 +33576,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33604,8 +33604,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33613,7 +33613,7 @@ disable otel:
 minimal capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.1.
+      Thank you for installing kubescape-operator version 1.40.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -33649,8 +33649,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -33696,8 +33696,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -33724,8 +33724,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33746,8 +33746,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33767,8 +33767,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -33787,8 +33787,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33806,9 +33806,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33828,9 +33828,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -33891,8 +33891,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34161,8 +34161,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34186,8 +34186,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34218,8 +34218,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -34351,8 +34351,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34370,8 +34370,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34401,8 +34401,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34427,8 +34427,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34457,8 +34457,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34476,8 +34476,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34495,9 +34495,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34517,9 +34517,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -34580,8 +34580,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -34621,8 +34621,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -34646,8 +34646,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34675,8 +34675,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -34701,7 +34701,7 @@ minimal capabilities:
                   value: "1"
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/kubevuln:v0.3.138
+              image: quay.io/kubescape/kubevuln:v0.3.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -34781,8 +34781,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -34810,8 +34810,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -35197,8 +35197,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -35354,8 +35354,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -35420,8 +35420,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35439,8 +35439,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35466,8 +35466,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -35509,12 +35509,12 @@ minimal capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.112
+                  value: v0.3.119
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.112
+              image: quay.io/kubescape/node-agent:v0.3.119
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -35678,8 +35678,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -35706,8 +35706,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -35724,8 +35724,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -35751,8 +35751,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -35803,8 +35803,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -35826,8 +35826,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -35845,8 +35845,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -35970,8 +35970,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -36025,8 +36025,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36044,8 +36044,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36079,8 +36079,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -36094,7 +36094,7 @@ minimal capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -36106,7 +36106,7 @@ minimal capabilities:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -36287,8 +36287,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36372,8 +36372,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36457,8 +36457,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36476,8 +36476,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -36520,8 +36520,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -36546,8 +36546,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -36575,8 +36575,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -36593,8 +36593,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -36623,8 +36623,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -36646,8 +36646,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -36665,8 +36665,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -36731,8 +36731,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -36756,8 +36756,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -36797,8 +36797,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36816,8 +36816,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36842,8 +36842,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -36939,8 +36939,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -36963,8 +36963,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -36989,8 +36989,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -37313,8 +37313,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -37342,8 +37342,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -37351,7 +37351,7 @@ minimal capabilities:
 multiple node agents:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.1.
+      Thank you for installing kubescape-operator version 1.40.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -37385,8 +37385,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -37405,8 +37405,8 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
-                helm.sh/chart: kubescape-operator-1.40.1
+                app.kubernetes.io/version: 1.40.2
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -37462,8 +37462,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -37517,8 +37517,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -37542,8 +37542,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -37568,8 +37568,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -37589,8 +37589,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -37637,8 +37637,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -37665,8 +37665,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37686,8 +37686,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -37709,8 +37709,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37730,8 +37730,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -37748,9 +37748,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37770,9 +37770,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -37786,7 +37786,7 @@ multiple node agents:
                   command:
                     - /bin/sh
                     - -c
-                  image: quay.io/kubescape/kubectl:1.30.3
+                  image: quay.io/kubescape/kubectl:1.36.1
                   imagePullPolicy: IfNotPresent
                   name: grype-offline-db
                   resources:
@@ -37826,8 +37826,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37857,9 +37857,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
+            app.kubernetes.io/version: 1.40.2
             bar: baz
-            helm.sh/chart: kubescape-operator-1.40.1
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -37915,8 +37915,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -37950,8 +37950,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -37975,8 +37975,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -38000,8 +38000,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -38028,8 +38028,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -38048,8 +38048,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38067,9 +38067,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38089,9 +38089,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -38154,8 +38154,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -38217,8 +38217,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38487,8 +38487,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38512,8 +38512,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38545,8 +38545,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -38726,8 +38726,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38745,8 +38745,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38833,8 +38833,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38864,8 +38864,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38890,8 +38890,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -38916,8 +38916,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38946,8 +38946,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38964,8 +38964,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -38997,8 +38997,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39016,9 +39016,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39038,9 +39038,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -39103,8 +39103,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -39166,8 +39166,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -39216,8 +39216,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -39241,8 +39241,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39271,8 +39271,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -39303,7 +39303,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.138
+              image: quay.io/kubescape/kubevuln:v0.3.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -39399,8 +39399,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -39467,8 +39467,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -39491,8 +39491,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -39517,8 +39517,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -39546,8 +39546,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -39933,8 +39933,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -40090,8 +40090,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -40158,8 +40158,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40214,8 +40214,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40242,9 +40242,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
+            app.kubernetes.io/version: 1.40.2
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.1
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -40317,14 +40317,14 @@ multiple node agents:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.112
+                  value: v0.3.119
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.112
+              image: quay.io/kubescape/node-agent:v0.3.119
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -40506,8 +40506,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40534,9 +40534,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
+            app.kubernetes.io/version: 1.40.2
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.1
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -40609,14 +40609,14 @@ multiple node agents:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.112
+                  value: v0.3.119
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.112
+              image: quay.io/kubescape/node-agent:v0.3.119
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -40798,8 +40798,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -40849,8 +40849,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -41531,8 +41531,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -41596,8 +41596,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -41622,8 +41622,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -41650,8 +41650,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -41668,8 +41668,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -41695,8 +41695,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -41747,8 +41747,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -41770,8 +41770,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -41789,8 +41789,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -41923,8 +41923,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -41980,8 +41980,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -41999,8 +41999,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42035,8 +42035,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -42050,7 +42050,7 @@ multiple node agents:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -42066,7 +42066,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -42265,8 +42265,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42353,8 +42353,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42372,8 +42372,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42548,8 +42548,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42567,8 +42567,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42611,8 +42611,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42637,8 +42637,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -42663,8 +42663,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42692,8 +42692,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42709,8 +42709,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -42737,8 +42737,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -42762,8 +42762,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -42788,8 +42788,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -42869,8 +42869,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -42938,8 +42938,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -42966,8 +42966,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -42984,8 +42984,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -43020,8 +43020,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -43039,8 +43039,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -43065,8 +43065,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -43131,8 +43131,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -43156,8 +43156,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -43194,8 +43194,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43213,8 +43213,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43239,8 +43239,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -43333,8 +43333,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -43403,8 +43403,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -43427,8 +43427,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -43453,8 +43453,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -43479,8 +43479,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -43803,8 +43803,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -43832,8 +43832,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -43850,8 +43850,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44087,8 +44087,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44390,8 +44390,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44409,8 +44409,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44440,8 +44440,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -44453,7 +44453,7 @@ multiple node agents:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -44471,7 +44471,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.144
+              image: quay.io/kubescape/synchronizer:v0.0.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -44556,8 +44556,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44634,8 +44634,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44677,8 +44677,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44702,8 +44702,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -44727,8 +44727,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44755,8 +44755,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44764,7 +44764,7 @@ multiple node agents:
 priority class scheduling:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.1.
+      Thank you for installing kubescape-operator version 1.40.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -44800,8 +44800,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -44847,8 +44847,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -44875,8 +44875,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44897,8 +44897,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44918,8 +44918,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -44938,8 +44938,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44957,9 +44957,9 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44979,9 +44979,9 @@ priority class scheduling:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -45043,8 +45043,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -45313,8 +45313,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -45338,8 +45338,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45370,8 +45370,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -45506,8 +45506,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45525,8 +45525,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -45556,8 +45556,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -45582,8 +45582,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -45612,8 +45612,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -45631,8 +45631,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45650,9 +45650,9 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45672,9 +45672,9 @@ priority class scheduling:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -45736,8 +45736,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -45777,8 +45777,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -45802,8 +45802,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45831,8 +45831,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -45857,7 +45857,7 @@ priority class scheduling:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.138
+              image: quay.io/kubescape/kubevuln:v0.3.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -45938,8 +45938,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -45967,8 +45967,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -46354,8 +46354,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -46511,8 +46511,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -46579,8 +46579,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46598,8 +46598,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46625,8 +46625,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -46666,14 +46666,14 @@ priority class scheduling:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.112
+                  value: v0.3.119
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.112
+              image: quay.io/kubescape/node-agent:v0.3.119
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -46837,8 +46837,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -46865,8 +46865,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -46883,8 +46883,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -46910,8 +46910,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -46962,8 +46962,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -46985,8 +46985,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -47004,8 +47004,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47129,8 +47129,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47186,8 +47186,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47205,8 +47205,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47240,8 +47240,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -47255,7 +47255,7 @@ priority class scheduling:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -47265,7 +47265,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -47447,8 +47447,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47532,8 +47532,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47617,8 +47617,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47636,8 +47636,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47680,8 +47680,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47706,8 +47706,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47735,8 +47735,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47753,8 +47753,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -47783,8 +47783,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -47806,8 +47806,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -47825,8 +47825,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -47891,8 +47891,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -47916,8 +47916,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -47957,8 +47957,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47976,8 +47976,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48002,8 +48002,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -48098,8 +48098,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -48122,8 +48122,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -48148,8 +48148,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -48472,8 +48472,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -48501,8 +48501,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -48519,8 +48519,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -48687,8 +48687,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -48972,8 +48972,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48991,8 +48991,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49021,8 +49021,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -49034,7 +49034,7 @@ priority class scheduling:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -49046,7 +49046,7 @@ priority class scheduling:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.144
+              image: quay.io/kubescape/synchronizer:v0.0.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -49116,8 +49116,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -49159,8 +49159,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -49184,8 +49184,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -49212,8 +49212,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -49221,7 +49221,7 @@ priority class scheduling:
 relevancy only:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.1.
+      Thank you for installing kubescape-operator version 1.40.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -49256,8 +49256,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -49303,8 +49303,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -49331,8 +49331,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49353,8 +49353,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49374,8 +49374,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -49394,8 +49394,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49413,9 +49413,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49435,9 +49435,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -49498,8 +49498,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -49768,8 +49768,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -49793,8 +49793,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49825,8 +49825,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -49958,8 +49958,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49977,8 +49977,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50008,8 +50008,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50034,8 +50034,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50064,8 +50064,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50083,8 +50083,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50102,9 +50102,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50124,9 +50124,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -50187,8 +50187,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -50228,8 +50228,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -50253,8 +50253,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50282,8 +50282,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -50308,7 +50308,7 @@ relevancy only:
                   value: "1"
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/kubevuln:v0.3.138
+              image: quay.io/kubescape/kubevuln:v0.3.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -50388,8 +50388,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -50417,8 +50417,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -50804,8 +50804,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -50961,8 +50961,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -51027,8 +51027,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51046,8 +51046,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51073,8 +51073,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -51116,12 +51116,12 @@ relevancy only:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.112
+                  value: v0.3.119
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.112
+              image: quay.io/kubescape/node-agent:v0.3.119
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -51285,8 +51285,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -51313,8 +51313,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -51331,8 +51331,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -51456,8 +51456,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -51511,8 +51511,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51530,8 +51530,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51565,8 +51565,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -51580,7 +51580,7 @@ relevancy only:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -51592,7 +51592,7 @@ relevancy only:
                   value: zap
                 - name: OTEL_COLLECTOR_SVC
                   value: otelCollector.svc.monitoring:4317
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -51764,8 +51764,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51849,8 +51849,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51934,8 +51934,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51953,8 +51953,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -51997,8 +51997,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52023,8 +52023,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52052,8 +52052,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52070,8 +52070,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -52100,8 +52100,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -52123,8 +52123,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -52142,8 +52142,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -52208,8 +52208,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -52233,8 +52233,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -52274,8 +52274,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52293,8 +52293,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52319,8 +52319,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -52416,8 +52416,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -52440,8 +52440,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -52466,8 +52466,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -52790,8 +52790,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -52819,8 +52819,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -52828,7 +52828,7 @@ relevancy only:
 skipPersistence enabled:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.1.
+      Thank you for installing kubescape-operator version 1.40.2.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -52862,8 +52862,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -52882,8 +52882,8 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
-                helm.sh/chart: kubescape-operator-1.40.1
+                app.kubernetes.io/version: 1.40.2
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -52939,8 +52939,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -52994,8 +52994,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -53019,8 +53019,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -53045,8 +53045,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -53066,8 +53066,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -53114,8 +53114,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -53142,8 +53142,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53163,8 +53163,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -53186,8 +53186,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53207,8 +53207,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -53225,9 +53225,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53247,9 +53247,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -53263,7 +53263,7 @@ skipPersistence enabled:
                   command:
                     - /bin/sh
                     - -c
-                  image: quay.io/kubescape/kubectl:1.30.3
+                  image: quay.io/kubescape/kubectl:1.36.1
                   imagePullPolicy: IfNotPresent
                   name: grype-offline-db
                   resources:
@@ -53303,8 +53303,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53334,9 +53334,9 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
+            app.kubernetes.io/version: 1.40.2
             bar: baz
-            helm.sh/chart: kubescape-operator-1.40.1
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -53392,8 +53392,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -53427,8 +53427,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -53452,8 +53452,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -53477,8 +53477,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -53505,8 +53505,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -53525,8 +53525,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53544,9 +53544,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53566,9 +53566,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -53631,8 +53631,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -53694,8 +53694,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -53964,8 +53964,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -53989,8 +53989,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54022,8 +54022,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -54203,8 +54203,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54222,8 +54222,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54310,8 +54310,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54341,8 +54341,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54367,8 +54367,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -54393,8 +54393,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54423,8 +54423,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54441,8 +54441,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -54477,8 +54477,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54496,9 +54496,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
+        app.kubernetes.io/version: 1.40.2
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.1
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54518,9 +54518,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.1
+                app.kubernetes.io/version: 1.40.2
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.1
+                helm.sh/chart: kubescape-operator-1.40.2
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -54583,8 +54583,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -54646,8 +54646,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -54696,8 +54696,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -54721,8 +54721,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54751,8 +54751,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -54783,7 +54783,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.138
+              image: quay.io/kubescape/kubevuln:v0.3.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -54879,8 +54879,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -54947,8 +54947,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -54971,8 +54971,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -54997,8 +54997,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -55026,8 +55026,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -55413,8 +55413,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -55570,8 +55570,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -55638,8 +55638,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55694,8 +55694,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55722,9 +55722,9 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
+            app.kubernetes.io/version: 1.40.2
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.1
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -55797,14 +55797,14 @@ skipPersistence enabled:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.112
+                  value: v0.3.119
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.112
+              image: quay.io/kubescape/node-agent:v0.3.119
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -55985,8 +55985,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -56036,8 +56036,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -56718,8 +56718,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -56783,8 +56783,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -56809,8 +56809,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -56837,8 +56837,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -56855,8 +56855,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -56882,8 +56882,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -56934,8 +56934,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -56957,8 +56957,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -56976,8 +56976,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -57110,8 +57110,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -57167,8 +57167,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57186,8 +57186,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57222,8 +57222,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -57237,7 +57237,7 @@ skipPersistence enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -57253,7 +57253,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.141
+              image: quay.io/kubescape/operator:v0.2.142
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -57452,8 +57452,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57540,8 +57540,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57559,8 +57559,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -57735,8 +57735,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57754,8 +57754,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -57798,8 +57798,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -57824,8 +57824,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -57850,8 +57850,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -57879,8 +57879,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -57896,8 +57896,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -57924,8 +57924,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -57949,8 +57949,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -57975,8 +57975,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -58056,8 +58056,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58125,8 +58125,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58153,8 +58153,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58171,8 +58171,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58207,8 +58207,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -58226,8 +58226,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -58252,8 +58252,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -58318,8 +58318,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -58343,8 +58343,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -58381,8 +58381,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58400,8 +58400,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58426,8 +58426,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -58520,8 +58520,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -58590,8 +58590,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -58614,8 +58614,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -58640,8 +58640,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -58666,8 +58666,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -58990,8 +58990,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -59019,8 +59019,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -59037,8 +59037,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -59274,8 +59274,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -59577,8 +59577,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -59596,8 +59596,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -59627,8 +59627,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.1
-            helm.sh/chart: kubescape-operator-1.40.1
+            app.kubernetes.io/version: 1.40.2
+            helm.sh/chart: kubescape-operator-1.40.2
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -59640,7 +59640,7 @@ skipPersistence enabled:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.1
+                  value: kubescape-operator-1.40.2
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -59658,7 +59658,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,otel-collector,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.144
+              image: quay.io/kubescape/synchronizer:v0.0.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -59743,8 +59743,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -59821,8 +59821,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -59864,8 +59864,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -59889,8 +59889,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -59914,8 +59914,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -59942,8 +59942,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -59971,8 +59971,8 @@ with multiple private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets
@@ -60009,8 +60009,8 @@ with single private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.1
-        helm.sh/chart: kubescape-operator-1.40.1
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -337,7 +337,7 @@ operator:
   image:
     # -- source code: https://github.com/kubescape/operator
     repository: quay.io/kubescape/operator
-    tag: v0.2.141
+    tag: v0.2.142
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -426,7 +426,7 @@ kubevuln:
   image:
     # -- source code: https://github.com/kubescape/kubevuln
     repository: quay.io/kubescape/kubevuln
-    tag: v0.3.138
+    tag: v0.3.142
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -598,7 +598,7 @@ nodeAgent:
   image:
     # -- source code: https://github.com/kubescape/node-agent
     repository: quay.io/kubescape/node-agent
-    tag: v0.3.112
+    tag: v0.3.119
     pullPolicy: IfNotPresent
 
   config:
@@ -895,7 +895,7 @@ synchronizer:
   image:
     # -- source code: https://github.com/kubescape/synchronizer
     repository: quay.io/kubescape/synchronizer
-    tag: v0.0.144
+    tag: v0.0.147
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux
@@ -987,7 +987,7 @@ grypeOfflineDB:
   rollout:
     image:
       repository: quay.io/kubescape/kubectl
-      tag: 1.30.3
+      tag: 1.36.1
       pullPolicy: IfNotPresent
     nodeSelector:
       kubernetes.io/os: linux


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubescape operator Helm chart to version 1.40.2 with corresponding application version bump
  * Updated container images for all core components including operator, vulnerability scanner, node agent, synchronizer, and kubectl utility to latest available versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/helm-charts/pull/846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->