### PR TITLE
[ LFX 2026 ] feat(kubescape): grant SecurityException read + events RBAC under riskAcceptance

### DIFF
--- a/charts/kubescape-operator/templates/kubescape/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/kubescape/clusterrole.yaml
@@ -86,6 +86,18 @@ rules:
 - apiGroups: ["kubescape.io"]
   resources: ["servicesscanresults"]
   verbs: ["get", "watch", "list"]
+{{- if eq .Values.capabilities.riskAcceptance "enable" }}
+# SecurityException CRDs (opt-in via capabilities.riskAcceptance). The in-cluster
+# posture scanner reads these to suppress matching findings, and emits Events on the
+# matched SecurityException/ClusterSecurityException resource; both are only needed
+# when risk acceptance is enabled.
+- apiGroups: ["kubescape.io"]
+  resources: ["securityexceptions", "clustersecurityexceptions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+{{- end }}
 {{- if .Values.nodeAgent.config.hostSensor.enabled }}
 - apiGroups: ["hostdata.kubescape.cloud"]
   resources:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1089,6 +1089,22 @@ all capabilities:
           - watch
           - list
       - apiGroups:
+          - kubescape.io
+        resources:
+          - securityexceptions
+          - clustersecurityexceptions
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+      - apiGroups:
           - hostdata.kubescape.cloud
         resources:
           - osreleasefiles
@@ -38430,6 +38446,22 @@ multiple node agents:
           - watch
           - list
       - apiGroups:
+          - kubescape.io
+        resources:
+          - securityexceptions
+          - clustersecurityexceptions
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+      - apiGroups:
           - hostdata.kubescape.cloud
         resources:
           - osreleasefiles
@@ -53935,6 +53967,22 @@ skipPersistence enabled:
           - get
           - watch
           - list
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - securityexceptions
+          - clustersecurityexceptions
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
       - apiGroups:
           - hostdata.kubescape.cloud
         resources:


### PR DESCRIPTION
## Overview

The in-cluster `kubescape` component already **reads** `SecurityException` /
`ClusterSecurityException` CRDs and **emits Kubernetes Events** on matched exceptions —
this code is already merged and released on `kubescape/kubescape` `main`
(`core/cautils/getter/crdexceptionsgetter.go` calls `.List()` on both CRD kinds;
`core/core/scan.go` wires `newSecurityExceptionEventRecorder`; `core/pkg/opaprocessor/exceptionevents.go`
emits the Events). But the `kubescape` ClusterRole
(`charts/kubescape-operator/templates/kubescape/clusterrole.yaml`) was never granted the
matching permissions.

Net effect on a real cluster:

- `CRDExceptionsGetter.GetExceptions()` → `securityexceptions.List()` returns **403
  Forbidden**. The error is swallowed by `MergedExceptionsGetter` as a `Warning`, so
  **posture CRD exceptions silently do nothing** in-cluster.
- Every exception-match Event write (`recorder.Eventf`) is **403 Forbidden** — the
  observability half of the feature is dead.

This is the RBAC counterpart to the already-shipped code. The `kubevuln` and `operator`
ClusterRoles already carry the equivalent grants (both gated on
`capabilities.riskAcceptance`); the `kubescape` ClusterRole was the one left behind.

## What changed

One template, `charts/kubescape-operator/templates/kubescape/clusterrole.yaml`, adds a
block gated on `capabilities.riskAcceptance == "enable"` (matching the existing kubevuln
and operator gating exactly):

```yaml
{{- if eq .Values.capabilities.riskAcceptance "enable" }}
# SecurityException CRDs (opt-in via capabilities.riskAcceptance). The in-cluster
# posture scanner reads these to suppress matching findings, and emits Events on the
# matched SecurityException/ClusterSecurityException resource; both are only needed
# when risk acceptance is enabled.
- apiGroups: ["kubescape.io"]
  resources: ["securityexceptions", "clustersecurityexceptions"]
  verbs: ["get", "list", "watch"]
- apiGroups: [""]
  resources: ["events"]
  verbs: ["create", "patch"]
{{- end }}
```

- **Read-only on the CRDs** (`get`/`list`/`watch`) — the scanner consumes exceptions, it
  never mutates them. `create`/`update`/`delete` are deliberately withheld.
- **`create`/`patch` on core `events`** — the only Events the kubescape component emits
  today are the SecurityException match Events, so the grant is scoped inside the same
  `riskAcceptance` gate (least-privilege). If a future kubescape feature needs to emit
  unrelated Events, that grant should be lifted out of this gate.
- **Default install is unchanged.** `capabilities.riskAcceptance` defaults to `disable`,
  so a stock install gains no new permissions.

The regenerated `helm unittest` snapshot
(`charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap`, +48 lines across
the three `riskAcceptance: enable` snapshot cases) is included.

## How to Test

All of the following were run against a live **kind v1.31.0** cluster (3 nodes) with a
kubescape binary built from the current SecurityException branch.

### 1. Chart unit tests + template render

```bash
# renders the new rules only when the capability is on
helm template charts/kubescape-operator --set capabilities.riskAcceptance=enable \
  --show-only templates/kubescape/clusterrole.yaml | grep -A2 securityexceptions   # present
helm template charts/kubescape-operator \
  --show-only templates/kubescape/clusterrole.yaml | grep -c securityexceptions    # 0 (default)

helm unittest charts/kubescape-operator
# Test Suites: 4 passed, 4 total · Tests: 37 passed · Snapshot: 966 passed
```

### 2. RBAC enforcement (`kubectl auth can-i`)

Bound the rendered ClusterRole to a test ServiceAccount and probed it:

| Check | `riskAcceptance=enable` | default (`disable`) |
|---|---|---|
| `list securityexceptions.kubescape.io` | **yes** | **no** |
| `list clustersecurityexceptions.kubescape.io` | **yes** | **no** |
| `create events` / `patch events` | **yes** | **no** |
| `create` / `delete securityexceptions` (least-priv) | **no** | **no** |
| `list servicesscanresults` (baseline, unchanged) | yes | yes |

### 3. CRD CEL admission (companion CRDs, `--dry-run=server`)

Rejected: no `vulnerabilities`/`posture`; `not_affected` without `justification`; invalid
posture `action`. Accepted: posture-only; `not_affected`+`justification`+future
`expiresAt`; `ClusterSecurityException` with `namespaceSelector` + `objectSelector.matchExpressions`.

### 4. Full end-to-end posture scan

Deployed `Deployment/nginx-frontend` (labels `app=nginx, tier=frontend`) in namespace
`se-e2e`, then scanned `framework nsa` scoped to that namespace:

| Scenario | Expected | Observed |
|---|---|---|
| Baseline (no exception) | findings fail | 11 failed controls, score **55** |
| Except C-0017 via `objectSelector.matchExpressions In[frontend,backend]` + C-0034 via `resources` (`ignore`) | both excepted, others stay failed | C-0017 & C-0034 → `passed w/exceptions`; C-0013/C-0016 still failed; score **61** |
| **Events** emitted on match | Event bound to SE, visible in `kubectl describe se` | `Normal ExceptionMatched  kubescape  Matched control C-0017 on Deployment/nginx-frontend in namespace se-e2e` |
| **Expiry** (`expiresAt: 2020-01-01`) | exception skipped at scan time | C-0017/C-0034 back to failed; score **55** |
| `matchExpressions NotIn[frontend]` (negative) | not matched | C-0017 stays failed |
| `matchExpressions Exists` (positive) | matched | C-0017 → `passed w/exceptions`; score **59** |
| **ClusterSecurityException** + `namespaceSelector matchLabels{env:e2e}` | excepted + Event | C-0016 → `passed w/exceptions`; Event surfaced by `kubectl describe cse` |

The full chain works end-to-end with these RBAC grants in place: CRD read → match
conversion (resources, `objectSelector` matchLabels + matchExpressions with
`In`/`NotIn`/`Exists`, `namespaceSelector`) → cloud-vs-CRD precedence → scan-time expiry
filter → Event emission.

> **Observed during testing (out of scope for this RBAC PR):** the design doc's
> `alert_only` vs `ignore` scoring distinction does not appear to be differentiated
> downstream — a single `alert_only` exception raised the compliance score (55→59), i.e.
> `alert_only` is scored like `ignore`. Per the design, `alert_only` should still *fail*
> scoring (annotated but counted as failed). This lives in opa-utils/armotypes action
> handling, not in the RBAC or the CRD getter, and is tracked separately.

## Related issues/PRs

- Part of #1982 — SecurityException CRD implementation (epic).
- Companion CRD + gating already on `main`: helm-charts #855 (`capabilities.remediation`
  pattern), #859 (SecurityException CEL); kubevuln/operator ClusterRoles already gated on
  `capabilities.riskAcceptance`.
- Independent of kubescape #2480 (`objectSelector.matchExpressions`) — same code path, no
  RBAC change.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes (`helm unittest` green; snapshot regenerated)
- [x] Verified end-to-end on a live v1.31.0 cluster (RBAC enforcement + full scan + Events)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional permissions support for risk acceptance mode.
  * When enabled, the app can access additional security exception resources and create or update events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->