### PR TITLE
feat: add cveMatchingMode and trustedVendors to kubevuln config

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -146,6 +146,8 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | kubevuln.volumeMounts | object | `[]` | Additional volumeMounts for the image vulnerability scanning |
 | kubevuln.config.grypeDbListingURL | string | `""` | Parameter to override the default Grype vulnerability database URL (listings.json format) |
 | kubevuln.config.proxyRegistryMap | object | `{}` | Map of source registry address to mirror registry address. When set, kubevuln rewrites image pull references accordingly (useful for air-gapped or offline registry mirrors) |
+| kubevuln.config.cveMatchingMode | string | `""` | CVE matching mode: "off" (Grype defaults), "on" (CPE matching everywhere), or "adaptive" (CPE matching everywhere except trusted-vendor images, which rely on the vendor's authoritative feed). Empty derives the mode from useDefaultMatchers for backward compatibility (true -> "off", false -> "adaptive"). |
+| kubevuln.config.trustedVendors | list | `[]` | Distro identifiers treated as trusted vendors in adaptive mode. Empty uses kubevuln's built-in default set (echo, chainguard, wolfi, minimos). |
 | kubevulnScheduler.enabled | bool | `true` | enable/disable an image vulnerability scheduled scan using a CronJob |
 | kubevulnScheduler.podLabels| object | `{}` | Optional labels to add to the pods |
 | kubevulnScheduler.podAnnotations| object | `{}` | optional map of annotations to be applied to the Pods |

--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -1,5 +1,15 @@
 {{- $components := fromYaml (include "components" .)  }}
 {{- $configurations := fromYaml (include "configurations" .)  }}
+{{- $cveMatchingModeRaw := .Values.kubevuln.config.cveMatchingMode }}
+{{- $cveMatchingMode := "" }}
+{{- if kindIs "bool" $cveMatchingModeRaw }}
+  {{- /* Unquoted off/on/yes/no/true/false in YAML are parsed as booleans (the "Norway problem"); normalize back to the intended mode instead of silently misreading it. */}}
+  {{- $cveMatchingMode = ternary "on" "off" $cveMatchingModeRaw }}
+{{- else if $cveMatchingModeRaw }}
+  {{- $cveMatchingMode = $cveMatchingModeRaw }}
+{{- end }}
+{{- if not $cveMatchingMode }}{{- $cveMatchingMode = ternary "off" "adaptive" .Values.kubevuln.config.useDefaultMatchers }}{{- end }}
+{{- if not (has $cveMatchingMode (list "off" "on" "adaptive")) }}{{- fail (printf "kubevuln.config.cveMatchingMode must be one of off|on|adaptive, got %q" $cveMatchingMode) }}{{- end }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -31,7 +41,11 @@ data:
       "scanTimeout": "{{ .Values.kubevuln.config.scanTimeout }}",
       "scanEmbeddedSBOMs": {{ eq .Values.capabilities.scanEmbeddedSBOMs "enable" }},
       "vexGeneration": {{ eq .Values.capabilities.vexGeneration "enable" }},
-      "useDefaultMatchers": {{ .Values.kubevuln.config.useDefaultMatchers }},
+      "cveMatchingMode": "{{ $cveMatchingMode }}",
+      "useDefaultMatchers": {{ eq $cveMatchingMode "off" }},
+{{- if .Values.kubevuln.config.trustedVendors }}
+      "trustedVendors": {{ .Values.kubevuln.config.trustedVendors | toJson }},
+{{- end }}
       "storeFilteredSbom": {{ or .Values.kubevuln.config.storeFilteredSboms (eq .Values.capabilities.syncSBOM "enable") }},
       "continuousPostureScan": {{ $configurations.continuousScan }},
 {{- if not (empty .Values.kubevuln.config.grypeDbListingURL) }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -258,6 +258,7 @@ all capabilities:
           "scanTimeout": "5m",
           "scanEmbeddedSBOMs": true,
           "vexGeneration": true,
+          "cveMatchingMode": "off",
           "useDefaultMatchers": true,
           "storeFilteredSbom": true,
           "continuousPostureScan": false,
@@ -1164,7 +1165,7 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
           labels:
@@ -1866,7 +1867,7 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
           labels:
@@ -2825,7 +2826,7 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/node-agent-config: eb3f76dd9e71b550eb3556370bd7a98fef01a228bcd956544723c0af06223386
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
@@ -4394,7 +4395,7 @@ all capabilities:
         metadata:
           annotations:
             checksum/capabilities-config: 0e9e3a7b9e4d36c3050df06025f23eb2cf0eacf8d23704a6101ef9155e95a402
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: fe2488bc71adf7e0a5c922014a0d936ec867810643b5d17e5d46eee6111cef75
@@ -6777,7 +6778,7 @@ all capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             checksum/synchronizer-configmap: e76e7dbe5bf3893cc21ff4dc5ef6e85208fd0ede63a479fac4bde3f8c7f5a2b5
@@ -7165,6 +7166,7 @@ autoscaler mode with sbom sidecar:
           "scanTimeout": "5m",
           "scanEmbeddedSBOMs": false,
           "vexGeneration": false,
+          "cveMatchingMode": "adaptive",
           "useDefaultMatchers": false,
           "storeFilteredSbom": false,
           "continuousPostureScan": false,
@@ -7696,7 +7698,7 @@ autoscaler mode with sbom sidecar:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
           labels:
             app: kubescape
@@ -8155,7 +8157,7 @@ autoscaler mode with sbom sidecar:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
           labels:
             app: kubevuln
@@ -8970,7 +8972,7 @@ autoscaler mode with sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.119\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.119\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.119\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.119\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.119\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.119\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -9356,7 +9358,7 @@ autoscaler mode with sbom sidecar:
         metadata:
           annotations:
             checksum/capabilities-config: 304522a0aaf68306e89faf0e7eef45b9c7f45ee77f2568ecd50e0dbca2fce23e
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: eb8c2ba68d0a90d394a14eef4e3e3373e843277e76dde04f32aa1105b412b534
@@ -11168,7 +11170,7 @@ autoscaler mode with sbom sidecar:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
           labels:
@@ -11443,6 +11445,7 @@ autoscaler mode without sbom sidecar:
           "scanTimeout": "5m",
           "scanEmbeddedSBOMs": false,
           "vexGeneration": false,
+          "cveMatchingMode": "adaptive",
           "useDefaultMatchers": false,
           "storeFilteredSbom": false,
           "continuousPostureScan": false,
@@ -11974,7 +11977,7 @@ autoscaler mode without sbom sidecar:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
           labels:
             app: kubescape
@@ -12433,7 +12436,7 @@ autoscaler mode without sbom sidecar:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
           labels:
             app: kubevuln
@@ -13248,7 +13251,7 @@ autoscaler mode without sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.119\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.119\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.2\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.2\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.2\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.2\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir: {}\n        name: clamdb\n      - emptyDir: {}\n        name: clamrun\n      - configMap:\n          items:\n          - key: clamd.conf\n            path: clamd.conf\n          - key: freshclam.conf\n            path: freshclam.conf\n          name: clamav\n        name: etc\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.119\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.119\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: spc_t\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - mountPath: /clamav\n            name: clamrun\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -13634,7 +13637,7 @@ autoscaler mode without sbom sidecar:
         metadata:
           annotations:
             checksum/capabilities-config: f98ad436f602f6f4d0a2121a3bdc56fab146e382e946c59598d58490623d7f08
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: f25200b37249b83d95e85baa2d9177bec9fd9617e3d050e8189257fe2e6c9208
@@ -15446,7 +15449,7 @@ autoscaler mode without sbom sidecar:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
           labels:
@@ -15715,6 +15718,7 @@ backend-storage enabled disables scanning capabilities:
           "scanTimeout": "5m",
           "scanEmbeddedSBOMs": false,
           "vexGeneration": false,
+          "cveMatchingMode": "adaptive",
           "useDefaultMatchers": false,
           "storeFilteredSbom": false,
           "continuousPostureScan": false,
@@ -16454,7 +16458,7 @@ backend-storage enabled disables scanning capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 7d174f3b693f89a0ffc0607ad503f5304bcedc76202415139fc75e07e1622610
+            checksum/cloud-config: d0e00780bee5d2b3a068ad95ac2665cea1cb3b89c3aae81a1fe7659701877dda
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/node-agent-config: eb96c3c46f1b0866faae15793e5b3f9d521ee6d48ac042d8fdc9bef3347b0868
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
@@ -17855,7 +17859,7 @@ backend-storage enabled disables scanning capabilities:
         metadata:
           annotations:
             checksum/capabilities-config: 558d7399a4715d3ac4656f83a36fb5b81b48b49b09fa16cdcd23cecf0f01dc57
-            checksum/cloud-config: 7d174f3b693f89a0ffc0607ad503f5304bcedc76202415139fc75e07e1622610
+            checksum/cloud-config: d0e00780bee5d2b3a068ad95ac2665cea1cb3b89c3aae81a1fe7659701877dda
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: f52c7c610627e0f7441d7e1fec39106e63ed9c2a7aa1f57e0323fef7d786cf2f
@@ -19230,7 +19234,7 @@ backend-storage enabled disables scanning capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 7d174f3b693f89a0ffc0607ad503f5304bcedc76202415139fc75e07e1622610
+            checksum/cloud-config: d0e00780bee5d2b3a068ad95ac2665cea1cb3b89c3aae81a1fe7659701877dda
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/synchronizer-configmap: b740c76ec1e8306e80d1055384fb4c8dd99e593af67e991175a7d6ecb39a2a94
           labels:
@@ -19473,7 +19477,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
         metadata:
           annotations:
             checksum/capabilities-config: 34bbacd4f6d99b1fcb19916276fe277b7e88dacbd0e9fb747a078529df8a1deb
-            checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 0665196b0516908c723a461215096233418d974ba9b5e42322bb614b57a71bd6
@@ -19781,7 +19785,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
         metadata:
           annotations:
             checksum/capabilities-config: 34bbacd4f6d99b1fcb19916276fe277b7e88dacbd0e9fb747a078529df8a1deb
-            checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 0665196b0516908c723a461215096233418d974ba9b5e42322bb614b57a71bd6
@@ -20452,7 +20456,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
           annotations:
             checksum/admission-certgen-scripts: 68045c1d7a9c76b19d12ac26a2d1634bfc5f4707f2e153ffd535add8e4fb9d24
             checksum/capabilities-config: 75e10fbcc2060509fd45f904efcaf274317409c778d75c0f13129e7c43c4a333
-            checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 0665196b0516908c723a461215096233418d974ba9b5e42322bb614b57a71bd6
@@ -21023,7 +21027,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
           annotations:
             checksum/admission-certgen-scripts: 68045c1d7a9c76b19d12ac26a2d1634bfc5f4707f2e153ffd535add8e4fb9d24
             checksum/capabilities-config: 75e10fbcc2060509fd45f904efcaf274317409c778d75c0f13129e7c43c4a333
-            checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 0665196b0516908c723a461215096233418d974ba9b5e42322bb614b57a71bd6
@@ -21585,7 +21589,7 @@ cert strategy template, admission disabled, mtls disabled:
         metadata:
           annotations:
             checksum/capabilities-config: 34bbacd4f6d99b1fcb19916276fe277b7e88dacbd0e9fb747a078529df8a1deb
-            checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 0665196b0516908c723a461215096233418d974ba9b5e42322bb614b57a71bd6
@@ -21893,7 +21897,7 @@ cert strategy template, admission disabled, mtls enabled:
         metadata:
           annotations:
             checksum/capabilities-config: 34bbacd4f6d99b1fcb19916276fe277b7e88dacbd0e9fb747a078529df8a1deb
-            checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 0665196b0516908c723a461215096233418d974ba9b5e42322bb614b57a71bd6
@@ -22383,7 +22387,7 @@ cert strategy template, admission enabled, mtls disabled:
         metadata:
           annotations:
             checksum/capabilities-config: 75e10fbcc2060509fd45f904efcaf274317409c778d75c0f13129e7c43c4a333
-            checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 0665196b0516908c723a461215096233418d974ba9b5e42322bb614b57a71bd6
@@ -22830,7 +22834,7 @@ cert strategy template, admission enabled, mtls enabled:
         metadata:
           annotations:
             checksum/capabilities-config: 75e10fbcc2060509fd45f904efcaf274317409c778d75c0f13129e7c43c4a333
-            checksum/cloud-config: ec0a95cbe42fc974f50c86dd953a6b21e1e47d80fa8aa723c6d2042fa99bb2fe
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 0665196b0516908c723a461215096233418d974ba9b5e42322bb614b57a71bd6
@@ -23231,6 +23235,7 @@ default capabilities:
           "scanTimeout": "5m",
           "scanEmbeddedSBOMs": false,
           "vexGeneration": false,
+          "cveMatchingMode": "adaptive",
           "useDefaultMatchers": false,
           "storeFilteredSbom": false,
           "continuousPostureScan": false,
@@ -23973,7 +23978,7 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 3b417c79d450e1ee66af001647fdd151dd56c6892d6a369a2ee09fbf4528b763
+            checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
           labels:
@@ -24591,7 +24596,7 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 3b417c79d450e1ee66af001647fdd151dd56c6892d6a369a2ee09fbf4528b763
+            checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
           labels:
@@ -25452,7 +25457,7 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 3b417c79d450e1ee66af001647fdd151dd56c6892d6a369a2ee09fbf4528b763
+            checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/node-agent-config: 0e336255b65887eaaaf73b6cbbc676b55674c97ee5b3c5b29feef3274675b892
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
@@ -26788,7 +26793,7 @@ default capabilities:
         metadata:
           annotations:
             checksum/capabilities-config: 9acc756b55416dbdb9bec5de2aa1970f61432d9bdc8cb87c4b56616cc8aaf745
-            checksum/cloud-config: 3b417c79d450e1ee66af001647fdd151dd56c6892d6a369a2ee09fbf4528b763
+            checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 61ece26a62adc90490818f6bc0361a170b699228db38d5f3099286b59faa0304
@@ -28746,7 +28751,7 @@ default capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 3b417c79d450e1ee66af001647fdd151dd56c6892d6a369a2ee09fbf4528b763
+            checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
@@ -29096,6 +29101,7 @@ disable otel:
           "scanTimeout": "5m",
           "scanEmbeddedSBOMs": false,
           "vexGeneration": false,
+          "cveMatchingMode": "adaptive",
           "useDefaultMatchers": false,
           "storeFilteredSbom": false,
           "continuousPostureScan": false,
@@ -29627,7 +29633,7 @@ disable otel:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
           labels:
             app: kubescape
@@ -30086,7 +30092,7 @@ disable otel:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
           labels:
             app: kubevuln
@@ -30880,7 +30886,7 @@ disable otel:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/node-agent-config: 99ef333ed1cc3131db0f94d8dfbb53ed43256e9e3dcf5ceb4b5e5520b7f0b1f4
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
@@ -31505,7 +31511,7 @@ disable otel:
         metadata:
           annotations:
             checksum/capabilities-config: 7e323b40fc4893839b99fcd29a826ade32bb41ff7643b968a4ec31a253607018
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 61ece26a62adc90490818f6bc0361a170b699228db38d5f3099286b59faa0304
@@ -33299,7 +33305,7 @@ disable otel:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
           labels:
@@ -33580,6 +33586,7 @@ minimal capabilities:
           "scanTimeout": "5m",
           "scanEmbeddedSBOMs": false,
           "vexGeneration": false,
+          "cveMatchingMode": "adaptive",
           "useDefaultMatchers": false,
           "storeFilteredSbom": false,
           "continuousPostureScan": false,
@@ -34111,7 +34118,7 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: c2750cf0ee8a5883c746e9f14d6648b13e48c1ed8ce4f23683d97b03d2baa066
+            checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
           labels:
             app: kubescape
@@ -34566,7 +34573,7 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: c2750cf0ee8a5883c746e9f14d6648b13e48c1ed8ce4f23683d97b03d2baa066
+            checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
           labels:
             app: kubevuln
@@ -35356,7 +35363,7 @@ minimal capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: c2750cf0ee8a5883c746e9f14d6648b13e48c1ed8ce4f23683d97b03d2baa066
+            checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/node-agent-config: ba7c3406b2baffa8a744949152a86fe55c1bba5492269cefa6f2c1f886b86ef7
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
@@ -35980,7 +35987,7 @@ minimal capabilities:
         metadata:
           annotations:
             checksum/capabilities-config: 0c3d9d495fb3c46a6af146bd85ecb090713d307d593370376e5ef9670e82f6d3
-            checksum/cloud-config: c2750cf0ee8a5883c746e9f14d6648b13e48c1ed8ce4f23683d97b03d2baa066
+            checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 983fcf2e8de4e0e62b27ee03dc84ed2f56918469b6adec435f450608fdfe645e
@@ -37516,6 +37523,7 @@ multiple node agents:
           "scanTimeout": "5m",
           "scanEmbeddedSBOMs": true,
           "vexGeneration": true,
+          "cveMatchingMode": "off",
           "useDefaultMatchers": true,
           "storeFilteredSbom": true,
           "continuousPostureScan": false,
@@ -38422,7 +38430,7 @@ multiple node agents:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
           labels:
@@ -39124,7 +39132,7 @@ multiple node agents:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
           labels:
@@ -40083,7 +40091,7 @@ multiple node agents:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/node-agent-config: eb3f76dd9e71b550eb3556370bd7a98fef01a228bcd956544723c0af06223386
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
@@ -40376,7 +40384,7 @@ multiple node agents:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/node-agent-config: eb3f76dd9e71b550eb3556370bd7a98fef01a228bcd956544723c0af06223386
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
@@ -41946,7 +41954,7 @@ multiple node agents:
         metadata:
           annotations:
             checksum/capabilities-config: 0e9e3a7b9e4d36c3050df06025f23eb2cf0eacf8d23704a6101ef9155e95a402
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: fe2488bc71adf7e0a5c922014a0d936ec867810643b5d17e5d46eee6111cef75
@@ -44329,7 +44337,7 @@ multiple node agents:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             checksum/synchronizer-configmap: e76e7dbe5bf3893cc21ff4dc5ef6e85208fd0ede63a479fac4bde3f8c7f5a2b5
@@ -44717,6 +44725,7 @@ priority class scheduling:
           "scanTimeout": "5m",
           "scanEmbeddedSBOMs": false,
           "vexGeneration": false,
+          "cveMatchingMode": "adaptive",
           "useDefaultMatchers": false,
           "storeFilteredSbom": false,
           "continuousPostureScan": false,
@@ -45249,7 +45258,7 @@ priority class scheduling:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
           labels:
             app: kubescape
@@ -45710,7 +45719,7 @@ priority class scheduling:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
           labels:
             app: kubevuln
@@ -46505,7 +46514,7 @@ priority class scheduling:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/node-agent-config: 047b7dcdd5c998d09b413c9994cb27c81425d7194501b5c40c5ddc70de89bcb8
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
@@ -47130,7 +47139,7 @@ priority class scheduling:
         metadata:
           annotations:
             checksum/capabilities-config: f98ad436f602f6f4d0a2121a3bdc56fab146e382e946c59598d58490623d7f08
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 61ece26a62adc90490818f6bc0361a170b699228db38d5f3099286b59faa0304
@@ -48926,7 +48935,7 @@ priority class scheduling:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
           labels:
@@ -49201,6 +49210,7 @@ relevancy only:
           "scanTimeout": "5m",
           "scanEmbeddedSBOMs": false,
           "vexGeneration": false,
+          "cveMatchingMode": "adaptive",
           "useDefaultMatchers": false,
           "storeFilteredSbom": false,
           "continuousPostureScan": false,
@@ -49732,7 +49742,7 @@ relevancy only:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: c2750cf0ee8a5883c746e9f14d6648b13e48c1ed8ce4f23683d97b03d2baa066
+            checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
           labels:
             app: kubescape
@@ -50187,7 +50197,7 @@ relevancy only:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: c2750cf0ee8a5883c746e9f14d6648b13e48c1ed8ce4f23683d97b03d2baa066
+            checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
           labels:
             app: kubevuln
@@ -50977,7 +50987,7 @@ relevancy only:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: c2750cf0ee8a5883c746e9f14d6648b13e48c1ed8ce4f23683d97b03d2baa066
+            checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/node-agent-config: 9bb2873cf55e7e205fbfc6130c2fa9daf1b3e8bfae3b7d8f46954ed5c2f0bff6
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
@@ -51471,7 +51481,7 @@ relevancy only:
         metadata:
           annotations:
             checksum/capabilities-config: cb8fd019bb18ebe491b6564a383d8dbca1c83623b089c60c774850cc2a1707e9
-            checksum/cloud-config: c2750cf0ee8a5883c746e9f14d6648b13e48c1ed8ce4f23683d97b03d2baa066
+            checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: c8658f560be318b3d044901e321845815d54adeef14fa8ec74bb6c98c45e45b6
@@ -52998,6 +53008,7 @@ skipPersistence enabled:
           "scanTimeout": "5m",
           "scanEmbeddedSBOMs": true,
           "vexGeneration": true,
+          "cveMatchingMode": "off",
           "useDefaultMatchers": true,
           "storeFilteredSbom": true,
           "continuousPostureScan": false,
@@ -53904,7 +53915,7 @@ skipPersistence enabled:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
           labels:
@@ -54609,7 +54620,7 @@ skipPersistence enabled:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
           labels:
@@ -55568,7 +55579,7 @@ skipPersistence enabled:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/node-agent-config: eb3f76dd9e71b550eb3556370bd7a98fef01a228bcd956544723c0af06223386
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
@@ -57137,7 +57148,7 @@ skipPersistence enabled:
         metadata:
           annotations:
             checksum/capabilities-config: 0e9e3a7b9e4d36c3050df06025f23eb2cf0eacf8d23704a6101ef9155e95a402
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: fe2488bc71adf7e0a5c922014a0d936ec867810643b5d17e5d46eee6111cef75
@@ -59520,7 +59531,7 @@ skipPersistence enabled:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             checksum/synchronizer-configmap: e76e7dbe5bf3893cc21ff4dc5ef6e85208fd0ede63a479fac4bde3f8c7f5a2b5

--- a/charts/kubescape-operator/tests/offline_mode_test.yaml
+++ b/charts/kubescape-operator/tests/offline_mode_test.yaml
@@ -97,6 +97,7 @@ tests:
               "scanTimeout": "5m",
               "scanEmbeddedSBOMs": false,
               "vexGeneration": false,
+              "cveMatchingMode": "adaptive",
               "useDefaultMatchers": false,
               "storeFilteredSbom": false,
               "continuousPostureScan": false,

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -475,7 +475,11 @@ kubevuln:
     scanTimeout: 5m # set timeout for scanning an image
     grypeDbListingURL: "" # set the URL for the grype db listing, if empty the default URL will be used
     grypeDbPersistence: false # use a persistent volume for the grype db files
-    useDefaultMatchers: false # set to true to use the default matchers
+    useDefaultMatchers: false # Deprecated: use cveMatchingMode instead. Kept for backward compatibility (true -> "off", false -> "adaptive").
+    # -- CVE matching mode: "off" (Grype defaults), "on" (CPE matching everywhere), or "adaptive" (CPE matching everywhere except trusted-vendor images, which rely on the vendor's authoritative feed). Empty derives the mode from useDefaultMatchers for backward compatibility (true -> "off", false -> "adaptive").
+    cveMatchingMode: ""
+    # -- Distro identifiers treated as trusted vendors in adaptive mode. Empty uses kubevuln's built-in default set (echo, chainguard, wolfi, minimos).
+    trustedVendors: []
     storeFilteredSboms: false
     proxyRegistryMap: {} # map of source registry -> mirror registry; kubevuln rewrites image pull references accordingly (useful for air-gapped/offline registry mirrors)
 


### PR DESCRIPTION
## What

Plumbs kubevuln's new adaptive CVE-matching settings through the kubescape-operator chart into kubevuln's `clusterData.json`. Two new knobs under `kubevuln.config`:

| Key | Default | Meaning |
|-----|---------|---------|
| `cveMatchingMode` | `""` (→ `adaptive`) | `off` (Grype defaults) / `on` (CPE matching everywhere) / `adaptive` (CPE on, except trusted-vendor images) |
| `trustedVendors` | `[]` | distro identifiers trusted in adaptive mode; empty uses kubevuln's built-in set (echo, chainguard, wolfi, minimos) |

Depends on the kubevuln change that adds `cveMatchingMode` (kubevuln PR #372). Adaptive only takes effect once an image with that support is pinned.

## Backward compatibility (the design goal)

The configmap resolves the effective mode and emits **both** the new `cveMatchingMode` key and a **derived** `useDefaultMatchers`, so an **old kubevuln image keeps working unchanged** — it ignores the unknown `cveMatchingMode`/`trustedVendors` keys (mapstructure drops unknown fields) and reads the derived boolean:

| values | `cveMatchingMode` | `useDefaultMatchers` | new image | old image |
|---|---|---|---|---|
| defaults | `adaptive` | `false` | adaptive | CPE on (unchanged) |
| `useDefaultMatchers: true` (legacy) | `off` | `true` | off | off (intent preserved) |
| `cveMatchingMode: on` | `on` | `false` | on | CPE on |
| `cveMatchingMode: off` | `off` | `true` | off | off |
| `cveMatchingMode: on` + `useDefaultMatchers: true` | `on` | `false` | on (explicit wins) | CPE on |

A legacy `useDefaultMatchers: true` is preserved as mode `off`; `adaptive` maps to `useDefaultMatchers: false` (CPE on) as the safe fallback for old binaries. An invalid `cveMatchingMode` fails `helm template` (with a clear message) rather than crashing kubevuln at boot.

## Deliberately out of scope
- **kubevuln image tag** — not bumped; adaptive activates when the supporting release is pinned (follow-up).
- **Chart version/appVersion** — left to the maintainers' release-prep process.

## Testing
- `helm lint` clean.
- `helm template` matrix verified (default, legacy bool, on, off, adaptive+trustedVendors, explicit-wins, invalid-guard); default `clusterData` parses as valid JSON; `trustedVendors` renders as a proper JSON array.
- `helm unittest charts/kubescape-operator/` passes (snapshot regenerated, 966 snapshots).
- README values table updated for the two new keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CVE matching modes: off, on, and adaptive.
  * Added support for specifying trusted vendors in configuration.

* **Documentation**
  * Updated configuration documentation with new options and backward-compatibility details for existing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->