### PR TITLE
feat(storage): require Kubernetes >= 1.28 via kubeVersion guard

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -5,6 +5,12 @@ description:
 
 type: application
 
+# Storage (an aggregated APIServer built on recent k8s.io/apiserver libraries)
+# requires Kubernetes >= 1.28. On older clusters the delegated-authentication
+# informer never syncs, leaving the storage pod NotReady (/readyz
+# [-]informer-sync) and the APIService in MissingEndpoints.
+kubeVersion: ">=1.28.0-0"
+
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)


### PR DESCRIPTION
## Why
A customer's IPv6-only cluster ran storage `v0.0.282` but the pod stayed `NotReady` with the APIService stuck in `MissingEndpoints` — and storage logged only 4 lines. Root cause: the cluster was **Kubernetes 1.26**, but storage (an aggregated APIServer built on recent `k8s.io/apiserver` libraries) **requires >= 1.28**. On older clusters the delegated-authentication informer never completes its cache sync against the control plane, so `/readyz` is permanently `[-]informer-sync` and the pod never becomes Ready.

## Change
- Add `kubeVersion: ">=1.28.0-0"` to `charts/kubescape-operator/Chart.yaml` so `helm install`/`upgrade` **fails fast with a clear message** on unsupported clusters instead of silently leaving storage wedged.
- Bump chart `version` 1.40.2 → 1.40.3 (chart-only change; `appVersion` unchanged).

## Notes
- `kubeVersion` uses a semver range; `-0` includes pre-release builds (e.g. `1.28.0-rc.1`) so EKS/GKE-style versions aren't wrongly rejected.
- Companion work in `kubescape/storage`: PR #336 surfaces the apiserver logs (`KS_LOGGER_LEVEL=debug`) that were muted — which is what hid this root cause — and documents the >= 1.28 requirement in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)