### PR TITLE
node-agent: bump GKE Autopilot allowlist default to 1.40-v2

### DIFF
--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -614,7 +614,7 @@ nodeAgent:
   gke:
     allowlist:
       enabled: false
-      name: armo-kubescape-node-agent-1.29
+      name: armo-kubescape-node-agent-1.40-v2
 
   # prometheus (operator) service monitor
   serviceMonitor:


### PR DESCRIPTION
Updates the default `nodeAgent.gke.allowlist.name` from the stale `armo-kubescape-node-agent-1.29` to `armo-kubescape-node-agent-1.40-v2`, matching chart 1.40.x.

Remains opt-in (`nodeAgent.gke.allowlist.enabled: false`) — only takes effect when a user enables the GKE Autopilot allowlist feature. Validated on a live Autopilot cluster (node-agent admitted and Running against the matching allowlist).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a GKE allowlist entry to use a newer node agent name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->