### PR TITLE
fix(kubescape-operator): sanitize '+' in app.kubernetes.io/version label

### DIFF
--- a/charts/kubescape-operator/templates/_helpers.tpl
+++ b/charts/kubescape-operator/templates/_helpers.tpl
@@ -46,7 +46,7 @@ Common labels
 helm.sh/chart: {{ include "kubescape-operator.chart" . }}
 {{ include "kubescape-operator.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: kubescape


### PR DESCRIPTION
## Summary
The `kubescape-operator.labels` helper built the `app.kubernetes.io/version` label from the raw `.Chart.AppVersion`. When the chart — or a parent chart embedding it — uses a semver build-metadata appVersion such as `1.40.2+private.1`, the `+` is illegal in a Kubernetes label value and resource creation fails. This applies the same `replace "+" "_"` sanitization already used for the `helm.sh/chart` label and the chart-version references in the deployment templates.

## Changes
- `charts/kubescape-operator/templates/_helpers.tpl`: sanitize `+` to `_` in the `app.kubernetes.io/version` label value.

## Context
The failure surfaced on a `pre-upgrade` hook in a downstream parent chart whose `appVersion` carries `+private.1` build metadata:

```
ServiceAccount "armosec-host-scanner-cleanup" is invalid: metadata.labels:
Invalid value: "1.40.2+private.1": a valid label must consist of alphanumeric
characters, '-', '_' or '.', and must start and end with an alphanumeric
character (regex '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

Only this path failed because the downstream template passes the parent `.Chart` (with `+private.1`) into the helper, whereas the in-chart templates use the subchart's own clean `1.40.2`.

## Testing
`helm template` with `appVersion: 1.40.2+private.1` now renders a valid label:
```
app.kubernetes.io/version: "1.40.2_private.1"
```

## Docs
Docs-exempt: bugfix to template label sanitization, no behavioral/feature change.

<!-- armosec-pr: v=1 via=manual -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version label formatting to ensure proper Kubernetes compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->