### PR TITLE
feat(synchronizer): register aisandboxheartbeats httpEndpoint resource

### DIFF
--- a/charts/kubescape-operator/templates/synchronizer/configmap.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/configmap.yaml
@@ -315,6 +315,12 @@ data:
             "version": "v1",
             "resource": "registrystatuses",
             "strategy": "copy"
+          },
+          {
+            "group": "kubescape.io",
+            "version": "v1",
+            "resource": "aisandboxheartbeats",
+            "strategy": "copy"
           }
         ]
       }

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -6728,6 +6728,12 @@ all capabilities:
                 "version": "v1",
                 "resource": "registrystatuses",
                 "strategy": "copy"
+              },
+              {
+                "group": "kubescape.io",
+                "version": "v1",
+                "resource": "aisandboxheartbeats",
+                "strategy": "copy"
               }
             ]
           }
@@ -6784,7 +6790,7 @@ all capabilities:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: e76e7dbe5bf3893cc21ff4dc5ef6e85208fd0ede63a479fac4bde3f8c7f5a2b5
+            checksum/synchronizer-configmap: cb62da628f5afa9a6ea3abdcf39087e081964cb1f377a58b82bf2c90abbe81c7
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -11123,6 +11129,12 @@ autoscaler mode with sbom sidecar:
                 "version": "v1",
                 "resource": "registrystatuses",
                 "strategy": "copy"
+              },
+              {
+                "group": "kubescape.io",
+                "version": "v1",
+                "resource": "aisandboxheartbeats",
+                "strategy": "copy"
               }
             ]
           }
@@ -11178,7 +11190,7 @@ autoscaler mode with sbom sidecar:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
+            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -15405,6 +15417,12 @@ autoscaler mode without sbom sidecar:
                 "version": "v1",
                 "resource": "registrystatuses",
                 "strategy": "copy"
+              },
+              {
+                "group": "kubescape.io",
+                "version": "v1",
+                "resource": "aisandboxheartbeats",
+                "strategy": "copy"
               }
             ]
           }
@@ -15460,7 +15478,7 @@ autoscaler mode without sbom sidecar:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
+            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -19190,6 +19208,12 @@ backend-storage enabled disables scanning capabilities:
                 "version": "v1",
                 "resource": "registrystatuses",
                 "strategy": "copy"
+              },
+              {
+                "group": "kubescape.io",
+                "version": "v1",
+                "resource": "aisandboxheartbeats",
+                "strategy": "copy"
               }
             ]
           }
@@ -19245,7 +19269,7 @@ backend-storage enabled disables scanning capabilities:
           annotations:
             checksum/cloud-config: d0e00780bee5d2b3a068ad95ac2665cea1cb3b89c3aae81a1fe7659701877dda
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: b740c76ec1e8306e80d1055384fb4c8dd99e593af67e991175a7d6ecb39a2a94
+            checksum/synchronizer-configmap: 5b74632f016d9c39500eebe8e60adaa9f8543666d1517cd2dfb68f0a695ba41a
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -28732,6 +28756,12 @@ default capabilities:
                 "version": "v1",
                 "resource": "registrystatuses",
                 "strategy": "copy"
+              },
+              {
+                "group": "kubescape.io",
+                "version": "v1",
+                "resource": "aisandboxheartbeats",
+                "strategy": "copy"
               }
             ]
           }
@@ -28788,7 +28818,7 @@ default capabilities:
             checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
+            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -33289,6 +33319,12 @@ disable otel:
                 "version": "v1",
                 "resource": "registrystatuses",
                 "strategy": "copy"
+              },
+              {
+                "group": "kubescape.io",
+                "version": "v1",
+                "resource": "aisandboxheartbeats",
+                "strategy": "copy"
               }
             ]
           }
@@ -33344,7 +33380,7 @@ disable otel:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
+            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -44327,6 +44363,12 @@ multiple node agents:
                 "version": "v1",
                 "resource": "registrystatuses",
                 "strategy": "copy"
+              },
+              {
+                "group": "kubescape.io",
+                "version": "v1",
+                "resource": "aisandboxheartbeats",
+                "strategy": "copy"
               }
             ]
           }
@@ -44383,7 +44425,7 @@ multiple node agents:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: e76e7dbe5bf3893cc21ff4dc5ef6e85208fd0ede63a479fac4bde3f8c7f5a2b5
+            checksum/synchronizer-configmap: cb62da628f5afa9a6ea3abdcf39087e081964cb1f377a58b82bf2c90abbe81c7
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -48928,6 +48970,12 @@ priority class scheduling:
                 "version": "v1",
                 "resource": "registrystatuses",
                 "strategy": "copy"
+              },
+              {
+                "group": "kubescape.io",
+                "version": "v1",
+                "resource": "aisandboxheartbeats",
+                "strategy": "copy"
               }
             ]
           }
@@ -48983,7 +49031,7 @@ priority class scheduling:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: dd187d5161f4700388e301de32465c01e24598dd501ba7b091cb7dec78079638
+            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -59530,6 +59578,12 @@ skipPersistence enabled:
                 "version": "v1",
                 "resource": "registrystatuses",
                 "strategy": "copy"
+              },
+              {
+                "group": "kubescape.io",
+                "version": "v1",
+                "resource": "aisandboxheartbeats",
+                "strategy": "copy"
               }
             ]
           }
@@ -59586,7 +59640,7 @@ skipPersistence enabled:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: e76e7dbe5bf3893cc21ff4dc5ef6e85208fd0ede63a479fac4bde3f8c7f5a2b5
+            checksum/synchronizer-configmap: cb62da628f5afa9a6ea3abdcf39087e081964cb1f377a58b82bf2c90abbe81c7
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer


### PR DESCRIPTION
## Overview
Registers a new `kubescape.io/v1/aisandboxheartbeats` resource (`strategy: copy`) in the synchronizer's `httpEndpoint.resources`, alongside the existing `networkstreams`/`nodeprofiles`/`runtimealerts`/`registrystatuses` entries.

This unblocks the node-agent AI-sandbox instance heartbeat ([`armosec/private-node-agent` PR #407](https://github.com/armosec/private-node-agent/pull/407), **merged**) on k8s. The synchronizer's `httpEndpoint` adapter only accepts requests shaped `/apis/v1/<group>/<version>/<resource>` with a body that parses as a Kubernetes `unstructured.Unstructured` object matching that group/version/resource. Without this registration, the heartbeat's `POST /apis/v1/kubescape.io/v1/aisandboxheartbeats` request is rejected with a 400 before the body is even read — confirmed live against a synchronizer `v0.0.147` deployment.

**Update:** this exact change (registering the resource) was also applied live to `armo-dev-stage`'s `synchronizer` configmap ahead of this PR merging, to unblock end-to-end testing. Result: real node-agent pods sending correctly-shaped `aisandboxheartbeats` requests every 30s, synchronizer accepting with `202` (~114 requests / 3 min across the fleet, zero rejections). This PR's change is confirmed correct and safe to merge — it's just a live-tested preview of exactly this diff.

The `event-ingester-service` side (routing the resulting `PutObjectMessage` to the existing `ai-sandbox-heartbeat-v1` Pulsar topic) is tracked separately and does not depend on this PR being merged first — it's a config/code change gated on this Kind existing, but this registration alone is harmless to add ahead of time (an unused registered path costs nothing).

## Additional Information
This repo change is one of three needed end-to-end:
1. **This PR**: synchronizer's `httpEndpoint.resources` (client-side inbound validation). **Live-validated correct on `armo-dev-stage`.**
2. `armosec/event-ingester-service`: `isKindToProduce` + `gvrProducerMap` entry routing this Kind to `ai-sandbox-heartbeat-v1` (backend-side, tracked separately, owned by that team). **Not yet confirmed done** — this is the only remaining unverified piece in the whole chain.
3. `armosec/helm-charts`: bump its pinned `kubescape-operator` chart dependency once this lands in a release, to actually pick up the change for ARMO deployments.

## How to Test
- `helm unittest -u charts/kubescape-operator` (snapshots regenerated in this PR to reflect the new resource entry + the resulting configmap checksum change on the synchronizer deployment).
- `helm lint charts/kubescape-operator` — clean.
- Live-validated on `armo-dev-stage` (see Overview) — this exact diff, applied directly to the deployed configmap, produced correct behavior with real traffic.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project (matches the exact shape of the existing `httpEndpoint.resources` entries)
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)