### PR TITLE
prepate release 1.40.3

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -15,14 +15,14 @@ kubeVersion: ">=1.28.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.40.2
+version: 1.40.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.40.2
+appVersion: 1.40.3
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -1,6 +1,6 @@
 # Kubescape Operator
 
-![Version: 1.40.2](https://img.shields.io/badge/Version-1.40.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.40.2](https://img.shields.io/badge/AppVersion-v1.40.2-informational?style=flat-square)
+![Version: 1.40.3](https://img.shields.io/badge/Version-1.40.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.40.3](https://img.shields.io/badge/AppVersion-v1.40.3-informational?style=flat-square)
 
 [Kubescape operator documentation](https://kubescape.io/docs/install-operator/)
 

--- a/charts/kubescape-operator/templates/_common.tpl
+++ b/charts/kubescape-operator/templates/_common.tpl
@@ -63,9 +63,9 @@ submit: {{ $submit }}
 
 {{- define "components" -}}
 {{- $configurations := fromYaml (include "configurations" .) }}
-{{- $nodeScanEnabled := and (eq .Values.capabilities.nodeScan "enable") (not $configurations.backendStorageEnabled) }}
-{{- $configurationScanEnabled := and (eq .Values.capabilities.configurationScan "enable") (not $configurations.backendStorageEnabled) }}
-{{- $vulnerabilityScanEnabled := and (eq .Values.capabilities.vulnerabilityScan "enable") (not $configurations.backendStorageEnabled) }}
+{{- $nodeScanEnabled := eq .Values.capabilities.nodeScan "enable" }}
+{{- $configurationScanEnabled := eq .Values.capabilities.configurationScan "enable" }}
+{{- $vulnerabilityScanEnabled := eq .Values.capabilities.vulnerabilityScan "enable" }}
 kubescape:
   enabled: {{ $configurationScanEnabled }}
 kubescapeScheduler:
@@ -89,7 +89,7 @@ operator:
 serviceDiscovery:
   enabled: {{ $configurations.submit }}
 storage:
-  enabled: {{ not $configurations.backendStorageEnabled }}
+  enabled: {{ .Values.storage.enabled }}
 prometheusExporter:
   enabled: {{ eq .Values.capabilities.prometheusExporter "enable" }}
 cloudSecret:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1265,7 +1265,7 @@ all capabilities:
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v4.0.9
+              image: quay.io/kubescape/kubescape:v4.0.10
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -1923,7 +1923,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.146
+              image: quay.io/kubescape/kubevuln:v0.3.159
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -2542,8 +2542,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-gke-allowlist
@@ -2950,14 +2950,14 @@ all capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.129
+                  value: v0.3.147
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.129
+              image: quay.io/kubescape/node-agent:v0.3.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -4472,7 +4472,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -5203,7 +5203,7 @@ all capabilities:
                   value: zap
                 - name: ENABLE_WORKLOAD_METRICS
                   value: "true"
-              image: quay.io/kubescape/prometheus-exporter:v0.2.21
+              image: quay.io/kubescape/prometheus-exporter:v0.2.22
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 initialDelaySeconds: 3
@@ -5644,7 +5644,7 @@ all capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -7797,7 +7797,7 @@ autoscaler mode with sbom sidecar:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.9
+              image: quay.io/kubescape/kubescape:v4.0.10
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -8237,7 +8237,7 @@ autoscaler mode with sbom sidecar:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.146
+              image: quay.io/kubescape/kubevuln:v0.3.159
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -9017,7 +9017,7 @@ autoscaler mode with sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.129\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.129\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.129\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.147\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.147\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.147\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -9439,7 +9439,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -10214,7 +10214,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12085,7 +12085,7 @@ autoscaler mode without sbom sidecar:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.9
+              image: quay.io/kubescape/kubescape:v4.0.10
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12525,7 +12525,7 @@ autoscaler mode without sbom sidecar:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.146
+              image: quay.io/kubescape/kubevuln:v0.3.159
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -13305,7 +13305,7 @@ autoscaler mode without sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.129\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.129\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.147\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.147\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -13727,7 +13727,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -14502,7 +14502,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16375,7 +16375,7 @@ backend-storage enabled allows scanning capabilities:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease
-              image: quay.io/kubescape/kubescape:v4.0.9
+              image: quay.io/kubescape/kubescape:v4.0.10
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16815,7 +16815,7 @@ backend-storage enabled allows scanning capabilities:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.146
+              image: quay.io/kubescape/kubevuln:v0.3.159
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -17626,14 +17626,14 @@ backend-storage enabled allows scanning capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.129
+                  value: v0.3.147
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.129
+              image: quay.io/kubescape/node-agent:v0.3.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19011,7 +19011,7 @@ backend-storage enabled allows scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19768,7 +19768,7 @@ backend-storage enabled allows scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21057,7 +21057,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21236,7 +21236,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21368,7 +21368,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21649,7 +21649,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22041,7 +22041,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22297,7 +22297,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22615,7 +22615,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22973,7 +22973,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23179,7 +23179,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23358,7 +23358,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23490,7 +23490,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23715,7 +23715,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23983,7 +23983,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24171,7 +24171,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24433,7 +24433,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24667,7 +24667,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -25599,7 +25599,7 @@ default capabilities:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.9
+              image: quay.io/kubescape/kubescape:v4.0.10
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -26198,7 +26198,7 @@ default capabilities:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.146
+              image: quay.io/kubescape/kubevuln:v0.3.159
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -27076,14 +27076,14 @@ default capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.129
+                  value: v0.3.147
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.129
+              image: quay.io/kubescape/node-agent:v0.3.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -28396,7 +28396,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -29265,7 +29265,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -31262,7 +31262,7 @@ disable otel:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.9
+              image: quay.io/kubescape/kubescape:v4.0.10
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -31702,7 +31702,7 @@ disable otel:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.146
+              image: quay.io/kubescape/kubevuln:v0.3.159
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -32513,14 +32513,14 @@ disable otel:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.129
+                  value: v0.3.147
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.129
+              image: quay.io/kubescape/node-agent:v0.3.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -33122,7 +33122,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -33879,7 +33879,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -35752,7 +35752,7 @@ minimal capabilities:
                   value: /home/nonroot/.kubescape/host-scanner.yaml
                 - name: LARGE_CLUSTER_SIZE
                   value: "1500"
-              image: quay.io/kubescape/kubescape:v4.0.9
+              image: quay.io/kubescape/kubescape:v4.0.10
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -36190,7 +36190,7 @@ minimal capabilities:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.146
+              image: quay.io/kubescape/kubevuln:v0.3.159
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -37002,12 +37002,12 @@ minimal capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.129
+                  value: v0.3.147
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.129
+              image: quay.io/kubescape/node-agent:v0.3.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -37607,7 +37607,7 @@ minimal capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -38364,7 +38364,7 @@ minimal capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -40117,7 +40117,7 @@ multiple node agents:
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v4.0.9
+              image: quay.io/kubescape/kubescape:v4.0.10
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -40775,7 +40775,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.146
+              image: quay.io/kubescape/kubevuln:v0.3.159
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -41394,8 +41394,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-gke-allowlist
@@ -41802,14 +41802,14 @@ multiple node agents:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.129
+                  value: v0.3.147
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.129
+              image: quay.io/kubescape/node-agent:v0.3.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -42095,14 +42095,14 @@ multiple node agents:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.129
+                  value: v0.3.147
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.129
+              image: quay.io/kubescape/node-agent:v0.3.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -43618,7 +43618,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -44349,7 +44349,7 @@ multiple node agents:
                   value: zap
                 - name: ENABLE_WORKLOAD_METRICS
                   value: "true"
-              image: quay.io/kubescape/prometheus-exporter:v0.2.21
+              image: quay.io/kubescape/prometheus-exporter:v0.2.22
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 initialDelaySeconds: 3
@@ -44790,7 +44790,7 @@ multiple node agents:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -46944,7 +46944,7 @@ priority class scheduling:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.9
+              image: quay.io/kubescape/kubescape:v4.0.10
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -47386,7 +47386,7 @@ priority class scheduling:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.146
+              image: quay.io/kubescape/kubevuln:v0.3.159
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -48198,14 +48198,14 @@ priority class scheduling:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.129
+                  value: v0.3.147
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.129
+              image: quay.io/kubescape/node-agent:v0.3.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -48807,7 +48807,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -49565,7 +49565,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -51433,7 +51433,7 @@ relevancy only:
                   value: /home/nonroot/.kubescape/host-scanner.yaml
                 - name: LARGE_CLUSTER_SIZE
                   value: "1500"
-              image: quay.io/kubescape/kubescape:v4.0.9
+              image: quay.io/kubescape/kubescape:v4.0.10
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -51871,7 +51871,7 @@ relevancy only:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.146
+              image: quay.io/kubescape/kubevuln:v0.3.159
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -52683,12 +52683,12 @@ relevancy only:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.129
+                  value: v0.3.147
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.129
+              image: quay.io/kubescape/node-agent:v0.3.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -53158,7 +53158,7 @@ relevancy only:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -53906,7 +53906,7 @@ relevancy only:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -55659,7 +55659,7 @@ skipPersistence enabled:
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v4.0.9
+              image: quay.io/kubescape/kubescape:v4.0.10
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -56320,7 +56320,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.146
+              image: quay.io/kubescape/kubevuln:v0.3.159
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -56939,8 +56939,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-gke-allowlist
@@ -57347,14 +57347,14 @@ skipPersistence enabled:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.129
+                  value: v0.3.147
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.129
+              image: quay.io/kubescape/node-agent:v0.3.147
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -58869,7 +58869,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.149
+              image: quay.io/kubescape/operator:v0.2.151
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -59600,7 +59600,7 @@ skipPersistence enabled:
                   value: zap
                 - name: ENABLE_WORKLOAD_METRICS
                   value: "true"
-              image: quay.io/kubescape/prometheus-exporter:v0.2.21
+              image: quay.io/kubescape/prometheus-exporter:v0.2.22
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 initialDelaySeconds: 3
@@ -60041,7 +60041,7 @@ skipPersistence enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.278
+              image: quay.io/kubescape/storage:v0.0.297
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 all capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.2.
+      Thank you for installing kubescape-operator version 1.40.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -35,8 +35,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -55,8 +55,8 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
-                helm.sh/chart: kubescape-operator-1.40.2
+                app.kubernetes.io/version: 1.40.3
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -112,8 +112,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -156,8 +156,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -181,8 +181,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -207,8 +207,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -228,8 +228,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -276,8 +276,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -306,8 +306,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -327,8 +327,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -350,8 +350,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -371,8 +371,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -389,9 +389,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -411,9 +411,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -467,8 +467,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -498,9 +498,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
+            app.kubernetes.io/version: 1.40.3
             bar: baz
-            helm.sh/chart: kubescape-operator-1.40.2
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -556,8 +556,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -591,8 +591,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -616,8 +616,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -641,8 +641,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -669,8 +669,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -689,8 +689,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -708,9 +708,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -730,9 +730,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -747,7 +747,7 @@ all capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -795,8 +795,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -847,8 +847,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1133,8 +1133,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1158,8 +1158,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1191,8 +1191,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1265,7 +1265,7 @@ all capabilities:
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v4.0.8
+              image: quay.io/kubescape/kubescape:v4.0.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -1370,8 +1370,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1389,8 +1389,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1466,8 +1466,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1497,8 +1497,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1523,8 +1523,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -1549,8 +1549,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1579,8 +1579,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1597,8 +1597,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -1630,8 +1630,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1649,9 +1649,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1671,9 +1671,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -1688,7 +1688,7 @@ all capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -1736,8 +1736,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -1788,8 +1788,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1838,8 +1838,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1863,8 +1863,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1893,8 +1893,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1923,7 +1923,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.142
+              image: quay.io/kubescape/kubevuln:v0.3.146
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -2019,8 +2019,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2076,8 +2076,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -2100,8 +2100,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -2126,8 +2126,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2155,8 +2155,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2562,8 +2562,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2719,8 +2719,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2790,8 +2790,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2846,8 +2846,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2874,9 +2874,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
+            app.kubernetes.io/version: 1.40.3
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.2
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -2950,14 +2950,14 @@ all capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.119
+                  value: v0.3.129
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.119
+              image: quay.io/kubescape/node-agent:v0.3.129
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -3138,8 +3138,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -3189,8 +3189,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -3911,8 +3911,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -3970,8 +3970,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -3996,8 +3996,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -4024,8 +4024,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -4046,8 +4046,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -4069,8 +4069,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -4088,8 +4088,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -4115,8 +4115,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -4172,8 +4172,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4331,8 +4331,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4388,8 +4388,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4407,8 +4407,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4443,8 +4443,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -4458,7 +4458,7 @@ all capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -4624,7 +4624,7 @@ all capabilities:
                   - name: bar
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -4671,8 +4671,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4712,7 +4712,7 @@ all capabilities:
                   - name: bar
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -4759,8 +4759,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4778,8 +4778,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4896,7 +4896,7 @@ all capabilities:
                   - name: bar
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -4943,8 +4943,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4962,8 +4962,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5006,8 +5006,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5032,8 +5032,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -5058,8 +5058,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5087,8 +5087,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5104,8 +5104,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5132,8 +5132,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5157,8 +5157,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5183,8 +5183,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -5203,7 +5203,7 @@ all capabilities:
                   value: zap
                 - name: ENABLE_WORKLOAD_METRICS
                   value: "true"
-              image: quay.io/kubescape/prometheus-exporter:v0.2.18
+              image: quay.io/kubescape/prometheus-exporter:v0.2.21
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 initialDelaySeconds: 3
@@ -5264,8 +5264,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5322,8 +5322,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5350,8 +5350,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5368,8 +5368,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5404,8 +5404,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -5423,8 +5423,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -5449,8 +5449,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5515,8 +5515,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -5540,8 +5540,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5578,8 +5578,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5597,8 +5597,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5626,8 +5626,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -5644,7 +5644,7 @@ all capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -5718,8 +5718,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5777,8 +5777,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -5801,8 +5801,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -5827,8 +5827,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -5853,8 +5853,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -6177,8 +6177,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -6206,8 +6206,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -6224,8 +6224,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6463,8 +6463,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6784,8 +6784,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6803,8 +6803,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6834,8 +6834,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -6847,7 +6847,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -6863,7 +6863,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.147
+              image: quay.io/kubescape/synchronizer:v0.0.149
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -6948,8 +6948,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7015,8 +7015,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7058,8 +7058,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7083,8 +7083,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -7108,8 +7108,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7136,8 +7136,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7145,7 +7145,7 @@ all capabilities:
 autoscaler mode with sbom sidecar:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.2.
+      Thank you for installing kubescape-operator version 1.40.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -7181,8 +7181,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -7228,8 +7228,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -7258,8 +7258,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7280,8 +7280,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7301,8 +7301,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -7321,8 +7321,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7340,9 +7340,9 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7362,9 +7362,9 @@ autoscaler mode with sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -7379,7 +7379,7 @@ autoscaler mode with sbom sidecar:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -7425,8 +7425,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7695,8 +7695,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7720,8 +7720,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7752,8 +7752,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -7797,7 +7797,7 @@ autoscaler mode with sbom sidecar:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.8
+              image: quay.io/kubescape/kubescape:v4.0.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -7887,8 +7887,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7906,8 +7906,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7937,8 +7937,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7963,8 +7963,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7993,8 +7993,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -8012,8 +8012,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8031,9 +8031,9 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8053,9 +8053,9 @@ autoscaler mode with sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -8070,7 +8070,7 @@ autoscaler mode with sbom sidecar:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -8116,8 +8116,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8157,8 +8157,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8182,8 +8182,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8211,8 +8211,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -8237,7 +8237,7 @@ autoscaler mode with sbom sidecar:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.142
+              image: quay.io/kubescape/kubevuln:v0.3.146
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -8317,8 +8317,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8346,8 +8346,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8733,8 +8733,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8890,8 +8890,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8961,8 +8961,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8980,8 +8980,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -9008,8 +9008,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -9017,7 +9017,7 @@ autoscaler mode with sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.119\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.119\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.119\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.129\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.129\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.129\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -9028,8 +9028,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9051,8 +9051,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -9074,8 +9074,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -9093,8 +9093,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -9120,8 +9120,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -9177,8 +9177,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9303,8 +9303,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9360,8 +9360,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9379,8 +9379,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9414,8 +9414,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -9429,7 +9429,7 @@ autoscaler mode with sbom sidecar:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -9579,7 +9579,7 @@ autoscaler mode with sbom sidecar:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -9626,8 +9626,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9664,7 +9664,7 @@ autoscaler mode with sbom sidecar:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -9711,8 +9711,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9749,7 +9749,7 @@ autoscaler mode with sbom sidecar:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -9796,8 +9796,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9815,8 +9815,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9871,8 +9871,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9897,8 +9897,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9926,8 +9926,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9944,8 +9944,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -9974,8 +9974,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -9997,8 +9997,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -10016,8 +10016,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10082,8 +10082,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -10107,8 +10107,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10148,8 +10148,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10167,8 +10167,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10196,8 +10196,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -10214,7 +10214,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -10291,8 +10291,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -10315,8 +10315,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -10341,8 +10341,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -10665,8 +10665,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10694,8 +10694,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10712,8 +10712,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10882,8 +10882,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11185,8 +11185,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11204,8 +11204,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11234,8 +11234,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -11247,7 +11247,7 @@ autoscaler mode with sbom sidecar:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -11259,7 +11259,7 @@ autoscaler mode with sbom sidecar:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.147
+              image: quay.io/kubescape/synchronizer:v0.0.149
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -11328,8 +11328,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11371,8 +11371,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11396,8 +11396,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11424,8 +11424,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11433,7 +11433,7 @@ autoscaler mode with sbom sidecar:
 autoscaler mode without sbom sidecar:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.2.
+      Thank you for installing kubescape-operator version 1.40.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -11469,8 +11469,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -11516,8 +11516,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -11546,8 +11546,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11568,8 +11568,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11589,8 +11589,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -11609,8 +11609,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11628,9 +11628,9 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11650,9 +11650,9 @@ autoscaler mode without sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11667,7 +11667,7 @@ autoscaler mode without sbom sidecar:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -11713,8 +11713,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11983,8 +11983,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12008,8 +12008,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12040,8 +12040,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -12085,7 +12085,7 @@ autoscaler mode without sbom sidecar:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.8
+              image: quay.io/kubescape/kubescape:v4.0.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12175,8 +12175,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12194,8 +12194,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12225,8 +12225,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12251,8 +12251,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12281,8 +12281,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12300,8 +12300,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12319,9 +12319,9 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12341,9 +12341,9 @@ autoscaler mode without sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -12358,7 +12358,7 @@ autoscaler mode without sbom sidecar:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -12404,8 +12404,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12445,8 +12445,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12470,8 +12470,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12499,8 +12499,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -12525,7 +12525,7 @@ autoscaler mode without sbom sidecar:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.142
+              image: quay.io/kubescape/kubevuln:v0.3.146
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12605,8 +12605,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12634,8 +12634,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -13021,8 +13021,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13178,8 +13178,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13249,8 +13249,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13268,8 +13268,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13296,8 +13296,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13305,7 +13305,7 @@ autoscaler mode without sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.119\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.119\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.129\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.129\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -13316,8 +13316,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13339,8 +13339,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -13362,8 +13362,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -13381,8 +13381,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -13408,8 +13408,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -13465,8 +13465,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13591,8 +13591,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13648,8 +13648,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13667,8 +13667,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13702,8 +13702,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -13717,7 +13717,7 @@ autoscaler mode without sbom sidecar:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -13867,7 +13867,7 @@ autoscaler mode without sbom sidecar:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -13914,8 +13914,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13952,7 +13952,7 @@ autoscaler mode without sbom sidecar:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -13999,8 +13999,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14037,7 +14037,7 @@ autoscaler mode without sbom sidecar:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -14084,8 +14084,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14103,8 +14103,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14159,8 +14159,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14185,8 +14185,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14214,8 +14214,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14232,8 +14232,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -14262,8 +14262,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -14285,8 +14285,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -14304,8 +14304,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14370,8 +14370,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -14395,8 +14395,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14436,8 +14436,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14455,8 +14455,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14484,8 +14484,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -14502,7 +14502,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -14579,8 +14579,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -14603,8 +14603,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -14629,8 +14629,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -14953,8 +14953,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14982,8 +14982,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -15000,8 +15000,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15170,8 +15170,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15473,8 +15473,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15492,8 +15492,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15522,8 +15522,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15535,7 +15535,7 @@ autoscaler mode without sbom sidecar:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -15547,7 +15547,7 @@ autoscaler mode without sbom sidecar:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.147
+              image: quay.io/kubescape/synchronizer:v0.0.149
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -15616,8 +15616,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15659,8 +15659,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15684,8 +15684,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15712,8 +15712,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15721,7 +15721,7 @@ autoscaler mode without sbom sidecar:
 backend-storage enabled disables scanning capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.2.
+      Thank you for installing kubescape-operator version 1.40.3.
 
 
 
@@ -15751,8 +15751,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -15798,8 +15798,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -15828,8 +15828,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15850,8 +15850,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15871,8 +15871,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -16258,8 +16258,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16415,8 +16415,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -16486,8 +16486,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16505,8 +16505,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16532,8 +16532,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16573,14 +16573,14 @@ backend-storage enabled disables scanning capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.119
+                  value: v0.3.129
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.119
+              image: quay.io/kubescape/node-agent:v0.3.129
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16744,8 +16744,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -16798,8 +16798,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -17520,8 +17520,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -17548,8 +17548,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -17570,8 +17570,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -17593,8 +17593,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -17612,8 +17612,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -17639,8 +17639,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -17696,8 +17696,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17822,8 +17822,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -17879,8 +17879,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17898,8 +17898,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17933,8 +17933,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17948,7 +17948,7 @@ backend-storage enabled disables scanning capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -18092,7 +18092,7 @@ backend-storage enabled disables scanning capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -18139,8 +18139,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18177,7 +18177,7 @@ backend-storage enabled disables scanning capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -18224,8 +18224,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18262,7 +18262,7 @@ backend-storage enabled disables scanning capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -18309,8 +18309,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18328,8 +18328,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18372,8 +18372,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18398,8 +18398,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18427,8 +18427,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18449,8 +18449,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -18472,8 +18472,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -18491,8 +18491,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -18815,8 +18815,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -18985,8 +18985,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19264,8 +19264,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19283,8 +19283,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19313,8 +19313,8 @@ backend-storage enabled disables scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19326,7 +19326,7 @@ backend-storage enabled disables scanning capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19338,7 +19338,7 @@ backend-storage enabled disables scanning capabilities:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.147
+              image: quay.io/kubescape/synchronizer:v0.0.149
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19407,8 +19407,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19450,8 +19450,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19475,8 +19475,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19503,8 +19503,8 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -19522,8 +19522,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19557,8 +19557,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19572,7 +19572,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19688,8 +19688,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -19714,8 +19714,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19743,8 +19743,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19761,7 +19761,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19833,8 +19833,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19868,8 +19868,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19883,7 +19883,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19999,8 +19999,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -20024,8 +20024,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -20049,8 +20049,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -20074,8 +20074,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -20100,8 +20100,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -20126,8 +20126,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20156,8 +20156,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20174,7 +20174,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -20320,8 +20320,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -20345,8 +20345,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -20370,8 +20370,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20396,8 +20396,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20422,8 +20422,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20449,8 +20449,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20505,8 +20505,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20541,8 +20541,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20556,7 +20556,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -20749,8 +20749,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -20775,8 +20775,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20804,8 +20804,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20822,7 +20822,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -20894,8 +20894,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -20919,8 +20919,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -20944,8 +20944,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20970,8 +20970,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -20996,8 +20996,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21023,8 +21023,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21079,8 +21079,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21115,8 +21115,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21130,7 +21130,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -21323,8 +21323,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -21348,8 +21348,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -21373,8 +21373,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -21398,8 +21398,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -21424,8 +21424,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -21450,8 +21450,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21480,8 +21480,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21498,7 +21498,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21644,8 +21644,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21679,8 +21679,8 @@ cert strategy template, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21694,7 +21694,7 @@ cert strategy template, admission disabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -21810,8 +21810,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -21836,8 +21836,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21865,8 +21865,8 @@ cert strategy template, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21883,7 +21883,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21955,8 +21955,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21990,8 +21990,8 @@ cert strategy template, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22005,7 +22005,7 @@ cert strategy template, admission disabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -22121,8 +22121,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -22151,8 +22151,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -22174,8 +22174,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -22193,8 +22193,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22222,8 +22222,8 @@ cert strategy template, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22240,7 +22240,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22322,8 +22322,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -22345,8 +22345,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -22364,8 +22364,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22391,8 +22391,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22448,8 +22448,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22483,8 +22483,8 @@ cert strategy template, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22498,7 +22498,7 @@ cert strategy template, admission enabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -22623,8 +22623,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -22649,8 +22649,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22678,8 +22678,8 @@ cert strategy template, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22696,7 +22696,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22772,8 +22772,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -22795,8 +22795,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -22814,8 +22814,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22841,8 +22841,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22898,8 +22898,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22933,8 +22933,8 @@ cert strategy template, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22948,7 +22948,7 @@ cert strategy template, admission enabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -23073,8 +23073,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -23103,8 +23103,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -23126,8 +23126,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -23145,8 +23145,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23174,8 +23174,8 @@ cert strategy template, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23192,7 +23192,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23260,7 +23260,7 @@ cert strategy template, admission enabled, mtls enabled:
 default capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.2.
+      Thank you for installing kubescape-operator version 1.40.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -23296,8 +23296,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -23344,8 +23344,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -23374,8 +23374,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23396,8 +23396,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23417,8 +23417,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -23435,8 +23435,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23465,8 +23465,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23519,8 +23519,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23554,8 +23554,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23582,8 +23582,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -23602,8 +23602,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23621,9 +23621,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23643,9 +23643,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -23660,7 +23660,7 @@ default capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -23705,8 +23705,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -23751,8 +23751,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24021,8 +24021,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24046,8 +24046,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24079,8 +24079,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24124,7 +24124,7 @@ default capabilities:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.8
+              image: quay.io/kubescape/kubescape:v4.0.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24229,8 +24229,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24248,8 +24248,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24314,8 +24314,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24345,8 +24345,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24371,8 +24371,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24401,8 +24401,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -24419,8 +24419,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -24452,8 +24452,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24471,9 +24471,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24493,9 +24493,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -24510,7 +24510,7 @@ default capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -24555,8 +24555,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -24601,8 +24601,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -24642,8 +24642,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -24667,8 +24667,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24697,8 +24697,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24723,7 +24723,7 @@ default capabilities:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.142
+              image: quay.io/kubescape/kubevuln:v0.3.146
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24818,8 +24818,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -24869,8 +24869,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -24898,8 +24898,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -25285,8 +25285,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25442,8 +25442,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -25513,8 +25513,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25532,8 +25532,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25560,8 +25560,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -25601,14 +25601,14 @@ default capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.119
+                  value: v0.3.129
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.119
+              image: quay.io/kubescape/node-agent:v0.3.129
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -25790,8 +25790,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -25847,8 +25847,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -26569,8 +26569,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -26612,8 +26612,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -26640,8 +26640,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -26658,8 +26658,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -26784,8 +26784,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -26841,8 +26841,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26860,8 +26860,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26896,8 +26896,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -26911,7 +26911,7 @@ default capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -27061,7 +27061,7 @@ default capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -27108,8 +27108,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27146,7 +27146,7 @@ default capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -27193,8 +27193,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27212,8 +27212,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27313,7 +27313,7 @@ default capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -27360,8 +27360,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27379,8 +27379,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27423,8 +27423,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27449,8 +27449,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27478,8 +27478,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27501,8 +27501,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -27520,8 +27520,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -27550,8 +27550,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -27573,8 +27573,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -27592,8 +27592,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -27658,8 +27658,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -27683,8 +27683,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -27724,8 +27724,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27743,8 +27743,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27772,8 +27772,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -27790,7 +27790,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -27867,8 +27867,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -27918,8 +27918,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -27942,8 +27942,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -27968,8 +27968,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -28292,8 +28292,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28321,8 +28321,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28339,8 +28339,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -28509,8 +28509,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -28812,8 +28812,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28831,8 +28831,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28862,8 +28862,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -28875,7 +28875,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -28887,7 +28887,7 @@ default capabilities:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.147
+              image: quay.io/kubescape/synchronizer:v0.0.149
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -28972,8 +28972,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29028,8 +29028,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29071,8 +29071,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29096,8 +29096,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29124,8 +29124,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29133,7 +29133,7 @@ default capabilities:
 disable otel:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.2.
+      Thank you for installing kubescape-operator version 1.40.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -29171,8 +29171,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -29218,8 +29218,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -29248,8 +29248,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29270,8 +29270,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29291,8 +29291,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -29311,8 +29311,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29330,9 +29330,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29352,9 +29352,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -29369,7 +29369,7 @@ disable otel:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -29415,8 +29415,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -29685,8 +29685,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -29710,8 +29710,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29742,8 +29742,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -29787,7 +29787,7 @@ disable otel:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.8
+              image: quay.io/kubescape/kubescape:v4.0.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -29877,8 +29877,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29896,8 +29896,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -29927,8 +29927,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -29953,8 +29953,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -29983,8 +29983,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30002,8 +30002,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30021,9 +30021,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30043,9 +30043,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -30060,7 +30060,7 @@ disable otel:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -30106,8 +30106,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30147,8 +30147,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30172,8 +30172,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30201,8 +30201,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -30227,7 +30227,7 @@ disable otel:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.142
+              image: quay.io/kubescape/kubevuln:v0.3.146
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -30307,8 +30307,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30336,8 +30336,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30723,8 +30723,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -30880,8 +30880,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -30951,8 +30951,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30970,8 +30970,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30997,8 +30997,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -31038,14 +31038,14 @@ disable otel:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.119
+                  value: v0.3.129
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.119
+              image: quay.io/kubescape/node-agent:v0.3.129
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -31209,8 +31209,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31237,8 +31237,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31259,8 +31259,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -31282,8 +31282,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -31301,8 +31301,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -31328,8 +31328,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -31385,8 +31385,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -31511,8 +31511,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -31568,8 +31568,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31587,8 +31587,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31622,8 +31622,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -31637,7 +31637,7 @@ disable otel:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -31781,7 +31781,7 @@ disable otel:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -31828,8 +31828,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31866,7 +31866,7 @@ disable otel:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -31913,8 +31913,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31951,7 +31951,7 @@ disable otel:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -31998,8 +31998,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32017,8 +32017,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32061,8 +32061,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32087,8 +32087,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32116,8 +32116,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -32134,8 +32134,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -32164,8 +32164,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -32187,8 +32187,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -32206,8 +32206,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -32272,8 +32272,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -32297,8 +32297,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -32338,8 +32338,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32357,8 +32357,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32386,8 +32386,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -32404,7 +32404,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -32481,8 +32481,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -32505,8 +32505,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -32531,8 +32531,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -32855,8 +32855,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -32884,8 +32884,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -32902,8 +32902,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33072,8 +33072,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33375,8 +33375,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33394,8 +33394,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33424,8 +33424,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -33437,7 +33437,7 @@ disable otel:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -33449,7 +33449,7 @@ disable otel:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.147
+              image: quay.io/kubescape/synchronizer:v0.0.149
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -33518,8 +33518,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33561,8 +33561,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33586,8 +33586,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33614,8 +33614,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -33623,7 +33623,7 @@ disable otel:
 minimal capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.2.
+      Thank you for installing kubescape-operator version 1.40.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -33665,8 +33665,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -33712,8 +33712,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -33742,8 +33742,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33764,8 +33764,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33785,8 +33785,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -33805,8 +33805,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33824,9 +33824,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33846,9 +33846,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -33863,7 +33863,7 @@ minimal capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -33909,8 +33909,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34179,8 +34179,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34204,8 +34204,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34236,8 +34236,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -34277,7 +34277,7 @@ minimal capabilities:
                   value: /home/nonroot/.kubescape/host-scanner.yaml
                 - name: LARGE_CLUSTER_SIZE
                   value: "1500"
-              image: quay.io/kubescape/kubescape:v4.0.8
+              image: quay.io/kubescape/kubescape:v4.0.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -34367,8 +34367,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34386,8 +34386,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34417,8 +34417,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34443,8 +34443,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34473,8 +34473,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -34492,8 +34492,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34511,9 +34511,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34533,9 +34533,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -34550,7 +34550,7 @@ minimal capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -34596,8 +34596,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -34637,8 +34637,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -34662,8 +34662,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34691,8 +34691,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -34715,7 +34715,7 @@ minimal capabilities:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.142
+              image: quay.io/kubescape/kubevuln:v0.3.146
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -34795,8 +34795,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -34824,8 +34824,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -35211,8 +35211,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -35368,8 +35368,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -35437,8 +35437,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35456,8 +35456,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35483,8 +35483,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -35527,12 +35527,12 @@ minimal capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.119
+                  value: v0.3.129
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.119
+              image: quay.io/kubescape/node-agent:v0.3.129
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -35696,8 +35696,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -35724,8 +35724,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -35746,8 +35746,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -35769,8 +35769,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -35788,8 +35788,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -35815,8 +35815,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -35872,8 +35872,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -35998,8 +35998,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -36053,8 +36053,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36072,8 +36072,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36107,8 +36107,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -36122,7 +36122,7 @@ minimal capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -36266,7 +36266,7 @@ minimal capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -36313,8 +36313,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36351,7 +36351,7 @@ minimal capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -36398,8 +36398,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36436,7 +36436,7 @@ minimal capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -36483,8 +36483,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36502,8 +36502,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -36546,8 +36546,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -36572,8 +36572,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -36601,8 +36601,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -36619,8 +36619,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -36649,8 +36649,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -36672,8 +36672,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -36691,8 +36691,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -36757,8 +36757,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -36782,8 +36782,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -36823,8 +36823,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36842,8 +36842,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36871,8 +36871,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -36889,7 +36889,7 @@ minimal capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -36966,8 +36966,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -36990,8 +36990,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -37016,8 +37016,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -37340,8 +37340,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -37369,8 +37369,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -37378,7 +37378,7 @@ minimal capabilities:
 multiple node agents:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.2.
+      Thank you for installing kubescape-operator version 1.40.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -37412,8 +37412,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -37432,8 +37432,8 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
-                helm.sh/chart: kubescape-operator-1.40.2
+                app.kubernetes.io/version: 1.40.3
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -37489,8 +37489,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -37533,8 +37533,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -37558,8 +37558,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -37584,8 +37584,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -37605,8 +37605,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -37653,8 +37653,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -37683,8 +37683,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37704,8 +37704,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -37727,8 +37727,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37748,8 +37748,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -37766,9 +37766,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37788,9 +37788,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -37844,8 +37844,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37875,9 +37875,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
+            app.kubernetes.io/version: 1.40.3
             bar: baz
-            helm.sh/chart: kubescape-operator-1.40.2
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -37933,8 +37933,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -37968,8 +37968,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -37993,8 +37993,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -38018,8 +38018,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -38046,8 +38046,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -38066,8 +38066,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38085,9 +38085,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38107,9 +38107,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -38124,7 +38124,7 @@ multiple node agents:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -38172,8 +38172,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -38224,8 +38224,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38510,8 +38510,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38535,8 +38535,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38568,8 +38568,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -38642,7 +38642,7 @@ multiple node agents:
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v4.0.8
+              image: quay.io/kubescape/kubescape:v4.0.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -38747,8 +38747,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38766,8 +38766,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38843,8 +38843,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38874,8 +38874,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38900,8 +38900,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -38926,8 +38926,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38956,8 +38956,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -38974,8 +38974,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -39007,8 +39007,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39026,9 +39026,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39048,9 +39048,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -39065,7 +39065,7 @@ multiple node agents:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -39113,8 +39113,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -39165,8 +39165,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -39215,8 +39215,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -39240,8 +39240,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39270,8 +39270,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -39300,7 +39300,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.142
+              image: quay.io/kubescape/kubevuln:v0.3.146
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -39396,8 +39396,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -39453,8 +39453,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -39477,8 +39477,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -39503,8 +39503,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -39532,8 +39532,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -39939,8 +39939,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -40096,8 +40096,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -40167,8 +40167,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40223,8 +40223,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40251,9 +40251,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
+            app.kubernetes.io/version: 1.40.3
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.2
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -40327,14 +40327,14 @@ multiple node agents:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.119
+                  value: v0.3.129
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.119
+              image: quay.io/kubescape/node-agent:v0.3.129
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -40516,8 +40516,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40544,9 +40544,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
+            app.kubernetes.io/version: 1.40.3
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.2
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -40620,14 +40620,14 @@ multiple node agents:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.119
+                  value: v0.3.129
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.119
+              image: quay.io/kubescape/node-agent:v0.3.129
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -40809,8 +40809,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -40860,8 +40860,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -41582,8 +41582,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -41641,8 +41641,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -41667,8 +41667,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -41695,8 +41695,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -41717,8 +41717,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -41740,8 +41740,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -41759,8 +41759,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -41786,8 +41786,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -41843,8 +41843,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42002,8 +42002,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42059,8 +42059,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42078,8 +42078,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42114,8 +42114,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -42129,7 +42129,7 @@ multiple node agents:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -42295,7 +42295,7 @@ multiple node agents:
                   - name: bar
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -42342,8 +42342,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42383,7 +42383,7 @@ multiple node agents:
                   - name: bar
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -42430,8 +42430,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42449,8 +42449,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42567,7 +42567,7 @@ multiple node agents:
                   - name: bar
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -42614,8 +42614,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42633,8 +42633,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42677,8 +42677,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42703,8 +42703,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -42729,8 +42729,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42758,8 +42758,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -42775,8 +42775,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -42803,8 +42803,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -42828,8 +42828,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -42854,8 +42854,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -42874,7 +42874,7 @@ multiple node agents:
                   value: zap
                 - name: ENABLE_WORKLOAD_METRICS
                   value: "true"
-              image: quay.io/kubescape/prometheus-exporter:v0.2.18
+              image: quay.io/kubescape/prometheus-exporter:v0.2.21
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 initialDelaySeconds: 3
@@ -42935,8 +42935,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -42993,8 +42993,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -43021,8 +43021,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -43039,8 +43039,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -43075,8 +43075,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -43094,8 +43094,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -43120,8 +43120,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -43186,8 +43186,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -43211,8 +43211,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -43249,8 +43249,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43268,8 +43268,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43297,8 +43297,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -43315,7 +43315,7 @@ multiple node agents:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -43389,8 +43389,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -43448,8 +43448,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -43472,8 +43472,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -43498,8 +43498,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -43524,8 +43524,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -43848,8 +43848,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -43877,8 +43877,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -43895,8 +43895,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44134,8 +44134,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44455,8 +44455,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44474,8 +44474,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44505,8 +44505,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -44518,7 +44518,7 @@ multiple node agents:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -44534,7 +44534,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.147
+              image: quay.io/kubescape/synchronizer:v0.0.149
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -44619,8 +44619,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44686,8 +44686,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44729,8 +44729,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44754,8 +44754,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -44779,8 +44779,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44807,8 +44807,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -44816,7 +44816,7 @@ multiple node agents:
 priority class scheduling:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.2.
+      Thank you for installing kubescape-operator version 1.40.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -44852,8 +44852,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -44899,8 +44899,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -44929,8 +44929,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44951,8 +44951,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44972,8 +44972,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -44992,8 +44992,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45011,9 +45011,9 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45033,9 +45033,9 @@ priority class scheduling:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -45050,7 +45050,7 @@ priority class scheduling:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -45097,8 +45097,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -45367,8 +45367,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -45392,8 +45392,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45424,8 +45424,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -45469,7 +45469,7 @@ priority class scheduling:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.8
+              image: quay.io/kubescape/kubescape:v4.0.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -45560,8 +45560,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45579,8 +45579,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -45610,8 +45610,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -45636,8 +45636,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -45666,8 +45666,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -45685,8 +45685,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45704,9 +45704,9 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45726,9 +45726,9 @@ priority class scheduling:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -45743,7 +45743,7 @@ priority class scheduling:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -45790,8 +45790,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -45831,8 +45831,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -45856,8 +45856,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -45885,8 +45885,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -45911,7 +45911,7 @@ priority class scheduling:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.142
+              image: quay.io/kubescape/kubevuln:v0.3.146
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -45992,8 +45992,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -46021,8 +46021,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -46408,8 +46408,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -46565,8 +46565,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -46636,8 +46636,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46655,8 +46655,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46682,8 +46682,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -46723,14 +46723,14 @@ priority class scheduling:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.119
+                  value: v0.3.129
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.119
+              image: quay.io/kubescape/node-agent:v0.3.129
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -46894,8 +46894,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -46922,8 +46922,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -46944,8 +46944,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -46967,8 +46967,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -46986,8 +46986,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -47013,8 +47013,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -47070,8 +47070,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47196,8 +47196,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47253,8 +47253,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47272,8 +47272,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47307,8 +47307,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -47322,7 +47322,7 @@ priority class scheduling:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -47467,7 +47467,7 @@ priority class scheduling:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -47514,8 +47514,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47552,7 +47552,7 @@ priority class scheduling:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -47599,8 +47599,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47637,7 +47637,7 @@ priority class scheduling:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -47684,8 +47684,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47703,8 +47703,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47747,8 +47747,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47773,8 +47773,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47802,8 +47802,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -47820,8 +47820,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -47850,8 +47850,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -47873,8 +47873,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -47892,8 +47892,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -47958,8 +47958,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -47983,8 +47983,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -48024,8 +48024,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48043,8 +48043,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48072,8 +48072,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -48090,7 +48090,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -48168,8 +48168,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -48192,8 +48192,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -48218,8 +48218,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -48542,8 +48542,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -48571,8 +48571,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -48589,8 +48589,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -48759,8 +48759,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -49062,8 +49062,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49081,8 +49081,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49111,8 +49111,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -49124,7 +49124,7 @@ priority class scheduling:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -49136,7 +49136,7 @@ priority class scheduling:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.147
+              image: quay.io/kubescape/synchronizer:v0.0.149
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -49206,8 +49206,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -49249,8 +49249,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -49274,8 +49274,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -49302,8 +49302,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -49311,7 +49311,7 @@ priority class scheduling:
 relevancy only:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.2.
+      Thank you for installing kubescape-operator version 1.40.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -49346,8 +49346,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -49393,8 +49393,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -49423,8 +49423,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49445,8 +49445,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49466,8 +49466,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -49486,8 +49486,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49505,9 +49505,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49527,9 +49527,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -49544,7 +49544,7 @@ relevancy only:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -49590,8 +49590,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -49860,8 +49860,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -49885,8 +49885,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49917,8 +49917,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -49958,7 +49958,7 @@ relevancy only:
                   value: /home/nonroot/.kubescape/host-scanner.yaml
                 - name: LARGE_CLUSTER_SIZE
                   value: "1500"
-              image: quay.io/kubescape/kubescape:v4.0.8
+              image: quay.io/kubescape/kubescape:v4.0.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -50048,8 +50048,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50067,8 +50067,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50098,8 +50098,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50124,8 +50124,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50154,8 +50154,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -50173,8 +50173,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50192,9 +50192,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50214,9 +50214,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -50231,7 +50231,7 @@ relevancy only:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -50277,8 +50277,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -50318,8 +50318,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -50343,8 +50343,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50372,8 +50372,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -50396,7 +50396,7 @@ relevancy only:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.142
+              image: quay.io/kubescape/kubevuln:v0.3.146
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -50476,8 +50476,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -50505,8 +50505,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -50892,8 +50892,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -51049,8 +51049,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -51118,8 +51118,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51137,8 +51137,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51164,8 +51164,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -51208,12 +51208,12 @@ relevancy only:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.119
+                  value: v0.3.129
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.119
+              image: quay.io/kubescape/node-agent:v0.3.129
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -51377,8 +51377,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -51405,8 +51405,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -51423,8 +51423,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -51549,8 +51549,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -51604,8 +51604,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51623,8 +51623,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51658,8 +51658,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -51673,7 +51673,7 @@ relevancy only:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -51808,7 +51808,7 @@ relevancy only:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -51855,8 +51855,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51893,7 +51893,7 @@ relevancy only:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -51940,8 +51940,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51978,7 +51978,7 @@ relevancy only:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -52025,8 +52025,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52044,8 +52044,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52088,8 +52088,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52114,8 +52114,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52143,8 +52143,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -52161,8 +52161,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -52191,8 +52191,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -52214,8 +52214,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -52233,8 +52233,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -52299,8 +52299,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -52324,8 +52324,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -52365,8 +52365,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52384,8 +52384,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52413,8 +52413,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -52431,7 +52431,7 @@ relevancy only:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -52508,8 +52508,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -52532,8 +52532,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -52558,8 +52558,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -52882,8 +52882,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -52911,8 +52911,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -52920,7 +52920,7 @@ relevancy only:
 skipPersistence enabled:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.2.
+      Thank you for installing kubescape-operator version 1.40.3.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -52954,8 +52954,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -52974,8 +52974,8 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
-                helm.sh/chart: kubescape-operator-1.40.2
+                app.kubernetes.io/version: 1.40.3
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -53031,8 +53031,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -53075,8 +53075,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -53100,8 +53100,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -53126,8 +53126,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -53147,8 +53147,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -53195,8 +53195,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -53225,8 +53225,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53246,8 +53246,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -53269,8 +53269,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53290,8 +53290,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -53308,9 +53308,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53330,9 +53330,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -53386,8 +53386,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53417,9 +53417,9 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
+            app.kubernetes.io/version: 1.40.3
             bar: baz
-            helm.sh/chart: kubescape-operator-1.40.2
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -53475,8 +53475,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -53510,8 +53510,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -53535,8 +53535,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -53560,8 +53560,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -53588,8 +53588,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -53608,8 +53608,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53627,9 +53627,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53649,9 +53649,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -53666,7 +53666,7 @@ skipPersistence enabled:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -53714,8 +53714,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -53766,8 +53766,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54052,8 +54052,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54077,8 +54077,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54110,8 +54110,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -54184,7 +54184,7 @@ skipPersistence enabled:
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v4.0.8
+              image: quay.io/kubescape/kubescape:v4.0.9
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -54289,8 +54289,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54308,8 +54308,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54385,8 +54385,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54416,8 +54416,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54442,8 +54442,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -54468,8 +54468,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54498,8 +54498,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -54516,8 +54516,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -54552,8 +54552,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54571,9 +54571,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
+        app.kubernetes.io/version: 1.40.3
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.2
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54593,9 +54593,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.2
+                app.kubernetes.io/version: 1.40.3
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.2
+                helm.sh/chart: kubescape-operator-1.40.3
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -54610,7 +54610,7 @@ skipPersistence enabled:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.19
+                  image: quay.io/kubescape/http-request:v0.2.20
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -54658,8 +54658,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -54710,8 +54710,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -54760,8 +54760,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -54785,8 +54785,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54815,8 +54815,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -54845,7 +54845,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.142
+              image: quay.io/kubescape/kubevuln:v0.3.146
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -54941,8 +54941,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -54998,8 +54998,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -55022,8 +55022,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -55048,8 +55048,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -55077,8 +55077,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -55484,8 +55484,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -55641,8 +55641,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -55712,8 +55712,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55768,8 +55768,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55796,9 +55796,9 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
+            app.kubernetes.io/version: 1.40.3
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.2
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -55872,14 +55872,14 @@ skipPersistence enabled:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.119
+                  value: v0.3.129
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.119
+              image: quay.io/kubescape/node-agent:v0.3.129
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -56060,8 +56060,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -56111,8 +56111,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -56833,8 +56833,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -56892,8 +56892,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -56918,8 +56918,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -56946,8 +56946,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -56968,8 +56968,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -56991,8 +56991,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -57010,8 +57010,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -57037,8 +57037,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -57094,8 +57094,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -57253,8 +57253,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -57310,8 +57310,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57329,8 +57329,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57365,8 +57365,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -57380,7 +57380,7 @@ skipPersistence enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -57546,7 +57546,7 @@ skipPersistence enabled:
                   - name: bar
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -57593,8 +57593,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57634,7 +57634,7 @@ skipPersistence enabled:
                   - name: bar
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -57681,8 +57681,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57700,8 +57700,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -57818,7 +57818,7 @@ skipPersistence enabled:
                   - name: bar
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.19"
+                    image: "quay.io/kubescape/http-request:v0.2.20"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -57865,8 +57865,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57884,8 +57884,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -57928,8 +57928,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -57954,8 +57954,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -57980,8 +57980,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58009,8 +58009,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58026,8 +58026,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58054,8 +58054,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58079,8 +58079,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58105,8 +58105,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -58125,7 +58125,7 @@ skipPersistence enabled:
                   value: zap
                 - name: ENABLE_WORKLOAD_METRICS
                   value: "true"
-              image: quay.io/kubescape/prometheus-exporter:v0.2.18
+              image: quay.io/kubescape/prometheus-exporter:v0.2.21
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 initialDelaySeconds: 3
@@ -58186,8 +58186,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58244,8 +58244,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58272,8 +58272,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58290,8 +58290,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -58326,8 +58326,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -58345,8 +58345,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -58371,8 +58371,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -58437,8 +58437,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -58462,8 +58462,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -58500,8 +58500,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58519,8 +58519,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58548,8 +58548,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -58566,7 +58566,7 @@ skipPersistence enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.274
+              image: quay.io/kubescape/storage:v0.0.278
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -58640,8 +58640,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -58699,8 +58699,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -58723,8 +58723,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -58749,8 +58749,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -58775,8 +58775,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -59099,8 +59099,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -59128,8 +59128,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -59146,8 +59146,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -59385,8 +59385,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -59706,8 +59706,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -59725,8 +59725,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -59756,8 +59756,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.2
-            helm.sh/chart: kubescape-operator-1.40.2
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -59769,7 +59769,7 @@ skipPersistence enabled:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.2
+                  value: kubescape-operator-1.40.3
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -59785,7 +59785,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.147
+              image: quay.io/kubescape/synchronizer:v0.0.149
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -59870,8 +59870,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -59937,8 +59937,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -59980,8 +59980,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -60005,8 +60005,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -60030,8 +60030,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -60058,8 +60058,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -60087,8 +60087,8 @@ with multiple private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets
@@ -60125,8 +60125,8 @@ with single private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.2
-        helm.sh/chart: kubescape-operator-1.40.2
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -15718,12 +15718,20 @@ autoscaler mode without sbom sidecar:
         tier: ks-control-plane
       name: synchronizer
       namespace: kubescape
-backend-storage enabled disables scanning capabilities:
+backend-storage enabled allows scanning capabilities:
   1: |+
     raw: |+
       Thank you for installing kubescape-operator version 1.40.3.
+      View your cluster's configuration scanning schedule:
+      > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
+      To change the schedule, set `.spec.schedule`:
+      > kubectl -n kubescape edit cj kubescape-scheduler
+      View your cluster's image scanning schedule:
+      > kubectl -n kubescape get cj kubevuln-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
+      To change the schedule, edit `.spec.schedule`:
+      > kubectl -n kubescape edit cj kubevuln-scheduler
 
       View your image vulnerabilities scan summaries:
       > kubectl get vulnerabilitymanifestsummaries -A
@@ -15769,11 +15777,11 @@ backend-storage enabled disables scanning capabilities:
           "kubevulnURL": "kubevuln:8080",
           "kubescapeURL": "kubescape:8080",
           "clusterName": "kind-kind",
-          "storage": false,
+          "storage": true,
           "relevantImageVulnerabilitiesEnabled": true,
           "namespace": "kubescape",
-          "imageVulnerabilitiesScanningEnabled": false,
-          "postureScanEnabled": false,
+          "imageVulnerabilitiesScanningEnabled": true,
+          "postureScanEnabled": true,
           "nodeAgent": "true",
           "maxImageSize": 5.36870912e+09,
           "maxSBOMSize": 2.097152e+07,
@@ -15814,7 +15822,7 @@ backend-storage enabled disables scanning capabilities:
           "capabilities":{"admissionController":"enable","autoUpgrading":"disable","backend-storage":"enable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","remediation":"disable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "effectiveCapabilities":{"configurationScan":"backend","httpDetection":"disable","networkEventsStreaming":"enable","nodeProfileService":"enable","nodeScan":"backend","vulnerabilityScan":"backend"},
           "capabilityWarnings":["capabilities.httpDetection=enable but capabilities.runtimeDetection is not enabled. HTTP detection runs on top of runtime detection, so httpDetectionEnabled renders as FALSE in the node-agent configmap. To use it, set capabilities.runtimeDetection=enable."],
-          "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":false},"kubescapeScheduler":{"enabled":false},"kubevuln":{"enabled":false},"kubevulnScheduler":{"enabled":false},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":false},"synchronizer":{"enabled":true}},
+          "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
         }
@@ -15878,6 +15886,1051 @@ backend-storage enabled disables scanning capabilities:
       name: kubescape-critical
     value: 1.000001e+08
   7: |
+    apiVersion: v1
+    data:
+      request-body.json: '{"commands":[{"CommandName":"kubescapeScan","args":{"scanV1":{}}}]}'
+    kind: ConfigMap
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape-scheduler
+        app.kubernetes.io/component: kubescape-scheduler
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubescape-scheduler
+      namespace: kubescape
+  8: |
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape-scheduler
+        app.kubernetes.io/component: kubescape-scheduler
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        armo.tier: kubescape-scan
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubescape-scheduler
+      namespace: kubescape
+    spec:
+      failedJobsHistoryLimit: 1
+      jobTemplate:
+        spec:
+          template:
+            metadata:
+              annotations: null
+              labels:
+                app: kubescape-scheduler
+                app.kubernetes.io/component: kubescape-scheduler
+                app.kubernetes.io/instance: RELEASE-NAME
+                app.kubernetes.io/managed-by: Helm
+                app.kubernetes.io/name: kubescape-operator
+                app.kubernetes.io/part-of: kubescape
+                app.kubernetes.io/version: 1.40.3
+                armo.tier: kubescape-scan
+                helm.sh/chart: kubescape-operator-1.40.3
+                kubescape.io/ignore: "true"
+                kubescape.io/tier: core
+                tier: ks-control-plane
+            spec:
+              affinity: null
+              automountServiceAccountToken: false
+              containers:
+                - args:
+                    - -method=post
+                    - -scheme=http
+                    - -host=operator:4002
+                    - -path=v1/triggerAction
+                    - -headers=Content-Type:application/json
+                    - -path-body=/home/ks/request-body.json
+                  image: quay.io/kubescape/http-request:v0.2.20
+                  imagePullPolicy: IfNotPresent
+                  name: kubescape-scheduler
+                  resources:
+                    limits:
+                      cpu: 10m
+                      memory: 20Mi
+                    requests:
+                      cpu: 1m
+                      memory: 10Mi
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: true
+                    runAsNonRoot: true
+                    runAsUser: 100
+                  volumeMounts:
+                    - mountPath: /home/ks/request-body.json
+                      name: kubescape-scheduler
+                      readOnly: true
+                      subPath: request-body.json
+              nodeSelector:
+                kubernetes.io/os: linux
+              restartPolicy: Never
+              securityContext:
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: kubescape
+              tolerations: null
+              volumes:
+                - configMap:
+                    name: kubescape-scheduler
+                  name: kubescape-scheduler
+      schedule: 0 4 * * *
+      successfulJobsHistoryLimit: 3
+  9: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+          - pods/proxy
+          - namespaces
+          - nodes
+          - configmaps
+          - services
+          - serviceaccounts
+          - endpoints
+          - persistentvolumeclaims
+          - persistentvolumes
+          - limitranges
+          - replicationcontrollers
+          - podtemplates
+          - resourcequotas
+          - events
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - admissionregistration.k8s.io
+        resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - apiregistration.k8s.io
+        resources:
+          - apiservices
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - apps
+        resources:
+          - deployments
+          - statefulsets
+          - daemonsets
+          - replicasets
+          - controllerrevisions
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - autoscaling
+        resources:
+          - horizontalpodautoscalers
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - batch
+        resources:
+          - jobs
+          - cronjobs
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - events.k8s.io
+        resources:
+          - events
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - hostdata.kubescape.cloud
+        resources:
+          - APIServerInfo
+          - ControlPlaneInfo
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - networkpolicies
+          - Ingress
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - cilium.io
+        resources:
+          - ciliumnetworkpolicies
+          - ciliumclusterwidenetworkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - projectcalico.org
+        resources:
+          - networkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - networking.istio.io
+        resources:
+          - gateways
+          - virtualservices
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - security.istio.io
+        resources:
+          - authorizationpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - policy
+        resources:
+          - poddisruptionbudgets
+          - podsecuritypolicies
+          - PodSecurityPolicy
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - csistoragecapacities
+          - storageclasses
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - extensions
+        resources:
+          - Ingress
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - httproutes
+          - gateways
+          - gatewayclasses
+          - tcproutes
+          - tlsroutes
+          - udproutes
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+        verbs:
+          - update
+      - apiGroups:
+          - spdx.softwarecomposition.kubescape.io
+        resources:
+          - workloadconfigurationscans
+          - workloadconfigurationscansummaries
+        verbs:
+          - create
+          - get
+          - update
+          - patch
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - servicesscanresults
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - hostdata.kubescape.cloud
+        resources:
+          - osreleasefiles
+          - kernelversions
+          - linuxsecurityhardeningstatuses
+          - openportslists
+          - linuxkernelvariables
+          - kubeletinfos
+          - kubeproxyinfos
+          - controlplaneinfos
+          - cloudproviderinfos
+          - cniinfos
+        verbs:
+          - get
+          - list
+          - watch
+  10: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: kubescape
+    subjects:
+      - kind: ServiceAccount
+        name: kubescape
+        namespace: kubescape
+  11: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubescape
+      namespace: kubescape
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: kubescape
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: kubescape-operator
+      strategy:
+        rollingUpdate:
+          maxSurge: 0%
+          maxUnavailable: 100%
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
+            checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
+          labels:
+            app: kubescape
+            app.kubernetes.io/component: kubescape
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: kubescape-operator
+            app.kubernetes.io/part-of: kubescape
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
+            kubescape.io/ignore: "true"
+            kubescape.io/tier: core
+            tier: ks-control-plane
+        spec:
+          affinity: null
+          automountServiceAccountToken: true
+          containers:
+            - command:
+                - ksserver
+              env:
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      divisor: "1"
+                      resource: limits.memory
+                - name: KS_LOGGER_LEVEL
+                  value: info
+                - name: KS_LOGGER_NAME
+                  value: zap
+                - name: KS_DOWNLOAD_ARTIFACTS
+                  value: "true"
+                - name: KS_DEFAULT_CONFIGMAP_NAME
+                  value: kubescape-config
+                - name: KS_DEFAULT_CONFIGMAP_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: KS_CONTEXT
+                  value: kind-kind
+                - name: KS_DEFAULT_CLOUD_CONFIGMAP_NAME
+                  value: ks-cloud-config
+                - name: KS_ENABLE_HOST_SCANNER
+                  value: "true"
+                - name: KS_SKIP_UPDATE_CHECK
+                  value: "false"
+                - name: KS_HOST_SCAN_YAML
+                  value: /home/nonroot/.kubescape/host-scanner.yaml
+                - name: LARGE_CLUSTER_SIZE
+                  value: "1500"
+                - name: API_URL
+                  value: https://api.armosec.io
+                - name: KS_EXCLUDE_NAMESPACES
+                  value: kubescape,kube-system,kube-public,kube-node-lease
+              image: quay.io/kubescape/kubescape:v4.0.9
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /livez
+                  port: 8080
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              name: kubescape
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8080
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              resources:
+                limits:
+                  cpu: 600m
+                  memory: 1Gi
+                requests:
+                  cpu: 250m
+                  memory: 400Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              volumeMounts:
+                - mountPath: /etc/credentials
+                  name: cloud-secret
+                  readOnly: true
+                - mountPath: /home/nonroot/.kubescape
+                  name: kubescape-volume
+                  subPath: config.json
+                - mountPath: /home/nonroot/.kubescape/host-scanner.yaml
+                  name: host-scanner-definition
+                  subPath: host-scanner-yaml
+                - mountPath: /home/nonroot/results
+                  name: results
+                - mountPath: /home/nonroot/failed
+                  name: failed
+                - mountPath: /etc/config/clusterData.json
+                  name: ks-cloud-config
+                  readOnly: true
+                  subPath: clusterData.json
+          nodeSelector:
+            kubernetes.io/os: linux
+          securityContext:
+            fsGroup: 65532
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: kubescape
+          tolerations: null
+          volumes:
+            - name: cloud-secret
+              secret:
+                secretName: cloud-secret
+            - configMap:
+                items:
+                  - key: clusterData
+                    path: clusterData.json
+                name: ks-cloud-config
+              name: ks-cloud-config
+            - configMap:
+                name: host-scanner-definition
+              name: host-scanner-definition
+            - emptyDir: {}
+              name: kubescape-volume
+            - emptyDir: {}
+              name: results
+            - emptyDir: {}
+              name: failed
+  12: |
+    apiVersion: v1
+    data:
+      host-scanner-yaml: ""
+    kind: ConfigMap
+    metadata:
+      annotations: null
+      labels:
+        app: ks-cloud-config
+        app.kubernetes.io/component: ks-cloud-config
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: host-scanner-definition
+      namespace: kubescape
+  13: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape
+      namespace: kubescape
+    rules:
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+        verbs:
+          - create
+          - get
+          - update
+          - watch
+          - list
+          - patch
+          - delete
+  14: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape
+      namespace: kubescape
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: kubescape
+    subjects:
+      - kind: ServiceAccount
+        name: kubescape
+        namespace: kubescape
+  15: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape
+      namespace: kubescape
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
+  16: |
+    apiVersion: v1
+    automountServiceAccountToken: false
+    kind: ServiceAccount
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape
+      namespace: kubescape
+  17: |
+    apiVersion: v1
+    data:
+      request-body.json: '{"commands":[{"commandName":"scan","designators":[{"designatorType":"Attributes","attributes":{}}]}]}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: kubevuln-scheduler
+        app.kubernetes.io/component: kubevuln-scheduler
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubevuln-scheduler
+      namespace: kubescape
+  18: |
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      annotations: null
+      labels:
+        app: kubevuln-scheduler
+        app.kubernetes.io/component: kubevuln-scheduler
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        armo.tier: vuln-scan
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubevuln-scheduler
+      namespace: kubescape
+    spec:
+      failedJobsHistoryLimit: 1
+      jobTemplate:
+        spec:
+          template:
+            metadata:
+              annotations: null
+              labels:
+                app: kubevuln-scheduler
+                app.kubernetes.io/component: kubevuln-scheduler
+                app.kubernetes.io/instance: RELEASE-NAME
+                app.kubernetes.io/managed-by: Helm
+                app.kubernetes.io/name: kubescape-operator
+                app.kubernetes.io/part-of: kubescape
+                app.kubernetes.io/version: 1.40.3
+                armo.tier: vuln-scan
+                helm.sh/chart: kubescape-operator-1.40.3
+                kubescape.io/ignore: "true"
+                kubescape.io/tier: core
+                tier: ks-control-plane
+            spec:
+              affinity: null
+              automountServiceAccountToken: false
+              containers:
+                - args:
+                    - -method=post
+                    - -scheme=http
+                    - -host=operator:4002
+                    - -path=v1/triggerAction
+                    - -headers=Content-Type:application/json
+                    - -path-body=/home/ks/request-body.json
+                  image: quay.io/kubescape/http-request:v0.2.20
+                  imagePullPolicy: IfNotPresent
+                  name: kubevuln-scheduler
+                  resources:
+                    limits:
+                      cpu: 10m
+                      memory: 20Mi
+                    requests:
+                      cpu: 1m
+                      memory: 10Mi
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: true
+                    runAsNonRoot: true
+                    runAsUser: 100
+                  volumeMounts:
+                    - mountPath: /home/ks/request-body.json
+                      name: kubevuln-scheduler
+                      readOnly: true
+                      subPath: request-body.json
+              nodeSelector:
+                kubernetes.io/os: linux
+              restartPolicy: Never
+              securityContext:
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: kubevuln
+              tolerations: null
+              volumes:
+                - configMap:
+                    name: kubevuln-scheduler
+                  name: kubevuln-scheduler
+      schedule: 0 4 * * *
+      successfulJobsHistoryLimit: 3
+  19: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations: null
+      labels:
+        app: kubevuln
+        app.kubernetes.io/component: kubevuln
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubevuln
+    rules:
+      - apiGroups:
+          - spdx.softwarecomposition.kubescape.io
+        resources:
+          - vulnerabilitymanifests
+          - vulnerabilitymanifestsummaries
+          - openvulnerabilityexchangecontainers
+          - sbomsyfts
+          - sbomsyftfiltereds
+        verbs:
+          - create
+          - get
+          - update
+          - watch
+          - list
+          - patch
+      - apiGroups:
+          - spdx.softwarecomposition.kubescape.io
+        resources:
+          - containerprofiles
+        verbs:
+          - get
+          - watch
+          - list
+  20: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: kubevuln
+        app.kubernetes.io/component: kubevuln
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubevuln
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: kubevuln
+    subjects:
+      - kind: ServiceAccount
+        name: kubevuln
+        namespace: kubescape
+  21: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations: null
+      labels:
+        app: kubevuln
+        app.kubernetes.io/component: kubevuln
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubevuln
+      namespace: kubescape
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: kubevuln
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: kubescape-operator
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          annotations:
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
+            checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
+          labels:
+            app: kubevuln
+            app.kubernetes.io/component: kubevuln
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: kubescape-operator
+            app.kubernetes.io/part-of: kubescape
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
+            kubescape.io/ignore: "true"
+            kubescape.io/tier: core
+            tier: ks-control-plane
+        spec:
+          affinity: null
+          automountServiceAccountToken: true
+          containers:
+            - args:
+                - -alsologtostderr
+                - -v=4
+                - 2>&1
+              env:
+                - name: GOMEMLIMIT
+                  value: 4000MiB
+                - name: KS_LOGGER_LEVEL
+                  value: info
+                - name: KS_LOGGER_NAME
+                  value: zap
+                - name: PRINT_POST_JSON
+                  value: ""
+                - name: API_URL
+                  value: https://api.armosec.io
+                - name: CA_MAX_VULN_SCAN_ROUTINES
+                  value: "1"
+              image: quay.io/kubescape/kubevuln:v0.3.146
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /v1/liveness
+                  port: 8080
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              name: kubevuln
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /v1/readiness
+                  port: 8080
+              resources:
+                limits:
+                  cpu: 1500m
+                  ephemeral-storage: 10Gi
+                  memory: 5000Mi
+                requests:
+                  cpu: 300m
+                  ephemeral-storage: 5Gi
+                  memory: 1000Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              volumeMounts:
+                - mountPath: /etc/credentials
+                  name: cloud-secret
+                  readOnly: true
+                - mountPath: /tmp
+                  name: tmp-dir
+                - mountPath: /home/nonroot/anchore-resources/db
+                  name: grype-db-cache
+                - mountPath: /etc/config/clusterData.json
+                  name: ks-cloud-config
+                  readOnly: true
+                  subPath: clusterData.json
+                - mountPath: /home/nonroot/.cache/grype
+                  name: grype-db
+          nodeSelector:
+            kubernetes.io/os: linux
+          securityContext:
+            fsGroup: 65532
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: kubevuln
+          tolerations: null
+          volumes:
+            - name: cloud-secret
+              secret:
+                secretName: cloud-secret
+            - emptyDir: {}
+              name: tmp-dir
+            - emptyDir: {}
+              name: grype-db-cache
+            - configMap:
+                items:
+                  - key: clusterData
+                    path: clusterData.json
+                name: ks-cloud-config
+              name: ks-cloud-config
+            - emptyDir: {}
+              name: grype-db
+  22: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app: kubevuln
+        app.kubernetes.io/component: kubevuln
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubevuln
+      namespace: kubescape
+    spec:
+      ports:
+        - port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app.kubernetes.io/component: kubevuln
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
+  23: |
+    apiVersion: v1
+    automountServiceAccountToken: false
+    kind: ServiceAccount
+    metadata:
+      annotations: null
+      labels:
+        app: kubevuln
+        app.kubernetes.io/component: kubevuln
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubevuln
+      namespace: kubescape
+  24: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -15911,7 +16964,7 @@ backend-storage enabled disables scanning capabilities:
               type: object
           served: true
           storage: true
-  8: |
+  25: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -15945,7 +16998,7 @@ backend-storage enabled disables scanning capabilities:
               type: object
           served: true
           storage: true
-  9: |
+  26: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -15979,7 +17032,7 @@ backend-storage enabled disables scanning capabilities:
               type: object
           served: true
           storage: true
-  10: |
+  27: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -16013,7 +17066,7 @@ backend-storage enabled disables scanning capabilities:
               type: object
           served: true
           storage: true
-  11: |
+  28: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -16047,7 +17100,7 @@ backend-storage enabled disables scanning capabilities:
               type: object
           served: true
           storage: true
-  12: |
+  29: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -16081,7 +17134,7 @@ backend-storage enabled disables scanning capabilities:
               type: object
           served: true
           storage: true
-  13: |
+  30: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -16115,7 +17168,7 @@ backend-storage enabled disables scanning capabilities:
               type: object
           served: true
           storage: true
-  14: |
+  31: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -16149,7 +17202,7 @@ backend-storage enabled disables scanning capabilities:
               type: object
           served: true
           storage: true
-  15: |
+  32: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -16183,7 +17236,7 @@ backend-storage enabled disables scanning capabilities:
               type: object
           served: true
           storage: true
-  16: |
+  33: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -16246,7 +17299,7 @@ backend-storage enabled disables scanning capabilities:
               type: object
           served: true
           storage: true
-  17: |
+  34: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -16403,7 +17456,7 @@ backend-storage enabled disables scanning capabilities:
           - patch
           - list
           - watch
-  18: |
+  35: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -16428,7 +17481,7 @@ backend-storage enabled disables scanning capabilities:
       - kind: ServiceAccount
         name: node-agent
         namespace: kubescape
-  19: |
+  36: |
     apiVersion: v1
     data:
       config.json: |
@@ -16493,7 +17546,7 @@ backend-storage enabled disables scanning capabilities:
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
-  20: |
+  37: |
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
@@ -16521,7 +17574,7 @@ backend-storage enabled disables scanning capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: d0e00780bee5d2b3a068ad95ac2665cea1cb3b89c3aae81a1fe7659701877dda
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/node-agent-config: eb96c3c46f1b0866faae15793e5b3f9d521ee6d48ac042d8fdc9bef3347b0868
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
@@ -16732,7 +17785,7 @@ backend-storage enabled disables scanning capabilities:
                     path: config.json
                 name: node-agent
               name: config
-  21: |
+  38: |
     apiVersion: kubescape.io/v1
     kind: RuntimeRuleAlertBinding
     metadata:
@@ -16786,7 +17839,7 @@ backend-storage enabled disables scanning capabilities:
         - ruleName: Unexpected Egress Network Traffic
         - ruleName: Malicious Ptrace Usage
         - ruleName: Unexpected io_uring Operation Detected
-  22: |
+  39: |
     apiVersion: kubescape.io/v1
     kind: Rules
     metadata:
@@ -17508,7 +18561,7 @@ backend-storage enabled disables scanning capabilities:
             - context:kubernetes
             - admission
             - network
-  23: |
+  40: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -17536,7 +18589,7 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/component: node-agent
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
-  24: |
+  41: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -17554,7 +18607,7 @@ backend-storage enabled disables scanning capabilities:
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
-  25: |
+  42: |
     apiVersion: v1
     data:
       tls.crt: bW9jay1jYS1jZXJ0
@@ -17577,7 +18630,7 @@ backend-storage enabled disables scanning capabilities:
       name: kubescape-admission-webhook-ca
       namespace: kubescape
     type: kubernetes.io/tls
-  26: |
+  43: |
     apiVersion: v1
     data:
       ca.crt: bW9jay1jYS1jZXJ0
@@ -17600,7 +18653,7 @@ backend-storage enabled disables scanning capabilities:
       name: kubescape-admission-webhook-tls
       namespace: kubescape
     type: kubernetes.io/tls
-  27: |
+  44: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -17627,7 +18680,7 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  28: |
+  45: |
     apiVersion: admissionregistration.k8s.io/v1
     kind: ValidatingWebhookConfiguration
     metadata:
@@ -17684,7 +18737,7 @@ backend-storage enabled disables scanning capabilities:
               - networkpolicies
             scope: '*'
         sideEffects: None
-  29: |
+  46: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -17810,7 +18863,7 @@ backend-storage enabled disables scanning capabilities:
           - list
           - update
           - patch
-  30: |
+  47: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -17835,7 +18888,7 @@ backend-storage enabled disables scanning capabilities:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  31: |
+  48: |
     apiVersion: v1
     data:
       config.json: |
@@ -17886,7 +18939,7 @@ backend-storage enabled disables scanning capabilities:
         tier: ks-control-plane
       name: operator
       namespace: kubescape
-  32: |
+  49: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -17921,8 +18974,8 @@ backend-storage enabled disables scanning capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 558d7399a4715d3ac4656f83a36fb5b81b48b49b09fa16cdcd23cecf0f01dc57
-            checksum/cloud-config: d0e00780bee5d2b3a068ad95ac2665cea1cb3b89c3aae81a1fe7659701877dda
+            checksum/capabilities-config: b58e056d8a41039566abe42d17ae06cf4fbfb303f71414da9d948dbbba34e4a2
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: f52c7c610627e0f7441d7e1fec39106e63ed9c2a7aa1f57e0323fef7d786cf2f
@@ -18061,7 +19114,7 @@ backend-storage enabled disables scanning capabilities:
                     path: matchingRules.json
                 name: cs-matching-rules
               name: cs-matching-rules
-  33: |
+  50: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -18146,7 +19199,7 @@ backend-storage enabled disables scanning capabilities:
         tier: ks-control-plane
       name: kubescape-cronjob-template
       namespace: kubescape
-  34: |
+  51: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -18231,7 +19284,7 @@ backend-storage enabled disables scanning capabilities:
         tier: ks-control-plane
       name: kubevuln-cronjob-template
       namespace: kubescape
-  35: |
+  52: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -18316,7 +19369,7 @@ backend-storage enabled disables scanning capabilities:
         tier: ks-control-plane
       name: registry-scan-cronjob-template
       namespace: kubescape
-  36: |
+  53: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -18360,7 +19413,7 @@ backend-storage enabled disables scanning capabilities:
           - list
           - patch
           - delete
-  37: |
+  54: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -18386,7 +19439,7 @@ backend-storage enabled disables scanning capabilities:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  38: |
+  55: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -18414,7 +19467,7 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  39: |
+  56: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -18433,7 +19486,33 @@ backend-storage enabled disables scanning capabilities:
         tier: ks-control-plane
       name: operator
       namespace: kubescape
-  40: |
+  57: |
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: v1beta1.spdx.softwarecomposition.kubescape.io
+    spec:
+      caBundle: bW9jay1jYS1jZXJ0
+      group: spdx.softwarecomposition.kubescape.io
+      groupPriorityMinimum: 1000
+      service:
+        name: storage
+        namespace: kubescape
+      version: v1beta1
+      versionPriority: 15
+  58: |
     apiVersion: v1
     data:
       tls.crt: bW9jay1jYS1jZXJ0
@@ -18456,7 +19535,7 @@ backend-storage enabled disables scanning capabilities:
       name: storage-tls-ca
       namespace: kubescape
     type: kubernetes.io/tls
-  41: |
+  59: |
     apiVersion: v1
     data:
       ca.crt: bW9jay1jYS1jZXJ0
@@ -18479,7 +19558,332 @@ backend-storage enabled disables scanning capabilities:
       name: storage-tls
       namespace: kubescape
     type: kubernetes.io/tls
-  42: |
+  60: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+          - pods
+          - services
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - admissionregistration.k8s.io
+        resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - batch
+        resources:
+          - cronjobs
+          - jobs
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - flowcontrol.apiserver.k8s.io
+        resources:
+          - prioritylevelconfigurations
+          - flowschemas
+        verbs:
+          - get
+          - watch
+          - list
+  61: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage:system:auth-delegator
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:auth-delegator
+    subjects:
+      - kind: ServiceAccount
+        name: storage
+        namespace: kubescape
+  62: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: storage
+    subjects:
+      - kind: ServiceAccount
+        name: storage
+        namespace: kubescape
+  63: |
+    apiVersion: v1
+    data:
+      config.json: |
+        {
+          "cleanupInterval": "6h",
+          "disableVirtualCRDs": true,
+          "disableSeccompProfileEndpoint": true,
+          "excludeJsonPaths": null,
+          "defaultQueueLength": 100,
+          "defaultWorkerCount": 2,
+          "defaultMaxObjectSize": 400000,
+          "queueManagerEnabled": true,
+          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+          "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
+          "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
+          "serverBindPort": "8443"
+        }
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: storage
+      namespace: kubescape
+  64: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: storage
+      namespace: kubescape
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: storage
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: kubescape-operator
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          annotations:
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
+            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+          labels:
+            app: storage
+            app.kubernetes.io/component: storage
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: kubescape-operator
+            app.kubernetes.io/part-of: kubescape
+            app.kubernetes.io/version: 1.40.3
+            helm.sh/chart: kubescape-operator-1.40.3
+            kubescape.io/ignore: "true"
+            kubescape.io/tier: core
+            tier: ks-control-plane
+        spec:
+          affinity: null
+          containers:
+            - env:
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      divisor: "1"
+                      resource: limits.memory
+                - name: KS_LOGGER_LEVEL
+                  value: info
+                - name: KS_LOGGER_NAME
+                  value: zap
+              image: quay.io/kubescape/storage:v0.0.278
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /livez
+                  port: 8443
+                  scheme: HTTPS
+              name: apiserver
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8443
+                  scheme: HTTPS
+              resources:
+                limits:
+                  cpu: 1500m
+                  memory: 1500Mi
+                requests:
+                  cpu: 100m
+                  memory: 400Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+              volumeMounts:
+                - mountPath: /data
+                  name: data
+                - mountPath: /etc/config/clusterData.json
+                  name: ks-cloud-config
+                  readOnly: true
+                  subPath: clusterData.json
+                - mountPath: /etc/config/config.json
+                  name: config
+                  readOnly: true
+                  subPath: config.json
+                - mountPath: /etc/storage-ca-certificates
+                  name: ca-certificates
+                  readOnly: true
+          nodeSelector:
+            kubernetes.io/os: linux
+          securityContext:
+            fsGroup: 65532
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: storage
+          tolerations: null
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: kubescape-storage
+            - configMap:
+                items:
+                  - key: clusterData
+                    path: clusterData.json
+                name: ks-cloud-config
+              name: ks-cloud-config
+            - configMap:
+                items:
+                  - key: config.json
+                    path: config.json
+                name: storage
+              name: config
+            - name: ca-certificates
+              secret:
+                secretName: storage-tls
+  65: |
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape-storage
+      namespace: kubescape
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+  66: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage-auth-reader
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+      - kind: ServiceAccount
+        name: storage
+        namespace: kubescape
+  67: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -18803,7 +20207,54 @@ backend-storage enabled disables scanning capabilities:
           storage: true
           subresources:
             status: {}
-  43: |
+  68: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage
+      namespace: kubescape
+    spec:
+      ports:
+        - name: https
+          port: 443
+          protocol: TCP
+          targetPort: 8443
+      selector:
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
+  69: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.3
+        helm.sh/chart: kubescape-operator-1.40.3
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage
+      namespace: kubescape
+  70: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -18974,7 +20425,7 @@ backend-storage enabled disables scanning capabilities:
           - update
           - patch
           - delete
-  44: |
+  71: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -18998,7 +20449,7 @@ backend-storage enabled disables scanning capabilities:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  45: |
+  72: |
     apiVersion: v1
     data:
       config.json: |
@@ -19145,6 +20596,30 @@ backend-storage enabled disables scanning capabilities:
                 "strategy": "patch"
               },
               {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
+                "resource": "applicationprofiles",
+                "strategy": "copy"
+              },
+              {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
+                "resource": "containerprofiles",
+                "strategy": "copy"
+              },
+              {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
+                "resource": "knownservers",
+                "strategy": "copy"
+              },
+              {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
+                "resource": "networkneighborhoods",
+                "strategy": "copy"
+              },
+              {
                 "group": "cilium.io",
                 "version": "v2",
                 "resource": "ciliumnetworkpolicies",
@@ -19271,7 +20746,7 @@ backend-storage enabled disables scanning capabilities:
         tier: ks-control-plane
       name: synchronizer
       namespace: kubescape
-  46: |
+  73: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -19303,9 +20778,9 @@ backend-storage enabled disables scanning capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: d0e00780bee5d2b3a068ad95ac2665cea1cb3b89c3aae81a1fe7659701877dda
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: 5b74632f016d9c39500eebe8e60adaa9f8543666d1517cd2dfb68f0a695ba41a
+            checksum/synchronizer-configmap: 89c4293fcd32cc7a3ee95ac49975a088c1eee7af72a1712948fa24960c0dcd6a
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -19396,7 +20871,7 @@ backend-storage enabled disables scanning capabilities:
                     path: config.json
                 name: synchronizer
               name: config
-  47: |
+  74: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -19439,7 +20914,7 @@ backend-storage enabled disables scanning capabilities:
           - list
           - patch
           - delete
-  48: |
+  75: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -19464,7 +20939,7 @@ backend-storage enabled disables scanning capabilities:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  49: |
+  76: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -19491,7 +20966,7 @@ backend-storage enabled disables scanning capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  50: |
+  77: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -515,7 +515,7 @@ tests:
         enableWorkloadMetrics: true
         serviceMonitor:
           enabled: true
-  - it: backend-storage enabled disables scanning capabilities
+  - it: backend-storage enabled allows scanning capabilities
     asserts:
       - matchSnapshot: {}
     capabilities:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -303,7 +303,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v4.0.8
+    tag: v4.0.9
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -440,7 +440,7 @@ kubevuln:
   image:
     # -- source code: https://github.com/kubescape/kubevuln
     repository: quay.io/kubescape/kubevuln
-    tag: v0.3.142
+    tag: v0.3.146
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -536,7 +536,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: quay.io/kubescape/storage
-    tag: v0.0.274
+    tag: v0.0.278
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -605,7 +605,7 @@ nodeAgent:
   image:
     # -- source code: https://github.com/kubescape/node-agent
     repository: quay.io/kubescape/node-agent
-    tag: v0.3.119
+    tag: v0.3.129
     pullPolicy: IfNotPresent
 
   config:
@@ -913,7 +913,7 @@ synchronizer:
   image:
     # -- source code: https://github.com/kubescape/synchronizer
     repository: quay.io/kubescape/synchronizer
-    tag: v0.0.147
+    tag: v0.0.149
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux
@@ -994,7 +994,7 @@ prometheusExporter:
   name: "prometheus-exporter"
   image:
     repository: quay.io/kubescape/prometheus-exporter
-    tag: v0.2.18
+    tag: v0.2.21
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -1100,7 +1100,7 @@ kubescapeScheduler:
   image:
     # -- source code: https://github.com/kubescape/http-request (public repo)
     repository: quay.io/kubescape/http-request
-    tag: v0.2.19
+    tag: v0.2.20
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -1148,7 +1148,7 @@ kubevulnScheduler:
   image:
     # source code - https://github.com/kubescape/http-request
     repository: quay.io/kubescape/http-request
-    tag: v0.2.19
+    tag: v0.2.20
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -1198,7 +1198,7 @@ registryScanScheduler:
   image:
     # -- source code: https://github.com/kubescape/http-request (public repo)
     repository: quay.io/kubescape/http-request
-    tag: v0.2.19
+    tag: v0.2.20
     pullPolicy: IfNotPresent
 
   nodeSelector:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -303,7 +303,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v4.0.9
+    tag: v4.0.10
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -365,7 +365,7 @@ operator:
   image:
     # -- source code: https://github.com/kubescape/operator
     repository: quay.io/kubescape/operator
-    tag: v0.2.149
+    tag: v0.2.151
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -440,7 +440,7 @@ kubevuln:
   image:
     # -- source code: https://github.com/kubescape/kubevuln
     repository: quay.io/kubescape/kubevuln
-    tag: v0.3.146
+    tag: v0.3.159
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -537,7 +537,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: quay.io/kubescape/storage
-    tag: v0.0.278
+    tag: v0.0.297
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -606,7 +606,7 @@ nodeAgent:
   image:
     # -- source code: https://github.com/kubescape/node-agent
     repository: quay.io/kubescape/node-agent
-    tag: v0.3.129
+    tag: v0.3.147
     pullPolicy: IfNotPresent
 
   config:
@@ -995,7 +995,7 @@ prometheusExporter:
   name: "prometheus-exporter"
   image:
     repository: quay.io/kubescape/prometheus-exporter
-    tag: v0.2.21
+    tag: v0.2.22
     pullPolicy: IfNotPresent
 
   nodeSelector:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -521,6 +521,7 @@ kubevuln:
 storage:
   # Values or the Aggregated APIServer
   name: "storage"
+  enabled: true
   mtls:
     enabled: true
     certificateValidityInDays: 730 # NOTE: only in effect when certificates.strategy is "template"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released Kubescape Operator v1.40.3.
  * Updated container image tags for kubescape, operator, kubevuln, storage, node-agent, synchronizer, prometheus-exporter, and scheduler helper.
  * Updated Helm documentation and version badges to v1.40.3.
  * Adjusted scan capability enablement and storage behavior to be driven directly by chart values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->