### PR TITLE
fix(storage): restart storage pod when storage config changes

### DIFF
--- a/charts/kubescape-operator/templates/_common.tpl
+++ b/charts/kubescape-operator/templates/_common.tpl
@@ -11,6 +11,7 @@ matchingRulesConfig: {{ include (printf "%s/%s/%s" $.Template.BasePath $.Values.
 nodeAgentConfig: {{ include (printf "%s/node-agent/configmap.yaml" $.Template.BasePath) . | replace .Chart.AppVersion "" | sha256sum }}
 operatorConfig: {{ include (printf "%s/operator/configmap.yaml" $.Template.BasePath) . | replace .Chart.AppVersion "" | sha256sum }}
 proxySecret: {{ include (printf "%s/%s/%s" $.Template.BasePath $.Values.global.proxySecretDirectory "proxy-secret.yaml") . | replace .Chart.AppVersion "" | sha256sum }}
+storageConfig: {{ include (printf "%s/storage/configmap.yaml" $.Template.BasePath) . | replace .Chart.AppVersion "" | sha256sum }}
 synchronizerConfig: {{ include (printf "%s/synchronizer/configmap.yaml" $.Template.BasePath) . | replace .Chart.AppVersion "" | sha256sum }}
 admissionCertgenScripts: {{ include (printf "%s/operator/admission-webhook/configmap.yaml" $.Template.BasePath) . | replace .Chart.AppVersion "" | sha256sum }}
 storageCertgenScripts: {{ include (printf "%s/storage/certgen/configmap.yaml" $.Template.BasePath) . | replace .Chart.AppVersion "" | sha256sum }}

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -24,14 +24,14 @@ spec:
     metadata:
       {{- $podAnnotations := include "kubescape-operator.annotations" (dict "Values" .Values) }}
       {{- $hasCertgenChecksum := and .Values.storage.mtls.enabled (eq (include "kubescape.certificates.strategy" .) "initContainer") }}
-      {{- if or $podAnnotations .Values.storage.podAnnotations $hasCertgenChecksum }}
       annotations:
         {{- with $podAnnotations }}{{- . | nindent 8 }}{{- end }}
         {{- with .Values.storage.podAnnotations }}{{- toYaml . | nindent 8 }}{{- end }}
+        checksum/storage-config: {{ $checksums.storageConfig }}
+        checksum/cloud-config: {{ $checksums.cloudConfig }}
         {{- if $hasCertgenChecksum }}
         checksum/storage-certgen-scripts: {{ $checksums.storageCertgenScripts }}
         {{- end }}
-      {{- end }}
       labels:
         {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.storage.name "tier" .Values.global.namespaceTier) | nindent 8 }}
         {{- with .Values.storage.podLabels }}{{- toYaml . | nindent 8 }}{{- end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -5580,6 +5580,9 @@ all capabilities:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
+            checksum/storage-config: 2bfab29c4f2202642843536de82e3599252f3db66aa3b8429db6fc662544401c
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -10141,6 +10144,9 @@ autoscaler mode with sbom sidecar:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
+            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -14420,6 +14426,9 @@ autoscaler mode without sbom sidecar:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
+            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -19664,6 +19673,9 @@ cert strategy initContainer, admission disabled, mtls disabled:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
+            checksum/storage-config: bacd8615629fc0d8d77c7fa095084e77313ab6666170a7985820f92dfc40670a
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -20074,7 +20086,9 @@ cert strategy initContainer, admission disabled, mtls enabled:
       template:
         metadata:
           annotations:
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/storage-certgen-scripts: 0437bf4a87439f0a5e709a25751946c2ea0940389b61c553aeac7c899fc362a4
+            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -20720,6 +20734,9 @@ cert strategy initContainer, admission enabled, mtls disabled:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
+            checksum/storage-config: bacd8615629fc0d8d77c7fa095084e77313ab6666170a7985820f92dfc40670a
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -21393,7 +21410,9 @@ cert strategy initContainer, admission enabled, mtls enabled:
       template:
         metadata:
           annotations:
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/storage-certgen-scripts: 0437bf4a87439f0a5e709a25751946c2ea0940389b61c553aeac7c899fc362a4
+            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -21776,6 +21795,9 @@ cert strategy template, admission disabled, mtls disabled:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
+            checksum/storage-config: bacd8615629fc0d8d77c7fa095084e77313ab6666170a7985820f92dfc40670a
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -22130,6 +22152,9 @@ cert strategy template, admission disabled, mtls enabled:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
+            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -22583,6 +22608,9 @@ cert strategy template, admission enabled, mtls disabled:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
+            checksum/storage-config: bacd8615629fc0d8d77c7fa095084e77313ab6666170a7985820f92dfc40670a
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -23076,6 +23104,9 @@ cert strategy template, admission enabled, mtls enabled:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
+            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -27671,6 +27702,9 @@ default capabilities:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
+            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -32276,6 +32310,9 @@ disable otel:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
+            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -36752,6 +36789,9 @@ minimal capabilities:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
+            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -43139,6 +43179,9 @@ multiple node agents:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
+            checksum/storage-config: 2bfab29c4f2202642843536de82e3599252f3db66aa3b8429db6fc662544401c
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -47905,6 +47948,9 @@ priority class scheduling:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
+            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -52237,6 +52283,9 @@ relevancy only:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
+            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -58333,6 +58382,9 @@ skipPersistence enabled:
         type: Recreate
       template:
         metadata:
+          annotations:
+            checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
+            checksum/storage-config: 2bfab29c4f2202642843536de82e3599252f3db66aa3b8429db6fc662544401c
           labels:
             app: storage
             app.kubernetes.io/component: storage

--- a/charts/kubescape-operator/tests/operator_node_agent_autoscaler_test.yaml
+++ b/charts/kubescape-operator/tests/operator_node_agent_autoscaler_test.yaml
@@ -10,6 +10,7 @@ templates:
   - operator/configmap.yaml
   - proxy-support/proxy-secret.yaml
   - storage/certgen/configmap.yaml
+  - storage/configmap.yaml
   - synchronizer/configmap.yaml
 tests:
   - it: does not mount the node-agent template when autoscaler is enabled but node-agent is disabled


### PR DESCRIPTION
## Overview
`storage/configmap.yaml` (`config.json`, e.g. `cleanupInterval`) is mounted into the kubescape-storage pod via a `subPath` volume mount, so kubelet never propagates ConfigMap updates to the running container. On top of that, the storage `Deployment` had no checksum annotation to trigger a rollout on `helm upgrade` either, so changing a value like `storage.cleanupInterval` never takes effect until the pod is restarted for an unrelated reason.

This adds a `storageConfig` checksum to the shared `checksums` helper (hash of `storage/configmap.yaml`) and wires it into the storage `Deployment`'s pod annotations, matching the pattern already used by `operator`, `node-agent`, and `synchronizer`. Also adds the `cloud-config` checksum, which was missing from this deployment as well (present on every other deployment).

## Related issues/PRs
Resolved #867

## How to Test
```
helm template charts/kubescape-operator --set account=<guid> --set storage.cleanupInterval=72h | grep checksum/storage-config
```
Changing `storage.cleanupInterval` (or any other `storage.*` config field) between installs now changes the annotation value, which triggers a pod restart on `helm upgrade`.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes (`helm unittest charts/kubescape-operator`, 45/45 passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage component pods now include additional rollout checksums, helping them restart automatically when related configuration changes.
  * Pod annotations are now consistently rendered, even when only checksum-based updates are present.
* **Tests**
  * Updated Helm test coverage to include the storage configuration resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->