### PR TITLE
feat: add serviceaccounts to resources synced by synchronizer

### DIFF
--- a/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
@@ -16,7 +16,7 @@ rules:
     resources: ["rolebindings", "clusterrolebindings", "roles", "clusterroles"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["pods", "namespaces", "nodes", "configmaps", "persistentvolumes", "services"]
+    resources: ["pods", "namespaces", "nodes", "configmaps", "persistentvolumes", "services", "serviceaccounts"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]

--- a/charts/kubescape-operator/templates/synchronizer/configmap.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/configmap.yaml
@@ -28,6 +28,12 @@ data:
             "strategy": "patch"
           },
           {
+            "group": "",
+            "version": "v1",
+            "resource": "serviceaccounts",
+            "strategy": "patch"
+          },
+          {
             "group": "networking.k8s.io",
             "version": "v1",
             "resource": "ingresses",

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -6141,6 +6141,7 @@ all capabilities:
           - configmaps
           - persistentvolumes
           - services
+          - serviceaccounts
         verbs:
           - get
           - list
@@ -6369,6 +6370,12 @@ all capabilities:
                 "group": "",
                 "version": "v1",
                 "resource": "services",
+                "strategy": "patch"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "resource": "serviceaccounts",
                 "strategy": "patch"
               },
               {
@@ -6689,7 +6696,7 @@ all capabilities:
             checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: 3174c8dfc918592ea301676ce0b289ff6d19145e7a60f8515d96d064158ba48b
+            checksum/synchronizer-configmap: e8b456b3b9068dc3c4b4faf6e86ebc575adf12d7d399f158e78de309120b5947
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -10592,6 +10599,7 @@ autoscaler mode with sbom sidecar:
           - configmaps
           - persistentvolumes
           - services
+          - serviceaccounts
         verbs:
           - get
           - list
@@ -10751,6 +10759,12 @@ autoscaler mode with sbom sidecar:
                 "group": "",
                 "version": "v1",
                 "resource": "services",
+                "strategy": "patch"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "resource": "serviceaccounts",
                 "strategy": "patch"
               },
               {
@@ -11052,7 +11066,7 @@ autoscaler mode with sbom sidecar:
           annotations:
             checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: fa25e5549001f4047cef967a744b959af552b30520407609f91764887e7aea4c
+            checksum/synchronizer-configmap: 0045bbf353118ddd7d3838ffdda1aaf10ef36b978b5d4cae64821a9afe442547
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -14843,6 +14857,7 @@ autoscaler mode without sbom sidecar:
           - configmaps
           - persistentvolumes
           - services
+          - serviceaccounts
         verbs:
           - get
           - list
@@ -15002,6 +15017,12 @@ autoscaler mode without sbom sidecar:
                 "group": "",
                 "version": "v1",
                 "resource": "services",
+                "strategy": "patch"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "resource": "serviceaccounts",
                 "strategy": "patch"
               },
               {
@@ -15303,7 +15324,7 @@ autoscaler mode without sbom sidecar:
           annotations:
             checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: fa25e5549001f4047cef967a744b959af552b30520407609f91764887e7aea4c
+            checksum/synchronizer-configmap: 0045bbf353118ddd7d3838ffdda1aaf10ef36b978b5d4cae64821a9afe442547
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -18584,6 +18605,7 @@ backend-storage enabled disables scanning capabilities:
           - configmaps
           - persistentvolumes
           - services
+          - serviceaccounts
         verbs:
           - get
           - list
@@ -18743,6 +18765,12 @@ backend-storage enabled disables scanning capabilities:
                 "group": "",
                 "version": "v1",
                 "resource": "services",
+                "strategy": "patch"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "resource": "serviceaccounts",
                 "strategy": "patch"
               },
               {
@@ -19026,7 +19054,7 @@ backend-storage enabled disables scanning capabilities:
           annotations:
             checksum/cloud-config: 7d174f3b693f89a0ffc0607ad503f5304bcedc76202415139fc75e07e1622610
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: 03e2983b6344d0360b442232570bfc4c1f2640db5b9ae6f46939eeca1675a249
+            checksum/synchronizer-configmap: b740c76ec1e8306e80d1055384fb4c8dd99e593af67e991175a7d6ecb39a2a94
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -27988,6 +28016,7 @@ default capabilities:
           - configmaps
           - persistentvolumes
           - services
+          - serviceaccounts
         verbs:
           - get
           - list
@@ -28147,6 +28176,12 @@ default capabilities:
                 "group": "",
                 "version": "v1",
                 "resource": "services",
+                "strategy": "patch"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "resource": "serviceaccounts",
                 "strategy": "patch"
               },
               {
@@ -28449,7 +28484,7 @@ default capabilities:
             checksum/cloud-config: 3b417c79d450e1ee66af001647fdd151dd56c6892d6a369a2ee09fbf4528b763
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: fa25e5549001f4047cef967a744b959af552b30520407609f91764887e7aea4c
+            checksum/synchronizer-configmap: 0045bbf353118ddd7d3838ffdda1aaf10ef36b978b5d4cae64821a9afe442547
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -32514,6 +32549,7 @@ disable otel:
           - configmaps
           - persistentvolumes
           - services
+          - serviceaccounts
         verbs:
           - get
           - list
@@ -32673,6 +32709,12 @@ disable otel:
                 "group": "",
                 "version": "v1",
                 "resource": "services",
+                "strategy": "patch"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "resource": "serviceaccounts",
                 "strategy": "patch"
               },
               {
@@ -32974,7 +33016,7 @@ disable otel:
           annotations:
             checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: fa25e5549001f4047cef967a744b959af552b30520407609f91764887e7aea4c
+            checksum/synchronizer-configmap: 0045bbf353118ddd7d3838ffdda1aaf10ef36b978b5d4cae64821a9afe442547
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -43353,6 +43395,7 @@ multiple node agents:
           - configmaps
           - persistentvolumes
           - services
+          - serviceaccounts
         verbs:
           - get
           - list
@@ -43581,6 +43624,12 @@ multiple node agents:
                 "group": "",
                 "version": "v1",
                 "resource": "services",
+                "strategy": "patch"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "resource": "serviceaccounts",
                 "strategy": "patch"
               },
               {
@@ -43901,7 +43950,7 @@ multiple node agents:
             checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: 3174c8dfc918592ea301676ce0b289ff6d19145e7a60f8515d96d064158ba48b
+            checksum/synchronizer-configmap: e8b456b3b9068dc3c4b4faf6e86ebc575adf12d7d399f158e78de309120b5947
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -48010,6 +48059,7 @@ priority class scheduling:
           - configmaps
           - persistentvolumes
           - services
+          - serviceaccounts
         verbs:
           - get
           - list
@@ -48169,6 +48219,12 @@ priority class scheduling:
                 "group": "",
                 "version": "v1",
                 "resource": "services",
+                "strategy": "patch"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "resource": "serviceaccounts",
                 "strategy": "patch"
               },
               {
@@ -48470,7 +48526,7 @@ priority class scheduling:
           annotations:
             checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: fa25e5549001f4047cef967a744b959af552b30520407609f91764887e7aea4c
+            checksum/synchronizer-configmap: 0045bbf353118ddd7d3838ffdda1aaf10ef36b978b5d4cae64821a9afe442547
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -58422,6 +58478,7 @@ skipPersistence enabled:
           - configmaps
           - persistentvolumes
           - services
+          - serviceaccounts
         verbs:
           - get
           - list
@@ -58650,6 +58707,12 @@ skipPersistence enabled:
                 "group": "",
                 "version": "v1",
                 "resource": "services",
+                "strategy": "patch"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "resource": "serviceaccounts",
                 "strategy": "patch"
               },
               {
@@ -58970,7 +59033,7 @@ skipPersistence enabled:
             checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: 3174c8dfc918592ea301676ce0b289ff6d19145e7a60f8515d96d064158ba48b
+            checksum/synchronizer-configmap: e8b456b3b9068dc3c4b4faf6e86ebc575adf12d7d399f158e78de309120b5947
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer


### PR DESCRIPTION
This PR adds serviceaccounts to the resources list synced by the synchronizer component, and updates the synchronizer's ClusterRole RBAC permissions to watch, list, and get serviceaccounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The synchronizer component now has expanded permissions to read, list, and monitor service accounts, enabling enhanced cluster synchronization capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->