### PR TITLE
warn when capability flags are dropped without a backend

### DIFF
--- a/charts/kubescape-operator/templates/NOTES.txt
+++ b/charts/kubescape-operator/templates/NOTES.txt
@@ -49,7 +49,7 @@ To enable scanning of private images, either:
 WARNING: capabilities.nodeProfileService is set to "enable", but the backend is not configured (.Values.server is empty / submit is disabled).
 This capability requires the synchronizer, which is only enabled when connected to a backend.
 As a result, nodeProfileServiceEnabled will render as FALSE in the node-agent configmap and node profiles will NOT be generated.
-To use this capability, connect to a backend by setting `.Values.server` (and `account` / `accessKey`).
+To use this capability, connect to a backend by setting `.Values.server`. This requires `account` and `accessKey` (or an existing `credentials.cloudSecret`); when submit is enabled and no cloudSecret is provided, the chart will fail if these are missing.
 {{- end }}
 
 {{- if and (eq .Values.capabilities.networkEventsStreaming "enable") (not $configurations.submit) }}
@@ -57,7 +57,7 @@ To use this capability, connect to a backend by setting `.Values.server` (and `a
 WARNING: capabilities.networkEventsStreaming is set to "enable", but the backend is not configured (.Values.server is empty / submit is disabled).
 This capability requires submitting data to a backend.
 As a result, networkStreamingEnabled will render as FALSE in the node-agent configmap and network events will NOT be streamed.
-To use this capability, connect to a backend by setting `.Values.server` (and `account` / `accessKey`).
+To use this capability, connect to a backend by setting `.Values.server`. This requires `account` and `accessKey` (or an existing `credentials.cloudSecret`); when submit is enabled and no cloudSecret is provided, the chart will fail if these are missing.
 {{- end }}
 
 {{- $legacyAdmissionSvc := .Values.operator.admissionService | default dict }}

--- a/charts/kubescape-operator/templates/NOTES.txt
+++ b/charts/kubescape-operator/templates/NOTES.txt
@@ -1,5 +1,6 @@
 Thank you for installing {{ .Chart.Name }} version {{ .Chart.Version }}.
 {{ $components := fromYaml (include "components" .) -}}
+{{ $configurations := fromYaml (include "configurations" .) -}}
 {{ if $components.kubescapeScheduler.enabled -}}
 
 View your cluster's configuration scanning schedule:
@@ -41,6 +42,22 @@ This means vulnerability scanning will be limited to images from public reposito
 To enable scanning of private images, either:
 - Enable nodeSbomGeneration (recommended): Set capabilities.nodeSbomGeneration: "enable"
 - Enable cluster-wide secret access: Set global.enableClusterWideSecretAccess: true
+{{- end }}
+
+{{- if and (eq .Values.capabilities.nodeProfileService "enable") (not $configurations.submit) }}
+
+WARNING: capabilities.nodeProfileService is set to "enable", but the backend is not configured (.Values.server is empty / submit is disabled).
+This capability requires the synchronizer, which is only enabled when connected to a backend.
+As a result, nodeProfileServiceEnabled will render as FALSE in the node-agent configmap and node profiles will NOT be generated.
+To use this capability, connect to a backend by setting `.Values.server` (and `account` / `accessKey`).
+{{- end }}
+
+{{- if and (eq .Values.capabilities.networkEventsStreaming "enable") (not $configurations.submit) }}
+
+WARNING: capabilities.networkEventsStreaming is set to "enable", but the backend is not configured (.Values.server is empty / submit is disabled).
+This capability requires submitting data to a backend.
+As a result, networkStreamingEnabled will render as FALSE in the node-agent configmap and network events will NOT be streamed.
+To use this capability, connect to a backend by setting `.Values.server` (and `account` / `accessKey`).
 {{- end }}
 
 {{- $legacyAdmissionSvc := .Values.operator.admissionService | default dict }}

--- a/charts/kubescape-operator/templates/NOTES.txt
+++ b/charts/kubescape-operator/templates/NOTES.txt
@@ -1,6 +1,7 @@
 Thank you for installing {{ .Chart.Name }} version {{ .Chart.Version }}.
 {{ $components := fromYaml (include "components" .) -}}
 {{ $configurations := fromYaml (include "configurations" .) -}}
+{{ $gates := fromYaml (include "capabilities.gates" .) -}}
 {{ if $components.kubescapeScheduler.enabled -}}
 
 View your cluster's configuration scanning schedule:
@@ -44,20 +45,9 @@ To enable scanning of private images, either:
 - Enable cluster-wide secret access: Set global.enableClusterWideSecretAccess: true
 {{- end }}
 
-{{- if and (eq .Values.capabilities.nodeProfileService "enable") (not $configurations.submit) }}
+{{- range $gates.warnings }}
 
-WARNING: capabilities.nodeProfileService is set to "enable", but the backend is not configured (.Values.server is empty / submit is disabled).
-This capability requires the synchronizer, which is only enabled when connected to a backend.
-As a result, nodeProfileServiceEnabled will render as FALSE in the node-agent configmap and node profiles will NOT be generated.
-To use this capability, connect to a backend by setting `.Values.server`. This requires `account` and `accessKey` (or an existing `credentials.cloudSecret`); when submit is enabled and no cloudSecret is provided, the chart will fail if these are missing.
-{{- end }}
-
-{{- if and (eq .Values.capabilities.networkEventsStreaming "enable") (not $configurations.submit) }}
-
-WARNING: capabilities.networkEventsStreaming is set to "enable", but the backend is not configured (.Values.server is empty / submit is disabled).
-This capability requires submitting data to a backend.
-As a result, networkStreamingEnabled will render as FALSE in the node-agent configmap and network events will NOT be streamed.
-To use this capability, connect to a backend by setting `.Values.server`. This requires `account` and `accessKey` (or an existing `credentials.cloudSecret`); when submit is enabled and no cloudSecret is provided, the chart will fail if these are missing.
+WARNING: {{ . }}
 {{- end }}
 
 {{- $legacyAdmissionSvc := .Values.operator.admissionService | default dict }}

--- a/charts/kubescape-operator/templates/_common.tpl
+++ b/charts/kubescape-operator/templates/_common.tpl
@@ -86,6 +86,48 @@ autoUpdater:
   enabled: {{ eq .Values.capabilities.autoUpgrading "enable" }}
 {{- end -}}
 
+{{/*
+"capabilities.gates" is the single source of truth for capability flags that are
+silently ANDed with an internal precondition before they reach a rendered
+manifest. The node-agent configmap consumes the effective.* values, while the
+ks-capabilities configmap and NOTES.txt consume effectiveCapabilities/warnings.
+Because the gate logic lives here only, the rendered value and the warning about
+that value can never drift apart. See issue #851.
+*/}}
+{{- define "capabilities.gates" -}}
+{{- $c := .Values.capabilities -}}
+{{- $configurations := fromYaml (include "configurations" .) -}}
+{{- $submit := $configurations.submit -}}
+{{- $backendStorage := $configurations.backendStorageEnabled -}}
+{{- $runtimeDetection := eq $c.runtimeDetection "enable" -}}
+{{- $nodeProfileService := and $submit (eq $c.nodeProfileService "enable") -}}
+{{- $networkStreaming := and $submit (eq $c.networkEventsStreaming "enable") -}}
+{{- $httpDetection := and (eq $c.httpDetection "enable") $runtimeDetection -}}
+# effective.* are the node-agent config.json flags, consumed by node-agent/configmap.yaml
+effective:
+  nodeProfileServiceEnabled: {{ $nodeProfileService }}
+  networkStreamingEnabled: {{ $networkStreaming }}
+  httpDetectionEnabled: {{ $httpDetection }}
+# effectiveCapabilities is requested-vs-effective per gated capability, consumed by ks-capabilities
+effectiveCapabilities:
+  nodeProfileService: {{ if $nodeProfileService }}enable{{ else }}disable{{ end }}
+  networkEventsStreaming: {{ if $networkStreaming }}enable{{ else }}disable{{ end }}
+  httpDetection: {{ if $httpDetection }}enable{{ else }}disable{{ end }}
+  nodeScan: {{ if and (eq $c.nodeScan "enable") $backendStorage }}backend{{ else }}{{ $c.nodeScan }}{{ end }}
+  configurationScan: {{ if and (eq $c.configurationScan "enable") $backendStorage }}backend{{ else }}{{ $c.configurationScan }}{{ end }}
+  vulnerabilityScan: {{ if and (eq $c.vulnerabilityScan "enable") $backendStorage }}backend{{ else }}{{ $c.vulnerabilityScan }}{{ end }}
+warnings:
+{{- if and (eq $c.nodeProfileService "enable") (not $nodeProfileService) }}
+- "capabilities.nodeProfileService=enable but the backend is not configured (.Values.server is empty / submit is disabled). This capability requires the synchronizer, which is only enabled when connected to a backend, so nodeProfileServiceEnabled renders as FALSE in the node-agent configmap and node profiles will NOT be generated. To use it, set .Values.server (requires account and accessKey, or an existing credentials.cloudSecret)."
+{{- end }}
+{{- if and (eq $c.networkEventsStreaming "enable") (not $networkStreaming) }}
+- "capabilities.networkEventsStreaming=enable but the backend is not configured (.Values.server is empty / submit is disabled). This capability requires submitting data to a backend, so networkStreamingEnabled renders as FALSE in the node-agent configmap and network events will NOT be streamed. To use it, set .Values.server (requires account and accessKey, or an existing credentials.cloudSecret)."
+{{- end }}
+{{- if and (eq $c.httpDetection "enable") (not $httpDetection) }}
+- "capabilities.httpDetection=enable but capabilities.runtimeDetection is not enabled. HTTP detection runs on top of runtime detection, so httpDetectionEnabled renders as FALSE in the node-agent configmap. To use it, set capabilities.runtimeDetection=enable."
+{{- end }}
+{{- end -}}
+
 {{- define "kubescape.certgen.scriptsHash" -}}
 {{- printf "%s%s" (.Files.Get "scripts/certgen-create.sh") (.Files.Get "scripts/certgen-patch.sh") | sha256sum | trunc 8 -}}
 {{- end }}

--- a/charts/kubescape-operator/templates/_common.tpl
+++ b/charts/kubescape-operator/templates/_common.tpl
@@ -98,9 +98,10 @@ that value can never drift apart. See issue #851.
 {{- $c := .Values.capabilities -}}
 {{- $configurations := fromYaml (include "configurations" .) -}}
 {{- $submit := $configurations.submit -}}
+{{- $synchronizerEnabled := (fromYaml (include "components" .)).synchronizer.enabled -}}
 {{- $backendStorage := $configurations.backendStorageEnabled -}}
 {{- $runtimeDetection := eq $c.runtimeDetection "enable" -}}
-{{- $nodeProfileService := and $submit (eq $c.nodeProfileService "enable") -}}
+{{- $nodeProfileService := and $synchronizerEnabled (eq $c.nodeProfileService "enable") -}}
 {{- $networkStreaming := and $submit (eq $c.networkEventsStreaming "enable") -}}
 {{- $httpDetection := and (eq $c.httpDetection "enable") $runtimeDetection -}}
 # effective.* are the node-agent config.json flags, consumed by node-agent/configmap.yaml

--- a/charts/kubescape-operator/templates/configs/components-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/components-configmap.yaml
@@ -8,10 +8,13 @@ metadata:
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" "ks-capabilities" "tier" .Values.global.namespaceTier) | nindent 4 }}
     kubescape.io/tier: "core"
+{{- $gates := fromYaml (include "capabilities.gates" .) }}
 data:
   capabilities: |
     {
       "capabilities": {{- .Values.capabilities | toJson }},
+      "effectiveCapabilities": {{- $gates.effectiveCapabilities | toJson }},
+      "capabilityWarnings": {{- $gates.warnings | default list | toJson }},
       "components": {{- include "components" . | fromYaml | toJson }},
       "configurations": {{- .Values.configurations | toJson }} ,
       "serviceScanConfig" : {{- .Values.serviceScanConfig | toJson }}

--- a/charts/kubescape-operator/templates/node-agent/configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/configmap.yaml
@@ -1,5 +1,6 @@
 {{- $components := fromYaml (include "components" .) }}
 {{- $configurations := fromYaml (include "configurations" .) }}
+{{- $gates := (fromYaml (include "capabilities.gates" .)).effective }}
 {{- if $components.nodeAgent.enabled }}
 {{/* validate that either alertCRD.scopeClustered or alertCRD.scopeNamespaced defined when the capability enabled */}}
 {{- if eq .Values.capabilities.runtimeDetection "enable" }}
@@ -24,15 +25,15 @@ data:
         "backendStorageEnabled": {{ $configurations.backendStorageEnabled }},
         "prometheusExporterEnabled": {{ eq .Values.nodeAgent.config.prometheusExporter "enable" }},
         "runtimeDetectionEnabled": {{ eq .Values.capabilities.runtimeDetection "enable" }},
-        "httpDetectionEnabled": {{ and (eq .Values.capabilities.httpDetection "enable") (eq .Values.capabilities.runtimeDetection "enable") }},
+        "httpDetectionEnabled": {{ $gates.httpDetectionEnabled }},
         "networkServiceEnabled": {{ eq .Values.capabilities.networkPolicyService "enable" }},
         "malwareDetectionEnabled": {{ eq .Values.capabilities.malwareDetection "enable" }},
         "hostMalwareSensorEnabled": {{ eq .Values.nodeAgent.config.hostMalwareSensor "enable" }},
         "hostNetworkSensorEnabled": {{ eq .Values.nodeAgent.config.hostNetworkSensor "enable" }},
         "hostSensorEnabled": {{ .Values.nodeAgent.config.hostSensor.enabled }},
         "hostSensorInterval": "{{ .Values.nodeAgent.config.hostSensor.interval }}",
-        "nodeProfileServiceEnabled": {{ and $components.synchronizer.enabled (eq .Values.capabilities.nodeProfileService "enable") }},
-        "networkStreamingEnabled": {{ and $configurations.submit (eq .Values.capabilities.networkEventsStreaming "enable") }},
+        "nodeProfileServiceEnabled": {{ $gates.nodeProfileServiceEnabled }},
+        "networkStreamingEnabled": {{ $gates.networkStreamingEnabled }},
         "maxImageSize": {{ .Values.kubevuln.config.maxImageSize }},
         "maxSBOMSize": {{ .Values.kubevuln.config.maxSBOMSize }},
         "sbomGenerationEnabled": {{ eq .Values.capabilities.nodeSbomGeneration "enable" }},

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -33186,6 +33186,16 @@ minimal capabilities:
       kubescape-operator generates suggested network policies. To view them:
       > kubectl get generatednetworkpolicies -n <namespace>
 
+      WARNING: capabilities.nodeProfileService is set to "enable", but the backend is not configured (.Values.server is empty / submit is disabled).
+      This capability requires the synchronizer, which is only enabled when connected to a backend.
+      As a result, nodeProfileServiceEnabled will render as FALSE in the node-agent configmap and node profiles will NOT be generated.
+      To use this capability, connect to a backend by setting `.Values.server` (and `account` / `accessKey`).
+
+      WARNING: capabilities.networkEventsStreaming is set to "enable", but the backend is not configured (.Values.server is empty / submit is disabled).
+      This capability requires submitting data to a backend.
+      As a result, networkStreamingEnabled will render as FALSE in the node-agent configmap and network events will NOT be streamed.
+      To use this capability, connect to a backend by setting `.Values.server` (and `account` / `accessKey`).
+
   2: |
     apiVersion: v1
     data:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -289,6 +289,8 @@ all capabilities:
       capabilities: |
         {
           "capabilities":{"admissionController":"enable","autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"enable","manageWorkloads":"enable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"enable","relevancy":"enable","riskAcceptance":"enable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"enable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"enable","vulnerabilityScan":"enable"},
+          "effectiveCapabilities":{"configurationScan":"enable","httpDetection":"enable","networkEventsStreaming":"enable","nodeProfileService":"enable","nodeScan":"enable","vulnerabilityScan":"enable"},
+          "capabilityWarnings":[],
           "components":{"autoUpdater":{"enabled":true},"clamAV":{"enabled":true},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":true},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":[".containers[*].env[?(@.name==\"KUBECONFIG\")]"],"otelUrl":"otelCollector.svc.monitoring:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -4314,7 +4316,7 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 491560de20053c77c48895fd008a225d6b490903da22b870e60d799f66f5f13e
+            checksum/capabilities-config: fc480b6d1f090b7b75e17965547ad27dcbbc31e41503fdb55ff03f27cac322fe
             checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -7102,6 +7104,8 @@ autoscaler mode with sbom sidecar:
       capabilities: |
         {
           "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "effectiveCapabilities":{"configurationScan":"enable","httpDetection":"enable","networkEventsStreaming":"enable","nodeProfileService":"enable","nodeScan":"enable","vulnerabilityScan":"enable"},
+          "capabilityWarnings":[],
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":true},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -9247,7 +9251,7 @@ autoscaler mode with sbom sidecar:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 2f1715cfc98ba5cb40c37d1ebbb6614c2d8a9505e64be34d6ff6f3af19ca636d
+            checksum/capabilities-config: 005a71a349173129be4bf1542a371e65c6bb8a06491216e66450ffbc4ca9129a
             checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -11351,6 +11355,8 @@ autoscaler mode without sbom sidecar:
       capabilities: |
         {
           "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "effectiveCapabilities":{"configurationScan":"enable","httpDetection":"enable","networkEventsStreaming":"enable","nodeProfileService":"enable","nodeScan":"enable","vulnerabilityScan":"enable"},
+          "capabilityWarnings":[],
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -13496,7 +13502,7 @@ autoscaler mode without sbom sidecar:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 70c98f97910c4b60af503ea887a5fc28b92c78729521f4bfd93aa01f578093a3
+            checksum/capabilities-config: 8fdd563762f3f4dce31e3c9ad3d892286b769349c98af321e04b857931483414
             checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -15517,6 +15523,8 @@ backend-storage enabled disables scanning capabilities:
       kubescape-operator generates suggested network policies. To view them:
       > kubectl get generatednetworkpolicies -n <namespace>
 
+      WARNING: capabilities.httpDetection=enable but capabilities.runtimeDetection is not enabled. HTTP detection runs on top of runtime detection, so httpDetectionEnabled renders as FALSE in the node-agent configmap. To use it, set capabilities.runtimeDetection=enable.
+
   2: |
     apiVersion: v1
     data:
@@ -15592,6 +15600,8 @@ backend-storage enabled disables scanning capabilities:
       capabilities: |
         {
           "capabilities":{"admissionController":"enable","autoUpgrading":"disable","backend-storage":"enable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "effectiveCapabilities":{"configurationScan":"backend","httpDetection":"disable","networkEventsStreaming":"enable","nodeProfileService":"enable","nodeScan":"backend","vulnerabilityScan":"backend"},
+          "capabilityWarnings":["capabilities.httpDetection=enable but capabilities.runtimeDetection is not enabled. HTTP detection runs on top of runtime detection, so httpDetectionEnabled renders as FALSE in the node-agent configmap. To use it, set capabilities.runtimeDetection=enable."],
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":false},"kubescapeScheduler":{"enabled":false},"kubevuln":{"enabled":false},"kubevulnScheduler":{"enabled":false},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":false},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -17646,7 +17656,7 @@ backend-storage enabled disables scanning capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: c51d7a072ddc1b393f191e0feec20fbcd8c64fa52690dd8135077c1b11fa342a
+            checksum/capabilities-config: 51bb496ef4e7b1c7bc86ff82d5120cc519ba179eb29b9f9aade7a5bea94ee7a1
             checksum/cloud-config: 7d174f3b693f89a0ffc0607ad503f5304bcedc76202415139fc75e07e1622610
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -19256,7 +19266,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 81860cc202844cab834e68e2bbf2658fafe85cd5f223553d696f3d9a9e967340
+            checksum/capabilities-config: 3d8435a1b3f7b401a329f75049b2ad411d54ffb06588a188e30826bbca092c41
             checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -19564,7 +19574,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 81860cc202844cab834e68e2bbf2658fafe85cd5f223553d696f3d9a9e967340
+            checksum/capabilities-config: 3d8435a1b3f7b401a329f75049b2ad411d54ffb06588a188e30826bbca092c41
             checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -20226,7 +20236,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
         metadata:
           annotations:
             checksum/admission-certgen-scripts: 68045c1d7a9c76b19d12ac26a2d1634bfc5f4707f2e153ffd535add8e4fb9d24
-            checksum/capabilities-config: e8fbf30b99bdb3136115a8a1d59c5fa89cdcf15141b55afc49fe1fad67faed7b
+            checksum/capabilities-config: 23331f344bbc5952815ec0b62fe71ef673a90ac288667d3cd0c72c11279fe230
             checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -20788,7 +20798,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
         metadata:
           annotations:
             checksum/admission-certgen-scripts: 68045c1d7a9c76b19d12ac26a2d1634bfc5f4707f2e153ffd535add8e4fb9d24
-            checksum/capabilities-config: e8fbf30b99bdb3136115a8a1d59c5fa89cdcf15141b55afc49fe1fad67faed7b
+            checksum/capabilities-config: 23331f344bbc5952815ec0b62fe71ef673a90ac288667d3cd0c72c11279fe230
             checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -21350,7 +21360,7 @@ cert strategy template, admission disabled, mtls disabled:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 81860cc202844cab834e68e2bbf2658fafe85cd5f223553d696f3d9a9e967340
+            checksum/capabilities-config: 3d8435a1b3f7b401a329f75049b2ad411d54ffb06588a188e30826bbca092c41
             checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -21658,7 +21668,7 @@ cert strategy template, admission disabled, mtls enabled:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 81860cc202844cab834e68e2bbf2658fafe85cd5f223553d696f3d9a9e967340
+            checksum/capabilities-config: 3d8435a1b3f7b401a329f75049b2ad411d54ffb06588a188e30826bbca092c41
             checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -22139,7 +22149,7 @@ cert strategy template, admission enabled, mtls disabled:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: e8fbf30b99bdb3136115a8a1d59c5fa89cdcf15141b55afc49fe1fad67faed7b
+            checksum/capabilities-config: 23331f344bbc5952815ec0b62fe71ef673a90ac288667d3cd0c72c11279fe230
             checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -22577,7 +22587,7 @@ cert strategy template, admission enabled, mtls enabled:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: e8fbf30b99bdb3136115a8a1d59c5fa89cdcf15141b55afc49fe1fad67faed7b
+            checksum/capabilities-config: 23331f344bbc5952815ec0b62fe71ef673a90ac288667d3cd0c72c11279fe230
             checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -23010,6 +23020,8 @@ default capabilities:
       capabilities: |
         {
           "capabilities":{"admissionController":"disable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"disable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"disable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "effectiveCapabilities":{"configurationScan":"enable","httpDetection":"disable","networkEventsStreaming":"enable","nodeProfileService":"disable","nodeScan":"enable","vulnerabilityScan":"enable"},
+          "capabilityWarnings":[],
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -26489,7 +26501,7 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: f51e51aff58cb03c4bab63af5433bc01626f2876ee7f460c0027d16978ffff71
+            checksum/capabilities-config: 970e7e1e4cd482a84a1675466f27e492cae7354e943c5572cfc5dd924fe72894
             checksum/cloud-config: 3b417c79d450e1ee66af001647fdd151dd56c6892d6a369a2ee09fbf4528b763
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -28737,6 +28749,8 @@ disable otel:
       kubescape-operator generates suggested network policies. To view them:
       > kubectl get generatednetworkpolicies -n <namespace>
 
+      WARNING: capabilities.httpDetection=enable but capabilities.runtimeDetection is not enabled. HTTP detection runs on top of runtime detection, so httpDetectionEnabled renders as FALSE in the node-agent configmap. To use it, set capabilities.runtimeDetection=enable.
+
   2: |
     apiVersion: v1
     data:
@@ -28812,6 +28826,8 @@ disable otel:
       capabilities: |
         {
           "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "effectiveCapabilities":{"configurationScan":"enable","httpDetection":"disable","networkEventsStreaming":"enable","nodeProfileService":"enable","nodeScan":"enable","vulnerabilityScan":"enable"},
+          "capabilityWarnings":["capabilities.httpDetection=enable but capabilities.runtimeDetection is not enabled. HTTP detection runs on top of runtime detection, so httpDetectionEnabled renders as FALSE in the node-agent configmap. To use it, set capabilities.runtimeDetection=enable."],
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -31175,7 +31191,7 @@ disable otel:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: d35263c6bb28aa1576c0848d93e8415be6ac8757e363f240df6e7af76d74b1a9
+            checksum/capabilities-config: efcd582528cff02b69724028c36b65a4ccb5c16dab990ccd491a03741962cfb3
             checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -33186,15 +33202,11 @@ minimal capabilities:
       kubescape-operator generates suggested network policies. To view them:
       > kubectl get generatednetworkpolicies -n <namespace>
 
-      WARNING: capabilities.nodeProfileService is set to "enable", but the backend is not configured (.Values.server is empty / submit is disabled).
-      This capability requires the synchronizer, which is only enabled when connected to a backend.
-      As a result, nodeProfileServiceEnabled will render as FALSE in the node-agent configmap and node profiles will NOT be generated.
-      To use this capability, connect to a backend by setting `.Values.server`. This requires `account` and `accessKey` (or an existing `credentials.cloudSecret`); when submit is enabled and no cloudSecret is provided, the chart will fail if these are missing.
+      WARNING: capabilities.nodeProfileService=enable but the backend is not configured (.Values.server is empty / submit is disabled). This capability requires the synchronizer, which is only enabled when connected to a backend, so nodeProfileServiceEnabled renders as FALSE in the node-agent configmap and node profiles will NOT be generated. To use it, set .Values.server (requires account and accessKey, or an existing credentials.cloudSecret).
 
-      WARNING: capabilities.networkEventsStreaming is set to "enable", but the backend is not configured (.Values.server is empty / submit is disabled).
-      This capability requires submitting data to a backend.
-      As a result, networkStreamingEnabled will render as FALSE in the node-agent configmap and network events will NOT be streamed.
-      To use this capability, connect to a backend by setting `.Values.server`. This requires `account` and `accessKey` (or an existing `credentials.cloudSecret`); when submit is enabled and no cloudSecret is provided, the chart will fail if these are missing.
+      WARNING: capabilities.networkEventsStreaming=enable but the backend is not configured (.Values.server is empty / submit is disabled). This capability requires submitting data to a backend, so networkStreamingEnabled renders as FALSE in the node-agent configmap and network events will NOT be streamed. To use it, set .Values.server (requires account and accessKey, or an existing credentials.cloudSecret).
+
+      WARNING: capabilities.httpDetection=enable but capabilities.runtimeDetection is not enabled. HTTP detection runs on top of runtime detection, so httpDetectionEnabled renders as FALSE in the node-agent configmap. To use it, set capabilities.runtimeDetection=enable.
 
   2: |
     apiVersion: v1
@@ -33271,6 +33283,8 @@ minimal capabilities:
       capabilities: |
         {
           "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "effectiveCapabilities":{"configurationScan":"enable","httpDetection":"disable","networkEventsStreaming":"disable","nodeProfileService":"disable","nodeScan":"enable","vulnerabilityScan":"enable"},
+          "capabilityWarnings":["capabilities.nodeProfileService=enable but the backend is not configured (.Values.server is empty / submit is disabled). This capability requires the synchronizer, which is only enabled when connected to a backend, so nodeProfileServiceEnabled renders as FALSE in the node-agent configmap and node profiles will NOT be generated. To use it, set .Values.server (requires account and accessKey, or an existing credentials.cloudSecret).","capabilities.networkEventsStreaming=enable but the backend is not configured (.Values.server is empty / submit is disabled). This capability requires submitting data to a backend, so networkStreamingEnabled renders as FALSE in the node-agent configmap and network events will NOT be streamed. To use it, set .Values.server (requires account and accessKey, or an existing credentials.cloudSecret).","capabilities.httpDetection=enable but capabilities.runtimeDetection is not enabled. HTTP detection runs on top of runtime detection, so httpDetectionEnabled renders as FALSE in the node-agent configmap. To use it, set capabilities.runtimeDetection=enable."],
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":"otelCollector.svc.monitoring:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -35625,7 +35639,7 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: fa3baf663baa550c8e4f29c6119e6fe503cbfb9fd0dafb8503acec598c5d8402
+            checksum/capabilities-config: cf75fb2432744e20288183806cfded73dd60cf79fe12bb2bb77ae818a8eb673b
             checksum/cloud-config: c2750cf0ee8a5883c746e9f14d6648b13e48c1ed8ce4f23683d97b03d2baa066
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -37193,6 +37207,8 @@ multiple node agents:
       capabilities: |
         {
           "capabilities":{"admissionController":"enable","autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"enable","manageWorkloads":"enable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"enable","relevancy":"enable","riskAcceptance":"enable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"enable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"enable","vulnerabilityScan":"enable"},
+          "effectiveCapabilities":{"configurationScan":"enable","httpDetection":"enable","networkEventsStreaming":"enable","nodeProfileService":"enable","nodeScan":"enable","vulnerabilityScan":"enable"},
+          "capabilityWarnings":[],
           "components":{"autoUpdater":{"enabled":true},"clamAV":{"enabled":true},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":true},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":[".containers[*].env[?(@.name==\"KUBECONFIG\")]"],"otelUrl":"otelCollector.svc.monitoring:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -41512,7 +41528,7 @@ multiple node agents:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 491560de20053c77c48895fd008a225d6b490903da22b870e60d799f66f5f13e
+            checksum/capabilities-config: fc480b6d1f090b7b75e17965547ad27dcbbc31e41503fdb55ff03f27cac322fe
             checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -44300,6 +44316,8 @@ priority class scheduling:
       capabilities: |
         {
           "capabilities":{"admissionController":"enable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "effectiveCapabilities":{"configurationScan":"enable","httpDetection":"enable","networkEventsStreaming":"enable","nodeProfileService":"enable","nodeScan":"enable","vulnerabilityScan":"enable"},
+          "capabilityWarnings":[],
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -46667,7 +46685,7 @@ priority class scheduling:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 70c98f97910c4b60af503ea887a5fc28b92c78729521f4bfd93aa01f578093a3
+            checksum/capabilities-config: 8fdd563762f3f4dce31e3c9ad3d892286b769349c98af321e04b857931483414
             checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -48755,6 +48773,8 @@ relevancy only:
       capabilities: |
         {
           "capabilities":{"admissionController":"disable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"disable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"disable","networkPolicyService":"disable","nodeProfileService":"disable","nodeSbomGeneration":"disable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"disable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"disable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "effectiveCapabilities":{"configurationScan":"enable","httpDetection":"disable","networkEventsStreaming":"disable","nodeProfileService":"disable","nodeScan":"enable","vulnerabilityScan":"enable"},
+          "capabilityWarnings":[],
           "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":"otelCollector.svc.monitoring:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -50988,7 +51008,7 @@ relevancy only:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 03f5b988ee8bf4aecb8c72ce3730330b4c160ece0633b95dcaea2501ddba988b
+            checksum/capabilities-config: d3f4db401a6cc64aaed40410dd873cae21af5213ae543febb3ac5b86ec0de259
             checksum/cloud-config: c2750cf0ee8a5883c746e9f14d6648b13e48c1ed8ce4f23683d97b03d2baa066
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
@@ -52547,6 +52567,8 @@ skipPersistence enabled:
       capabilities: |
         {
           "capabilities":{"admissionController":"enable","autoUpgrading":"enable","configurationScan":"enable","continuousScan":"enable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"enable","manageWorkloads":"enable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"enable","relevancy":"enable","riskAcceptance":"enable","runtimeDetection":"enable","runtimeObservability":"enable","scanEmbeddedSBOMs":"enable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"enable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"enable","vulnerabilityScan":"enable"},
+          "effectiveCapabilities":{"configurationScan":"enable","httpDetection":"enable","networkEventsStreaming":"enable","nodeProfileService":"enable","nodeScan":"enable","vulnerabilityScan":"enable"},
+          "capabilityWarnings":[],
           "components":{"autoUpdater":{"enabled":true},"clamAV":{"enabled":true},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":true},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":[".containers[*].env[?(@.name==\"KUBECONFIG\")]"],"otelUrl":"otelCollector.svc.monitoring:4317","persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
@@ -56575,7 +56597,7 @@ skipPersistence enabled:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: 491560de20053c77c48895fd008a225d6b490903da22b870e60d799f66f5f13e
+            checksum/capabilities-config: fc480b6d1f090b7b75e17965547ad27dcbbc31e41503fdb55ff03f27cac322fe
             checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -33189,12 +33189,12 @@ minimal capabilities:
       WARNING: capabilities.nodeProfileService is set to "enable", but the backend is not configured (.Values.server is empty / submit is disabled).
       This capability requires the synchronizer, which is only enabled when connected to a backend.
       As a result, nodeProfileServiceEnabled will render as FALSE in the node-agent configmap and node profiles will NOT be generated.
-      To use this capability, connect to a backend by setting `.Values.server` (and `account` / `accessKey`).
+      To use this capability, connect to a backend by setting `.Values.server`. This requires `account` and `accessKey` (or an existing `credentials.cloudSecret`); when submit is enabled and no cloudSecret is provided, the chart will fail if these are missing.
 
       WARNING: capabilities.networkEventsStreaming is set to "enable", but the backend is not configured (.Values.server is empty / submit is disabled).
       This capability requires submitting data to a backend.
       As a result, networkStreamingEnabled will render as FALSE in the node-agent configmap and network events will NOT be streamed.
-      To use this capability, connect to a backend by setting `.Values.server` (and `account` / `accessKey`).
+      To use this capability, connect to a backend by setting `.Values.server`. This requires `account` and `accessKey` (or an existing `credentials.cloudSecret`); when submit is enabled and no cloudSecret is provided, the chart will fail if these are missing.
 
   2: |
     apiVersion: v1


### PR DESCRIPTION
NodeProfileService and networkEventsStreaming default to "enable" and are reported as such in the ks-capabilities configmap, but the node-agent configmap silently ANDs them with the synchronizer/submit precondition and renders them false on backend-less (community) installs. The two configmaps disagree with no warning to the user.

Add NOTES.txt warnings (mirroring the existing nodeSbomGeneration warning) that fire when either capability is "enable" but submit is disabled, pointing users at .Values.server / account / accessKey.

#851 - Approach as discussed  with @matthyx on slack, Could also go with the other results as discussed in the issue ticket expected behaviours if that is preferred. Upto the code reviewers. All 3 approaches mentioned are doable. 

  ### Testing
  - **Community install** (no `server`): both warnings render in NOTES. ✅
  - **Backend configured** (`server`+`account`+`accessKey`): no warnings, and the
    node-agent flags render `true` — warning fires exactly when the flag would be `false`. ✅
  - `helm lint` passes; chart renders cleanly in both configurations. ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config now exposes computed effective capability flags and capability warnings so installations and agents reflect actual enabled features.

* **Documentation**
  * Installation notes now surface warnings when optional features (node profiling, network event streaming, etc.) cannot be enabled due to missing backend or prerequisites, with guidance for remediation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->