### PR TITLE
[LFX 2026] feat(crds): add CEL validation to SecurityException CRDs

### DIFF
--- a/charts/kubescape-operator/crds/cluster-security-exception.crd.yaml
+++ b/charts/kubescape-operator/crds/cluster-security-exception.crd.yaml
@@ -22,6 +22,10 @@ spec:
           properties:
             spec:
               type: object
+              x-kubernetes-validations:
+                # expiresAt is not validated as future-dated: CRD CEL has no now(); expiry is enforced at scan time.
+                - rule: "(has(self.vulnerabilities) && size(self.vulnerabilities) > 0) || (has(self.posture) && size(self.posture) > 0)"
+                  message: "at least one of spec.vulnerabilities or spec.posture must be set"
               properties:
                 author:
                   type: string
@@ -60,6 +64,9 @@ spec:
                   type: array
                   items:
                     type: object
+                    x-kubernetes-validations:
+                      - rule: "self.status != 'not_affected' || has(self.justification)"
+                        message: "justification is required when status is not_affected"
                     required:
                       - vulnerability
                       - status

--- a/charts/kubescape-operator/crds/security-exception.crd.yaml
+++ b/charts/kubescape-operator/crds/security-exception.crd.yaml
@@ -22,6 +22,10 @@ spec:
           properties:
             spec:
               type: object
+              x-kubernetes-validations:
+                # expiresAt is not validated as future-dated: CRD CEL has no now(); expiry is enforced at scan time.
+                - rule: "(has(self.vulnerabilities) && size(self.vulnerabilities) > 0) || (has(self.posture) && size(self.posture) > 0)"
+                  message: "at least one of spec.vulnerabilities or spec.posture must be set"
               properties:
                 author:
                   type: string
@@ -57,6 +61,9 @@ spec:
                   type: array
                   items:
                     type: object
+                    x-kubernetes-validations:
+                      - rule: "self.status != 'not_affected' || has(self.justification)"
+                        message: "justification is required when status is not_affected"
                     required:
                       - vulnerability
                       - status


### PR DESCRIPTION
## Overview

The shipping `SecurityException` and `ClusterSecurityException` CRDs
(`charts/kubescape-operator/crds/{security-exception,cluster-security-exception}.crd.yaml`)
enforced field shapes and value sets via structural `enum`/`required`, but had **no
cross-field validation**. A user could apply a CRD that is structurally valid yet
semantically meaningless e.g. an exception with neither `vulnerabilities` nor
`posture` entries, or a `not_affected` vulnerability with no `justification` and the
apiserver would accept it.

This PR adds the cross-field `x-kubernetes-validations` (CEL) rules from the
SecurityException design doc to both CRDs:

- **`spec` level:** at least one of `spec.vulnerabilities` or `spec.posture` must be set.
- **`spec.vulnerabilities[]` level:** `justification` is required when `status` is `not_affected`.

Current behavior → future behavior:

| Manifest | Before | After |
|---|---|---|
| Exception with no `vulnerabilities` and no `posture` | accepted | **rejected** at admission |
| `status: not_affected` with no `justification` | accepted | **rejected** at admission |

The remaining design-doc validation rules (`status`, `justification`, and posture
`action` value sets) were already enforced by structural `enum`s and are unchanged.

## Additional Information

- **`expiresAt` is intentionally not validated as future-dated.** Kubernetes CRD CEL
  exposes no current-time function (`now()` is unavailable), so any
  "`expiresAt` must be in the future" rule fails to compile and the apiserver rejects
  the entire CRD. This is the exact defect reported in `kubescape/kubescape#2400`
  (an orphan reference CRD that was since removed in `kubescape/kubescape#2403`). A
  one-line comment in each CRD records this so the rule is not reintroduced. RFC3339
  validity is already covered by `format: date-time`, and expiry is evaluated at scan
  time by the scanners.
- No schema-shape changes; this is additive validation only. Existing valid CRs
  continue to apply unchanged.

## How to Test

Validated with server-side dry-run against a live **v1.31.0** apiserver.

```bash
# Install the CRDs
kubectl apply -f charts/kubescape-operator/crds/security-exception.crd.yaml
kubectl apply -f charts/kubescape-operator/crds/cluster-security-exception.crd.yaml

# --- Must be REJECTED ---

# 1) neither vulnerabilities nor posture
kubectl apply --dry-run=server -f - <<'EOF'
apiVersion: kubescape.io/v1beta1
kind: SecurityException
metadata: {name: t1, namespace: default}
spec: {reason: empty}
EOF
# -> spec: Invalid value: "object": at least one of spec.vulnerabilities or spec.posture must be set

# 2) not_affected without justification
kubectl apply --dry-run=server -f - <<'EOF'
apiVersion: kubescape.io/v1beta1
kind: SecurityException
metadata: {name: t2, namespace: default}
spec:
  vulnerabilities:
    - {vulnerability: {id: CVE-2021-44228}, status: not_affected}
EOF
# -> spec.vulnerabilities[0]: Invalid value: "object": justification is required when status is not_affected

# 3) invalid posture action
kubectl apply --dry-run=server -f - <<'EOF'
apiVersion: kubescape.io/v1beta1
kind: SecurityException
metadata: {name: t3, namespace: default}
spec: {posture: [{controlID: C-0034, action: bogus}]}
EOF
# -> spec.posture[0].action: Unsupported value: "bogus": supported values: "ignore", "alert_only"

# --- Must be ACCEPTED ---

# valid posture-only
kubectl apply --dry-run=server -f - <<'EOF'
apiVersion: kubescape.io/v1beta1
kind: SecurityException
metadata: {name: t4, namespace: default}
spec: {posture: [{controlID: C-0034, action: alert_only}]}
EOF

# valid not_affected + justification (+ future expiresAt)
kubectl apply --dry-run=server -f - <<'EOF'
apiVersion: kubescape.io/v1beta1
kind: SecurityException
metadata: {name: t5, namespace: default}
spec:
  expiresAt: "2027-01-01T00:00:00Z"
  vulnerabilities:
    - {vulnerability: {id: CVE-2021-44228}, status: not_affected, justification: component_not_present}
EOF

# past expiresAt is accepted by design (expiry is a scan-time concern, not admission)
kubectl apply --dry-run=server -f - <<'EOF'
apiVersion: kubescape.io/v1beta1
kind: SecurityException
metadata: {name: t5b, namespace: default}
spec:
  expiresAt: "2020-01-01T00:00:00Z"
  posture: [{controlID: C-0034, action: ignore}]
EOF

# cluster-scoped with namespaceSelector
kubectl apply --dry-run=server -f - <<'EOF'
apiVersion: kubescape.io/v1beta1
kind: ClusterSecurityException
metadata: {name: t6}
spec:
  match: {namespaceSelector: {matchLabels: {env: staging}}}
  posture: [{controlID: C-0034, action: ignore}]
EOF
```

## Related issues/PRs

- Part of kubescape/kubescape#1982 (SecurityException CRD implementation)
- Context: kubescape/kubescape#2400 / kubescape/kubescape#2403 (why `expiresAt` future-dating is not a CEL rule)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

> Note: these are declarative CRD manifests (no Go code); validated via
> `kubectl apply --dry-run=server` on a v1.31.0 apiserver rather than unit tests.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stricter validation for security exceptions: now requires at least one vulnerability or posture rule, and mandates justification when marking vulnerabilities as addressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->