### PR TITLE
feat(synchronizer): sync containerprofiles to backend

### DIFF
--- a/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
@@ -28,7 +28,7 @@ rules:
     resources: ["networkpolicies", "ingresses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
-    resources: ["applicationprofiles", "networkneighborhoods"]
+    resources: ["applicationprofiles", "networkneighborhoods", "containerprofiles"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
     resources: ["knownservers"]

--- a/charts/kubescape-operator/templates/synchronizer/configmap.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/configmap.yaml
@@ -169,6 +169,12 @@ data:
           {
             "group": "spdx.softwarecomposition.kubescape.io",
             "version": "v1beta1",
+            "resource": "containerprofiles",
+            "strategy": "copy"
+          },
+          {
+            "group": "spdx.softwarecomposition.kubescape.io",
+            "version": "v1beta1",
             "resource": "knownservers",
             "strategy": "copy"
           },

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -6254,6 +6254,7 @@ all capabilities:
         resources:
           - applicationprofiles
           - networkneighborhoods
+          - containerprofiles
         verbs:
           - get
           - watch
@@ -6587,6 +6588,12 @@ all capabilities:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
+                "resource": "containerprofiles",
+                "strategy": "copy"
+              },
+              {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
                 "resource": "knownservers",
                 "strategy": "copy"
               },
@@ -6770,7 +6777,7 @@ all capabilities:
             checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: e8b456b3b9068dc3c4b4faf6e86ebc575adf12d7d399f158e78de309120b5947
+            checksum/synchronizer-configmap: e76e7dbe5bf3893cc21ff4dc5ef6e85208fd0ede63a479fac4bde3f8c7f5a2b5
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -10722,6 +10729,7 @@ autoscaler mode with sbom sidecar:
         resources:
           - applicationprofiles
           - networkneighborhoods
+          - containerprofiles
         verbs:
           - get
           - watch
@@ -10986,6 +10994,12 @@ autoscaler mode with sbom sidecar:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
+                "resource": "containerprofiles",
+                "strategy": "copy"
+              },
+              {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
                 "resource": "knownservers",
                 "strategy": "copy"
               },
@@ -11150,7 +11164,7 @@ autoscaler mode with sbom sidecar:
           annotations:
             checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: 0045bbf353118ddd7d3838ffdda1aaf10ef36b978b5d4cae64821a9afe442547
+            checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -14990,6 +15004,7 @@ autoscaler mode without sbom sidecar:
         resources:
           - applicationprofiles
           - networkneighborhoods
+          - containerprofiles
         verbs:
           - get
           - watch
@@ -15254,6 +15269,12 @@ autoscaler mode without sbom sidecar:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
+                "resource": "containerprofiles",
+                "strategy": "copy"
+              },
+              {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
                 "resource": "knownservers",
                 "strategy": "copy"
               },
@@ -15418,7 +15439,7 @@ autoscaler mode without sbom sidecar:
           annotations:
             checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: 0045bbf353118ddd7d3838ffdda1aaf10ef36b978b5d4cae64821a9afe442547
+            checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -18788,6 +18809,7 @@ backend-storage enabled disables scanning capabilities:
         resources:
           - applicationprofiles
           - networkneighborhoods
+          - containerprofiles
         verbs:
           - get
           - watch
@@ -28276,6 +28298,7 @@ default capabilities:
         resources:
           - applicationprofiles
           - networkneighborhoods
+          - containerprofiles
         verbs:
           - get
           - watch
@@ -28540,6 +28563,12 @@ default capabilities:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
+                "resource": "containerprofiles",
+                "strategy": "copy"
+              },
+              {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
                 "resource": "knownservers",
                 "strategy": "copy"
               },
@@ -28705,7 +28734,7 @@ default capabilities:
             checksum/cloud-config: 3b417c79d450e1ee66af001647fdd151dd56c6892d6a369a2ee09fbf4528b763
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: 0045bbf353118ddd7d3838ffdda1aaf10ef36b978b5d4cae64821a9afe442547
+            checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -32819,6 +32848,7 @@ disable otel:
         resources:
           - applicationprofiles
           - networkneighborhoods
+          - containerprofiles
         verbs:
           - get
           - watch
@@ -33083,6 +33113,12 @@ disable otel:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
+                "resource": "containerprofiles",
+                "strategy": "copy"
+              },
+              {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
                 "resource": "knownservers",
                 "strategy": "copy"
               },
@@ -33247,7 +33283,7 @@ disable otel:
           annotations:
             checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: 0045bbf353118ddd7d3838ffdda1aaf10ef36b978b5d4cae64821a9afe442547
+            checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -43749,6 +43785,7 @@ multiple node agents:
         resources:
           - applicationprofiles
           - networkneighborhoods
+          - containerprofiles
         verbs:
           - get
           - watch
@@ -44082,6 +44119,12 @@ multiple node agents:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
+                "resource": "containerprofiles",
+                "strategy": "copy"
+              },
+              {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
                 "resource": "knownservers",
                 "strategy": "copy"
               },
@@ -44265,7 +44308,7 @@ multiple node agents:
             checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: e8b456b3b9068dc3c4b4faf6e86ebc575adf12d7d399f158e78de309120b5947
+            checksum/synchronizer-configmap: e76e7dbe5bf3893cc21ff4dc5ef6e85208fd0ede63a479fac4bde3f8c7f5a2b5
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -48423,6 +48466,7 @@ priority class scheduling:
         resources:
           - applicationprofiles
           - networkneighborhoods
+          - containerprofiles
         verbs:
           - get
           - watch
@@ -48687,6 +48731,12 @@ priority class scheduling:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
+                "resource": "containerprofiles",
+                "strategy": "copy"
+              },
+              {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
                 "resource": "knownservers",
                 "strategy": "copy"
               },
@@ -48851,7 +48901,7 @@ priority class scheduling:
           annotations:
             checksum/cloud-config: aeb74e26eeb9309009b4e1507a4291de5e062bdd0f68d08a68250ea200f32fa0
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: 0045bbf353118ddd7d3838ffdda1aaf10ef36b978b5d4cae64821a9afe442547
+            checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -58917,6 +58967,7 @@ skipPersistence enabled:
         resources:
           - applicationprofiles
           - networkneighborhoods
+          - containerprofiles
         verbs:
           - get
           - watch
@@ -59250,6 +59301,12 @@ skipPersistence enabled:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
+                "resource": "containerprofiles",
+                "strategy": "copy"
+              },
+              {
+                "group": "spdx.softwarecomposition.kubescape.io",
+                "version": "v1beta1",
                 "resource": "knownservers",
                 "strategy": "copy"
               },
@@ -59433,7 +59490,7 @@ skipPersistence enabled:
             checksum/cloud-config: 50b2792a8d079d4384072c3b40787ff160fe85abe97736e2be4ac2a6bc56cd9e
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: e8b456b3b9068dc3c4b4faf6e86ebc575adf12d7d399f158e78de309120b5947
+            checksum/synchronizer-configmap: e76e7dbe5bf3893cc21ff4dc5ef6e85208fd0ede63a479fac4bde3f8c7f5a2b5
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer


### PR DESCRIPTION
## What

Adds `containerprofiles` to the in-cluster synchronizer's synced-resource list (strategy: `copy`), alongside `applicationprofiles` and `networkneighborhoods`.

## Changes
- **`templates/synchronizer/configmap.yaml`** — add `containerprofiles` (`spdx.softwarecomposition.kubescape.io/v1beta1`, strategy `copy`) to the synchronizer's resources, inside the `storage.enabled` block.
- **`templates/synchronizer/clusterrole.yaml`** — grant the synchronizer ServiceAccount RBAC on `containerprofiles` (`get/watch/list/create/update/patch/delete`), matching the existing AP/NN rule. Without this the synchronizer cannot read CPs and sync fails.
- **`tests/__snapshot__/snapshot_test.yaml.snap`** — regenerated via `helm-unittest`.

## Why
ContainerProfile storage has two mutually-exclusive modes:
- **Backend storage** — CPs are handled by the backend consolidator pipeline.
- **In-cluster storage** (`storage.enabled`) — profile CRDs live in the cluster and are synced to the backend by the synchronizer.

In the in-cluster-storage mode, `containerprofiles` was the only `spdx.softwarecomposition` profile CRD **not** in the synchronizer's resource list — `applicationprofiles` and `networkneighborhoods` were synced, but CPs were not. This closes that gap so CPs are synced like their AP/NN siblings.

The addition is inside the `storage.enabled` block, so it only takes effect in the in-cluster-storage deployment — it never runs alongside the backend consolidator path, so there is no duplicate handling.

## Testing
`docker run --rm -v "$(pwd)":/apps helmunittest/helm-unittest charts/kubescape-operator/` -> 37 tests, 966 snapshots passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)