### PR TITLE
feat(kubevuln): add configurable proxyRegistryMap to cluster config

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -145,6 +145,7 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | kubevuln.volumes | object | `[]` | Additional volumes for the image vulnerability scanning |
 | kubevuln.volumeMounts | object | `[]` | Additional volumeMounts for the image vulnerability scanning |
 | kubevuln.config.grypeDbListingURL | string | `""` | Parameter to override the default Grype vulnerability database URL (listings.json format) |
+| kubevuln.config.proxyRegistryMap | object | `{}` | Map of source registry address to mirror registry address. When set, kubevuln rewrites image pull references accordingly (useful for air-gapped or offline registry mirrors) |
 | kubevulnScheduler.enabled | bool | `true` | enable/disable an image vulnerability scheduled scan using a CronJob |
 | kubevulnScheduler.podLabels| object | `{}` | Optional labels to add to the pods |
 | kubevulnScheduler.podAnnotations| object | `{}` | optional map of annotations to be applied to the Pods |

--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -42,4 +42,7 @@ data:
 {{- end }}
       "relevantImageVulnerabilitiesConfiguration": "{{ .Values.capabilities.relevancy }}",
       "riskAcceptance": {{ eq .Values.capabilities.riskAcceptance "enable" }}
+      {{- if .Values.kubevuln.config.proxyRegistryMap }},
+      "proxyRegistryMap": {{ toJson .Values.kubevuln.config.proxyRegistryMap }}
+      {{- end }}
     }

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -455,6 +455,7 @@ kubevuln:
     grypeDbPersistence: false # use a persistent volume for the grype db files
     useDefaultMatchers: false # set to true to use the default matchers
     storeFilteredSboms: false
+    proxyRegistryMap: {} # map of source registry -> mirror registry; kubevuln rewrites image pull references accordingly (useful for air-gapped/offline registry mirrors)
 
   env:
     - name: CA_MAX_VULN_SCAN_ROUTINES # TODO update the kubevuln


### PR DESCRIPTION
## Overview

Add an optional `kubevuln.config.proxyRegistryMap` value that, when set, injects a `proxyRegistryMap` object into the `ks-cloud-config` ConfigMap's clusterData JSON consumed by kubevuln. This lets operators redirect image pulls to mirror registries, which is required for air-gapped / offline environments (e.g. Zarf NodePort registry -> in-cluster registry).

The key is rendered only when the map is non-empty, so default output is unchanged for existing users.

## How to Test

- helm lint passes.
- helm template validated with jq for both the default (no key, valid JSON) and configured (valid JSON with the key)
cases.

## Examples/Screenshots

```yaml
kubevuln:
  config:
    proxyRegistryMap:
      "127.0.0.1:31999": "zarf-docker-registry.zarf.svc.cluster.local:5000"
```

Renders into clusterData:
```json
"proxyRegistryMap": {"127.0.0.1:31999":"zarf-docker-registry.zarf.svc.cluster.local:5000"}
```

## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `main` branch**

-->
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for proxy registry mapping configuration to redirect container image pulls to mirror registries, enabling use in air-gapped and offline environments.

* **Documentation**
  * Updated configuration documentation to reference the new registry mapping parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->