### PR TITLE
GKE Autopilot allowlist drift gate + helper scripts

### DIFF
--- a/.github/workflows/03-helm-release.yaml
+++ b/.github/workflows/03-helm-release.yaml
@@ -22,12 +22,21 @@ on:
         required: false
         default: "main"
         type: string
+      BYPASS_ALLOWLIST_DRIFT:
+        description: "Set true to pass the GKE Autopilot allowlist drift gate after you have opened a Gerrit allowlist update"
+        required: false
+        default: false
+        type: boolean
 
   workflow_call:
     inputs:
       COMMIT_REF:
         required: true
         type: string
+      BYPASS_ALLOWLIST_DRIFT:
+        required: false
+        default: false
+        type: boolean
       CHARTS_NAME:
         required: true
         type: string
@@ -51,9 +60,43 @@ jobs:
     uses: ./.github/workflows/02-e2e-test.yaml
     secrets: inherit
 
+  allowlist-drift-check:
+    # Fails the release if the node-agent render drifts from the approved GKE Autopilot
+    # allowlist (vendored under gke-allowlist/). Bypass with BYPASS_ALLOWLIST_DRIFT=true
+    # after opening a Gerrit allowlist update. See scripts/gke-allowlist/README.md.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.RELEASE_BRANCH || inputs.COMMIT_REF }}
+      - name: Install Helm
+        uses: azure/setup-helm@v3.5
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install pyyaml
+      - name: Check node-agent vs approved allowlist
+        run: |
+          set +e
+          scripts/gke-allowlist/check-drift.sh \
+            charts/kubescape-operator \
+            gke-allowlist/armo-kubescape-node-agent-1.40-v2.yaml
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            if [ "${{ inputs.BYPASS_ALLOWLIST_DRIFT }}" = "true" ]; then
+              echo "::warning::node-agent drifts from the approved allowlist, but BYPASS_ALLOWLIST_DRIFT=true — ensure a Gerrit allowlist update is open."
+            else
+              echo "::error::node-agent drifts from the approved GKE Autopilot allowlist. Open a Gerrit allowlist update, then re-run the release with BYPASS_ALLOWLIST_DRIFT=true."
+              exit 1
+            fi
+          fi
+
   helm-chart-release:
-    needs: e2e-test
-    if: ${{ !cancelled() && (needs.e2e-test.result == 'success' || needs.e2e-test.result == 'skipped') }}
+    needs: [e2e-test, allowlist-drift-check]
+    if: ${{ !cancelled() && (needs.e2e-test.result == 'success' || needs.e2e-test.result == 'skipped') && needs.allowlist-drift-check.result == 'success' }}
     permissions:
       id-token: write      # Required: OIDC token for keyless attestation signing
       contents: write      # Required: chart-releaser creates GitHub Releases and pushes gh-pages index

--- a/.github/workflows/03-helm-release.yaml
+++ b/.github/workflows/03-helm-release.yaml
@@ -65,11 +65,14 @@ jobs:
     # allowlist (vendored under gke-allowlist/). Bypass with BYPASS_ALLOWLIST_DRIFT=true
     # after opening a Gerrit allowlist update. See scripts/gke-allowlist/README.md.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.RELEASE_BRANCH || inputs.COMMIT_REF }}
+          persist-credentials: false
       - name: Install Helm
         uses: azure/setup-helm@v3.5
       - name: Install Python
@@ -85,13 +88,19 @@ jobs:
             gke-allowlist/armo-kubescape-node-agent-1.40-v2.yaml
           rc=$?
           set -e
-          if [ "$rc" -ne 0 ]; then
+          # exit 2 = spec-drift (bypassable); 0 = OK; anything else = the check crashed and must not be bypassed.
+          if [ "$rc" -eq 0 ]; then
+            exit 0
+          elif [ "$rc" -eq 2 ]; then
             if [ "${{ inputs.BYPASS_ALLOWLIST_DRIFT }}" = "true" ]; then
               echo "::warning::node-agent drifts from the approved allowlist, but BYPASS_ALLOWLIST_DRIFT=true — ensure a Gerrit allowlist update is open."
-            else
-              echo "::error::node-agent drifts from the approved GKE Autopilot allowlist. Open a Gerrit allowlist update, then re-run the release with BYPASS_ALLOWLIST_DRIFT=true."
-              exit 1
+              exit 0
             fi
+            echo "::error::node-agent drifts from the approved GKE Autopilot allowlist. Open a Gerrit allowlist update, then re-run the release with BYPASS_ALLOWLIST_DRIFT=true."
+            exit 1
+          else
+            echo "::error::allowlist drift check failed to run (exit $rc) — not a drift result, so BYPASS_ALLOWLIST_DRIFT does not apply. Fix the check."
+            exit 1
           fi
 
   helm-chart-release:

--- a/docs/features/gke-autopilot-allowlist-tooling.md
+++ b/docs/features/gke-autopilot-allowlist-tooling.md
@@ -1,0 +1,61 @@
+# GKE Autopilot Allowlist Tooling & Release Drift Gate
+
+## Overview
+
+Running the `node-agent` on **GKE Autopilot** requires a Google-approved `WorkloadAllowlist` — Autopilot
+blocks privileged workloads unless a matching allowlist is installed (via an `AllowlistSynchronizer`).
+ARMO maintains those allowlists in a Google-managed (Gerrit) repository; this chart's node-agent is
+matched against `armo-kubescape-node-agent-<chart-minor>`.
+
+This feature adds tooling to keep the chart and the approved allowlist in sync, and a **release-time
+gate** that prevents shipping a chart the approved allowlist can no longer admit.
+
+## Why a gate is needed
+
+GKE Autopilot admission is **subset-based**: a pod is admitted only if its environment variables,
+containers, mounts, and Linux capabilities are a **subset** of the matched allowlist. If a chart change
+adds something new to the node-agent (a new env var, mount, capability, or sidecar) that the approved
+allowlist does not list, **customers on Autopilot can no longer install the chart** until a new
+allowlist is approved — which involves Google review and a gradual rollout. The gate catches this at
+release time instead of in the field.
+
+## Components
+
+- **`scripts/gke-allowlist/allowlist-drift.py`** — renders the node-agent and classifies it against an
+  allowlist as `no-op`, `digest-only`, or `spec-drift` (exit code 2 on spec-drift).
+- **`scripts/gke-allowlist/check-drift.sh`** — the wrapper the release workflow calls. It renders the
+  node-agent with the full set of optional features enabled (backend server/`API_URL`, HTTP proxy,
+  custom runtime path, kernel-check skip, full malware scan, ClamAV, SBOM scanner, OTEL) so the check
+  exercises the maximal privileged surface, then verifies it is a subset of the allowlist.
+- **`scripts/gke-allowlist/build-allowlists.py`, `refresh-digests.py`** — allowlist-repo-side helpers
+  (assemble allowlist files; append new node-agent image digests to the mutable `containerImageDigests`
+  field). Documented in `scripts/gke-allowlist/README.md`.
+- **`gke-allowlist/armo-kubescape-node-agent-1.40-v2.yaml`** — a vendored copy of the currently approved
+  allowlist, so the gate runs with no network or auth.
+
+## Release behavior
+
+The `03-helm-release.yaml` workflow runs an `allowlist-drift-check` job before publishing:
+
+- **No drift** → job passes, release proceeds.
+- **Drift detected** → job **fails** with the specific missing fields, blocking the release.
+- **Intentional drift** (you are shipping a change that needs a new allowlist): open the Gerrit
+  allowlist update first, then re-run the release with the **`BYPASS_ALLOWLIST_DRIFT: true`** input.
+  The gate then passes with a warning ("set as pass after you opened Gerrit to allowlist").
+
+When drift is intentional, also update the vendored `gke-allowlist/` copy and the chart's
+`nodeAgent.gke.allowlist.name` default to the new allowlist once it is approved.
+
+## Run locally
+
+```bash
+scripts/gke-allowlist/check-drift.sh charts/kubescape-operator \
+  gke-allowlist/armo-kubescape-node-agent-1.40-v2.yaml
+```
+
+## Limitation
+
+The check covers subset-matched fields (env names, containers, capabilities, mounts, hostPath volumes,
+image repo). It does not see runtime-only fields such as the per-node-group
+`node.kubernetes.io/instance-type` nodeSelector the autoscaler adds (which needs the
+`autogke-node-affinity-selector-limitation` exemption) — validate those on a live Autopilot cluster.

--- a/gke-allowlist/armo-kubescape-node-agent-1.40-v2.yaml
+++ b/gke-allowlist/armo-kubescape-node-agent-1.40-v2.yaml
@@ -1,0 +1,298 @@
+apiVersion: auto.gke.io/v1
+kind: WorkloadAllowlist
+minGKEVersion: 1.32.0-gke.1000000
+metadata:
+  name: armo-kubescape-node-agent-1.40-v2
+  annotations:
+    autopilot.gke.io/no-connect: "true"
+exemptions:
+  # Node Agent monitors all processes/containers on the node, so it needs the host PID namespace.
+  - autogke-disallow-hostnamespaces
+  # Node Agent needs write access to parts of the host (container runtime socket, eBPF fs) for eBPF.
+  - autogke-no-write-mode-hostpath
+  # Node Agent needs SYS_ADMIN/SYS_PTRACE/NET_ADMIN/SYSLOG/SYS_RESOURCE/IPC_LOCK/NET_RAW for eBPF.
+  - autogke-default-linux-capabilities
+  # Autoscaler mode adds a node.kubernetes.io/instance-type nodeSelector per node group;
+  # Autopilot disallows that selector key without this exemption.
+  - autogke-node-affinity-selector-limitation
+matchingCriteria:
+  hostPID: true
+  containers:
+    - name: clamav
+      image: ^quay\.io/kubescape/klamav$
+      securityContext:
+        capabilities:
+          add:
+            - SYS_PTRACE
+      volumeMounts:
+        - mountPath: /var/lib/clamav-tmp
+          name: clamdb
+        - mountPath: /run/clamav
+          name: clamrun
+        - mountPath: /etc/clamav
+          name: etc
+          readOnly: true
+    - name: sbom-scanner
+      image: ^quay\.io/kubescape/node-agent$
+      command:
+        - /usr/bin/sbom-scanner
+      env:
+        - name: GOMEMLIMIT
+        - name: SOCKET_PATH
+        - name: HOST_ROOT
+        - name: OTEL_COLLECTOR_SVC
+        - name: NODE_NAME
+        - name: POD_NAME
+        - name: NAMESPACE
+        - name: CLUSTER_NAME
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+      volumeMounts:
+        - mountPath: /sbom-comm
+          name: sbom-comm
+        - mountPath: /host
+          name: host
+          readOnly: true
+        - mountPath: /tmp
+          name: sbom-scanner-tmp
+    - name: node-agent
+      image: ^quay\.io/kubescape/node-agent$
+      env:
+        - name: GOMEMLIMIT
+        - name: HOST_ROOT
+        - name: KS_LOGGER_LEVEL
+        - name: KS_LOGGER_NAME
+        - name: OTEL_COLLECTOR_SVC
+        - name: CLAMAV_SOCKET
+        - name: SBOM_SCANNER_SOCKET
+        - name: SCANNER_MEMORY_LIMIT
+        - name: NODE_NAME
+        - name: POD_NAME
+        - name: NAMESPACE_NAME
+        - name: KUBELET_ROOT
+        - name: AGENT_VERSION
+        - name: NodeName
+        - name: IGNORERULEBINDINGS
+        # API_URL is set whenever .Values.server is configured (every backend-connected install).
+        - name: API_URL
+        # Conditional env from optional node-agent features (egress proxy / custom container
+        # runtime path / kernel-version-check skip / full-filesystem malware scan).
+        - name: HTTPS_PROXY
+        - name: no_proxy
+        - name: RUNTIME_PATH
+        - name: SKIP_KERNEL_VERSION_CHECK
+        - name: MALWARE_SCAN_ALL_FILES
+      securityContext:
+        capabilities:
+          add:
+            - SYS_ADMIN
+            - SYS_PTRACE
+            - NET_ADMIN
+            - SYSLOG
+            - SYS_RESOURCE
+            - IPC_LOCK
+            - NET_RAW
+        privileged: false
+      volumeMounts:
+        - mountPath: /host
+          name: host
+          readOnly: true
+        - mountPath: /var/lib/kubelet
+          name: kubeletdir
+        - mountPath: /run
+          name: run
+        - mountPath: /var
+          name: var
+          readOnly: true
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/kernel/debug
+          name: debugfs
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /sys/fs/bpf
+          name: bpffs
+        - mountPath: /data
+          name: data
+        - mountPath: /profiles
+          name: profiles
+        - mountPath: /boot
+          name: boot
+          readOnly: true
+        - mountPath: /clamav
+          name: clamrun
+        - mountPath: /sbom-comm
+          name: sbom-comm
+        - mountPath: /etc/credentials
+          name: cloud-secret
+          readOnly: true
+        - mountPath: /etc/config/clusterData.json
+          name: ks-cloud-config
+          readOnly: true
+          subPath: clusterData.json
+        - mountPath: /etc/config/config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+  securityContext:
+    appArmorProfile:
+      type: Unconfined
+  volumes:
+    - hostPath:
+        path: /
+      name: host
+    - hostPath:
+        path: /var/lib/kubelet
+      name: kubeletdir
+    - hostPath:
+        path: /run
+      name: run
+    - hostPath:
+        path: /var
+      name: var
+    - hostPath:
+        path: /sys/fs/cgroup
+      name: cgroup
+    - hostPath:
+        path: /lib/modules
+      name: modules
+    - hostPath:
+        path: /sys/fs/bpf
+      name: bpffs
+    - hostPath:
+        path: /sys/kernel/debug
+      name: debugfs
+    - hostPath:
+        path: /boot
+      name: boot
+    - name: data
+    - name: profiles
+    - hostPath:
+        path: /
+      name: host-filesystem
+    - name: clamdb
+    - name: clamrun
+    - configMap:
+        defaultMode: 420
+        name: clamav
+      name: etc
+    - name: sbom-comm
+    - name: sbom-scanner-tmp
+    - name: cloud-secret
+    - configMap:
+        defaultMode: 420
+        name: ks-cloud-config
+      name: ks-cloud-config
+    - configMap:
+        defaultMode: 420
+        name: node-agent
+      name: config
+containerImageDigests:
+  - containerName: node-agent
+    imageDigests:
+      # quay.io/kubescape/node-agent:v0.3.147
+      - a457e95a15d7031ca2cb496a8e5f55a586b5c89cbfa53a3f104dde07b22ec72d
+      # quay.io/kubescape/node-agent:v0.3.146
+      - c6bd0c08c77733a563533c80e23e9e32274619e0d86950b0da6341acc0cc8be8
+      # quay.io/kubescape/node-agent:v0.3.142
+      - 62d9409e776b031c06a243691517c6931974689ae0a224b4512a646569fd8096
+      # quay.io/kubescape/node-agent:v0.3.137
+      - 8a17ce5c46a1c1a91c5b9bf04b39f3c8f7aaf3876653610a56cc24b4c3c7ee58
+      # quay.io/kubescape/node-agent:v0.3.136
+      - 6c93d5a1cec99fd6bf12822a61eba28a44c096f734114dc051dcadad28abb268
+      # quay.io/kubescape/node-agent:v0.3.132
+      - 8ee74b7c2dd3bac652da66d250c6a413144b9470cee7f3cabc586cdd17344b2d
+      # quay.io/kubescape/node-agent:v0.3.129
+      - 88e30e5f81416be8bb53dfef0ff8acf2524e08c674b86706df8018687732dcff
+      # quay.io/kubescape/node-agent:v0.3.128
+      - 2e50795a3caf6037d4e68f93a243538b63a548384141e8363f1f5d4f0d6fd659
+      # quay.io/kubescape/node-agent:v0.3.127
+      - 8f601109d3e601f69ba3e53526738bafc86bde560b24f7e964b16e739adbc86f
+      # quay.io/kubescape/node-agent:v0.3.124
+      - 5fb4e257a0b073ba477bda3355fa3084303d1b296a471b16141439cfee0c188e
+      # quay.io/kubescape/node-agent:v0.3.122
+      - e5fbf7640ecdd55f08a548f6bf4d74ca08b7d0e61f42cdb2a0bda3e68f15191b
+      # quay.io/kubescape/node-agent:v0.3.119
+      - 49312282fb3ff219d5b3951e576238dec3c6aec3601dafc51e773925ef17ae23
+      # quay.io/kubescape/node-agent:v0.3.115
+      - 30d66204d7b96f9b14a66c374c473325b9887053e327f51e3dda5983a9d0d83b
+      # quay.io/kubescape/node-agent:v0.3.113
+      - a2eaf36df1e1ed1fe792e2630b4b6376141d3a092971498cce04e03a045eb319
+      # quay.io/kubescape/node-agent:v0.3.112
+      - 262e5410b840f4b3e5a4181a3f0bffdf243401d257b23d244aab46f48b30bd21
+      # quay.io/kubescape/node-agent:v0.3.111
+      - 0affd7279bb0be7fee4172a93ac7f321aeee13a5334dd75c4768e898f7d61213
+      # quay.io/kubescape/node-agent:v0.3.108
+      - 227ace3d845e8b879c4d52dbd488aa3898476c7c979bb26542725b5021841e47
+      # quay.io/kubescape/node-agent:v0.3.97
+      - 2650bf5f6372b623571bbf8a5b3cb6c1f9dbe3af9cb14ee47d2aecfc2d19de19
+      # quay.io/kubescape/node-agent:v0.3.94
+      - d1383f7554a880df1aee9c2b5de0bc601f5c8f55fdb864a961501c8b81da6000
+      # quay.io/kubescape/node-agent:v0.3.91
+      - 3f785d2f7e6ba9673d7d2984bba32fb9691ed4af2bbd6092628f45c653021a07
+      # quay.io/kubescape/node-agent:v0.3.79
+      - 79d0437e502e9185bc621ea1efcfcc9cecf9ae924e31ee81de0f0d9b0e2e5d14
+      # quay.io/kubescape/node-agent:v0.3.75
+      - be6d1c6a83b93a56284a41116d77572d6067fc48aee23e2af9a74901d5e347e8
+      # quay.io/kubescape/node-agent:v0.3.71
+      - 2321ac886b557bd1eabd685c0397d79e5163dec70852a3542cfe6818cd7161c9
+      # quay.io/kubescape/node-agent:v0.3.69
+      - 6ca437d13a07193c7efd84f4f616024d40c7a83412767b2388cd138b3b4cfad3
+      # quay.io/kubescape/node-agent:v0.3.63
+      - 6731c347fea645da1c543dec0fc720a073bb4a5e5792f5374fe5f210dc6407b3
+  - containerName: sbom-scanner
+    imageDigests:
+      # quay.io/kubescape/node-agent:v0.3.147
+      - a457e95a15d7031ca2cb496a8e5f55a586b5c89cbfa53a3f104dde07b22ec72d
+      # quay.io/kubescape/node-agent:v0.3.146
+      - c6bd0c08c77733a563533c80e23e9e32274619e0d86950b0da6341acc0cc8be8
+      # quay.io/kubescape/node-agent:v0.3.142
+      - 62d9409e776b031c06a243691517c6931974689ae0a224b4512a646569fd8096
+      # quay.io/kubescape/node-agent:v0.3.137
+      - 8a17ce5c46a1c1a91c5b9bf04b39f3c8f7aaf3876653610a56cc24b4c3c7ee58
+      # quay.io/kubescape/node-agent:v0.3.136
+      - 6c93d5a1cec99fd6bf12822a61eba28a44c096f734114dc051dcadad28abb268
+      # quay.io/kubescape/node-agent:v0.3.132
+      - 8ee74b7c2dd3bac652da66d250c6a413144b9470cee7f3cabc586cdd17344b2d
+      # quay.io/kubescape/node-agent:v0.3.129
+      - 88e30e5f81416be8bb53dfef0ff8acf2524e08c674b86706df8018687732dcff
+      # quay.io/kubescape/node-agent:v0.3.128
+      - 2e50795a3caf6037d4e68f93a243538b63a548384141e8363f1f5d4f0d6fd659
+      # quay.io/kubescape/node-agent:v0.3.127
+      - 8f601109d3e601f69ba3e53526738bafc86bde560b24f7e964b16e739adbc86f
+      # quay.io/kubescape/node-agent:v0.3.124
+      - 5fb4e257a0b073ba477bda3355fa3084303d1b296a471b16141439cfee0c188e
+      # quay.io/kubescape/node-agent:v0.3.122
+      - e5fbf7640ecdd55f08a548f6bf4d74ca08b7d0e61f42cdb2a0bda3e68f15191b
+      # quay.io/kubescape/node-agent:v0.3.119
+      - 49312282fb3ff219d5b3951e576238dec3c6aec3601dafc51e773925ef17ae23
+      # quay.io/kubescape/node-agent:v0.3.115
+      - 30d66204d7b96f9b14a66c374c473325b9887053e327f51e3dda5983a9d0d83b
+      # quay.io/kubescape/node-agent:v0.3.113
+      - a2eaf36df1e1ed1fe792e2630b4b6376141d3a092971498cce04e03a045eb319
+      # quay.io/kubescape/node-agent:v0.3.112
+      - 262e5410b840f4b3e5a4181a3f0bffdf243401d257b23d244aab46f48b30bd21
+      # quay.io/kubescape/node-agent:v0.3.111
+      - 0affd7279bb0be7fee4172a93ac7f321aeee13a5334dd75c4768e898f7d61213
+      # quay.io/kubescape/node-agent:v0.3.108
+      - 227ace3d845e8b879c4d52dbd488aa3898476c7c979bb26542725b5021841e47
+      # quay.io/kubescape/node-agent:v0.3.97
+      - 2650bf5f6372b623571bbf8a5b3cb6c1f9dbe3af9cb14ee47d2aecfc2d19de19
+      # quay.io/kubescape/node-agent:v0.3.94
+      - d1383f7554a880df1aee9c2b5de0bc601f5c8f55fdb864a961501c8b81da6000
+      # quay.io/kubescape/node-agent:v0.3.91
+      - 3f785d2f7e6ba9673d7d2984bba32fb9691ed4af2bbd6092628f45c653021a07
+      # quay.io/kubescape/node-agent:v0.3.79
+      - 79d0437e502e9185bc621ea1efcfcc9cecf9ae924e31ee81de0f0d9b0e2e5d14
+      # quay.io/kubescape/node-agent:v0.3.75
+      - be6d1c6a83b93a56284a41116d77572d6067fc48aee23e2af9a74901d5e347e8
+      # quay.io/kubescape/node-agent:v0.3.71
+      - 2321ac886b557bd1eabd685c0397d79e5163dec70852a3542cfe6818cd7161c9
+      # quay.io/kubescape/node-agent:v0.3.69
+      - 6ca437d13a07193c7efd84f4f616024d40c7a83412767b2388cd138b3b4cfad3
+      # quay.io/kubescape/node-agent:v0.3.63
+      - 6731c347fea645da1c543dec0fc720a073bb4a5e5792f5374fe5f210dc6407b3

--- a/scripts/gke-allowlist/README.md
+++ b/scripts/gke-allowlist/README.md
@@ -20,7 +20,7 @@ gradual rollout). The release drift gate (below) catches that before release.
 | Script | Purpose |
 |--------|---------|
 | `allowlist-drift.py` | Classify a chart render vs an allowlist as `no-op` / `digest-only` / `spec-drift`. Exit 2 on spec-drift (CI-gate friendly). |
-| `check-drift.sh` | Wrapper the release CI calls: renders the node-agent with all optional features on and runs `allowlist-drift.py`. |
+| `check-drift.sh` | Wrapper script the release CI calls: renders the node-agent with all optional features on and runs `allowlist-drift.py`. |
 | `build-allowlists.py` | (allowlist-repo side) Assemble final WorkloadAllowlist files from GKE-generated baselines + value overlays + image digests. |
 | `refresh-digests.py` | (allowlist-repo side) Append newly-released node-agent image SHA-256 digests to an approved allowlist's mutable `containerImageDigests` field. |
 

--- a/scripts/gke-allowlist/README.md
+++ b/scripts/gke-allowlist/README.md
@@ -1,0 +1,52 @@
+# GKE Autopilot allowlist tooling
+
+Scripts for maintaining the GKE Autopilot **WorkloadAllowlists** that let the node-agent run on
+Autopilot clusters. Background: [running the node-agent on GKE Autopilot](https://kubescape.io/docs/integrations/kubescape-integration-with-cloud-providers/running-armokubescape-node-agents-on-gke-autopilot-clusters/).
+
+The approved allowlists live in ARMO's Google-managed (Gerrit) repo `gke-ap-allowlist/ARMO`. A copy of
+the current approved allowlist for this chart is vendored under [`../../gke-allowlist/`](../../gke-allowlist/)
+so CI can check the chart against it without network/auth.
+
+## Why this matters
+
+GKE Autopilot admission is **subset-based**: a pod is admitted only if its env vars, containers,
+mounts and capabilities are a **subset** of the matched allowlist. So if a chart change adds a new
+env var / mount / capability / container to the node-agent that the approved allowlist doesn't list,
+**customers on Autopilot can no longer install** until a new allowlist is approved (Gerrit review +
+gradual rollout). The release drift gate (below) catches that before release.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `allowlist-drift.py` | Classify a chart render vs an allowlist as `no-op` / `digest-only` / `spec-drift`. Exit 2 on spec-drift (CI-gate friendly). |
+| `check-drift.sh` | Wrapper the release CI calls: renders the node-agent with all optional features on and runs `allowlist-drift.py`. |
+| `build-allowlists.py` | (allowlist-repo side) Assemble final WorkloadAllowlist files from GKE-generated baselines + value overlays + image digests. |
+| `refresh-digests.py` | (allowlist-repo side) Append newly-released node-agent image SHA-256 digests to an approved allowlist's mutable `containerImageDigests` field. |
+
+## Run the drift check locally
+
+```bash
+# public kubescape chart
+scripts/gke-allowlist/check-drift.sh charts/kubescape-operator \
+  gke-allowlist/armo-kubescape-node-agent-1.40-v2.yaml
+```
+Exit 0 = covered; exit 2 = drift (the render needs something the allowlist lacks — the output names
+each missing env/mount/container).
+
+## When the drift gate fails on a release
+
+1. The node-agent's privileged surface changed and needs a **new allowlist version**.
+2. Create it in the `ARMO` allowlist repo (see `build-allowlists.py` / the process runbook), open a
+   Gerrit change, and get it approved.
+3. Update the vendored copy under `gke-allowlist/` to match, and bump the chart's
+   `nodeAgent.gke.allowlist.name` default.
+4. Re-run the release with the **`BYPASS_ALLOWLIST_DRIFT`** input set to `true` ("set as pass after
+   you opened Gerrit to allowlist") while the new allowlist works through approval + rollout.
+
+## Limitation
+
+The check covers subset-matched fields (env names, containers, capabilities, mounts, hostPath
+volumes, image repo). It does **not** see runtime-only fields such as the per-node-group
+`node.kubernetes.io/instance-type` nodeSelector the autoscaler adds (that requires the
+`autogke-node-affinity-selector-limitation` exemption) — validate those on a live Autopilot cluster.

--- a/scripts/gke-allowlist/allowlist-drift.py
+++ b/scripts/gke-allowlist/allowlist-drift.py
@@ -127,8 +127,10 @@ def main():
             drift.append(f"container '{name}': privileged required but allowlist has privileged:false")
 
     for name, path in wl["hostpaths"].items():
-        if al["hostpaths"].get(name) not in (path, None):
-            drift.append(f"hostPath '{name}': workload {path} != allowlist {al['hostpaths'].get(name)}")
+        if name not in al["hostpaths"]:
+            drift.append(f"hostPath volume '{name}' ({path}) not in allowlist")
+        elif al["hostpaths"][name] != path:
+            drift.append(f"hostPath '{name}': workload path {path} != allowlist {al['hostpaths'][name]}")
 
     if args.check_digests:
         for name, wc in wl["containers"].items():

--- a/scripts/gke-allowlist/allowlist-drift.py
+++ b/scripts/gke-allowlist/allowlist-drift.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""GKE Autopilot allowlist drift detector (PoC).
+
+Renders a chart's node-agent pod spec and checks whether its privileged surface
+is still COVERED by an approved WorkloadAllowlist (subset-matching rules), so a
+chart-release pipeline can classify each release without a cluster:
+
+  no-op       - workload fully covered by the allowlist (nothing to do)
+  digest-only - covered, but the running image digest isn't in containerImageDigests
+                (Tier-1 action: append the digest)
+  spec-drift  - workload needs a capability / env / mount / container / hostPID
+                NOT present in the allowlist -> a NEW allowlist version is required
+                (Tier-2 gate should block the release until one is approved)
+
+Exit code: 0 for no-op/digest-only, 2 for spec-drift (CI-gate friendly).
+
+Usage:
+  allowlist-drift.py --chart <path> --allowlist <yaml> [--values f.yaml ...]
+                     [--set k=v ...] [--wrapper] [--check-digests]
+"""
+import argparse, re, subprocess, sys
+import yaml
+
+
+def render_node_agent(chart, values, sets, wrapper):
+    prefix = "kubescape-operator." if wrapper else ""
+    show = ("charts/kubescape-operator/templates/node-agent/daemonset.yaml"
+            if wrapper else "templates/node-agent/daemonset.yaml")
+    cmd = ["helm", "template", "na", chart, "--kube-version", "1.33.0",
+           "--show-only", show,
+           "--set", f"{prefix}clusterName=drift",
+           "--set", f"{prefix}account=00000000-0000-0000-0000-000000000000",
+           "--set", f"{prefix}nodeAgent.autoscaler.enabled=false"]
+    for v in values:
+        cmd += ["-f", v]
+    for s in sets:
+        cmd += ["--set", s]
+    out = subprocess.run(cmd, capture_output=True, text=True)
+    if out.returncode != 0:
+        sys.exit(f"helm template failed:\n{out.stderr}")
+    return yaml.safe_load(out.stdout)
+
+
+def project_container(c):
+    sc = c.get("securityContext", {}) or {}
+    caps = sc.get("capabilities", {}) or {}
+    return {
+        "image": c.get("image", ""),
+        "add": set(caps.get("add", []) or []),
+        "drop": set(caps.get("drop", []) or []),
+        "env": {e["name"] for e in (c.get("env", []) or [])},
+        "mounts": {m["mountPath"] for m in (c.get("volumeMounts", []) or [])},
+        "privileged": bool(sc.get("privileged", False)),
+    }
+
+
+def workload_projection(ds):
+    spec = ds["spec"]["template"]["spec"]
+    return {
+        "hostPID": bool(spec.get("hostPID", False)),
+        "containers": {c["name"]: project_container(c) for c in spec["containers"]},
+        "hostpaths": {v["name"]: v["hostPath"]["path"]
+                      for v in spec.get("volumes", []) if "hostPath" in v},
+    }
+
+
+def allowlist_projection(al):
+    mc = al["matchingCriteria"]
+    return {
+        "hostPID": bool(mc.get("hostPID", False)),
+        "containers": {c["name"]: project_container(c) for c in mc.get("containers", [])},
+        "hostpaths": {v["name"]: v["hostPath"]["path"]
+                      for v in mc.get("volumes", []) if "hostPath" in v},
+        "digests": {d["containerName"]: set(d.get("imageDigests", []))
+                    for d in al.get("containerImageDigests", [])},
+    }
+
+
+def repo(image):
+    return re.split(r"[:@]", image, maxsplit=1)[0]
+
+
+def resolve_digest(image):
+    out = subprocess.run(["skopeo", "inspect", f"docker://{image}"],
+                         capture_output=True, text=True)
+    if out.returncode != 0:
+        return None
+    import json
+    return json.loads(out.stdout).get("Digest", "").replace("sha256:", "")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--chart", required=True)
+    ap.add_argument("--allowlist", required=True)
+    ap.add_argument("--values", action="append", default=[])
+    ap.add_argument("--set", dest="sets", action="append", default=[])
+    ap.add_argument("--wrapper", action="store_true")
+    ap.add_argument("--check-digests", action="store_true",
+                    help="resolve running image digests via skopeo (network)")
+    args = ap.parse_args()
+
+    wl = workload_projection(render_node_agent(args.chart, args.values, args.sets, args.wrapper))
+    al = allowlist_projection(yaml.safe_load(open(args.allowlist)))
+
+    drift, digests_missing = [], []
+
+    if wl["hostPID"] and not al["hostPID"]:
+        drift.append("hostPID required by workload but not in allowlist")
+
+    for name, wc in wl["containers"].items():
+        ac = al["containers"].get(name)
+        if ac is None:
+            drift.append(f"container '{name}' not in allowlist")
+            continue
+        # image repo must satisfy the allowlist regex (tag-agnostic)
+        if not re.match(ac["image"], repo(wc["image"])):
+            drift.append(f"container '{name}': image repo {repo(wc['image'])} "
+                         f"not matched by allowlist regex {ac['image']}")
+        for cap in wc["add"] - ac["add"]:
+            drift.append(f"container '{name}': capability {cap} not in allowlist")
+        for env in wc["env"] - ac["env"]:
+            drift.append(f"container '{name}': env {env} not in allowlist")
+        for mp in wc["mounts"] - ac["mounts"]:
+            drift.append(f"container '{name}': mountPath {mp} not in allowlist")
+        if wc["privileged"] and not ac["privileged"]:
+            drift.append(f"container '{name}': privileged required but allowlist has privileged:false")
+
+    for name, path in wl["hostpaths"].items():
+        if al["hostpaths"].get(name) not in (path, None):
+            drift.append(f"hostPath '{name}': workload {path} != allowlist {al['hostpaths'].get(name)}")
+
+    if args.check_digests:
+        for name, wc in wl["containers"].items():
+            d = resolve_digest(wc["image"])
+            if d and d not in al["digests"].get(name, set()):
+                digests_missing.append(f"{name}: {wc['image']} -> sha256:{d[:16]}… not in containerImageDigests")
+
+    print(f"# drift report: {args.chart}")
+    print(f"#   allowlist: {args.allowlist}")
+    if drift:
+        print("CLASS: spec-drift  (NEW allowlist version required)")
+        for d in drift:
+            print(f"  - {d}")
+        sys.exit(2)
+    if digests_missing:
+        print("CLASS: digest-only  (append digests to existing allowlist)")
+        for d in digests_missing:
+            print(f"  - {d}")
+        sys.exit(0)
+    print("CLASS: no-op  (workload covered by approved allowlist)")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gke-allowlist/build-allowlists.py
+++ b/scripts/gke-allowlist/build-allowlists.py
@@ -10,8 +10,16 @@ this script normalizes them into the final, submittable form:
 """
 import os
 
-REPO = os.path.expanduser("~/projects/workspace-gke-autopilot-approval/gke-allow-list/ARMO")
-GEN = os.path.expanduser("~/projects/workspace-gke-autopilot-approval/gen")
+# Output repo (ARMO allowlist checkout) and the dir holding the digest files, both overridable via
+# env vars so the generator is not tied to one contributor's home directory.
+REPO = os.environ.get(
+    "GKE_ALLOWLIST_REPO",
+    os.path.expanduser("~/projects/workspace-gke-autopilot-approval/gke-allow-list/ARMO"),
+)
+GEN = os.environ.get(
+    "GKE_ALLOWLIST_GEN",
+    os.path.expanduser("~/projects/workspace-gke-autopilot-approval/gen"),
+)
 
 # --- digest blocks (read from the skopeo output, re-indented under imageDigests) ---
 def load_digests(path):
@@ -29,11 +37,14 @@ KS_DIGESTS = load_digests(f"{GEN}/digests-kubescape-node-agent.txt")
 ARMO_DIGESTS = load_digests(f"{GEN}/digests-armosec-node-agent.txt")
 
 # --- canonical body (everything except metadata.name, the image regexes, digests) ---
+# Full union of chart-conditional node-agent env names (subset matching => an uncovered env
+# rejects the workload). Kept in sync with the vendored gke-allowlist/*-1.40-v2.yaml files.
 NODE_AGENT_ENV = [
     "GOMEMLIMIT", "HOST_ROOT", "KS_LOGGER_LEVEL", "KS_LOGGER_NAME",
     "OTEL_COLLECTOR_SVC", "CLAMAV_SOCKET", "SBOM_SCANNER_SOCKET", "SCANNER_MEMORY_LIMIT",
     "NODE_NAME", "POD_NAME", "NAMESPACE_NAME", "KUBELET_ROOT", "AGENT_VERSION",
-    "NodeName", "IGNORERULEBINDINGS",
+    "NodeName", "IGNORERULEBINDINGS", "API_URL",
+    "HTTPS_PROXY", "no_proxy", "RUNTIME_PATH", "SKIP_KERNEL_VERSION_CHECK", "MALWARE_SCAN_ALL_FILES",
 ]
 SBOM_ENV = ["GOMEMLIMIT", "SOCKET_PATH", "HOST_ROOT", "OTEL_COLLECTOR_SVC",
             "NODE_NAME", "POD_NAME", "NAMESPACE", "CLUSTER_NAME"]
@@ -59,6 +70,9 @@ exemptions:
   - autogke-no-write-mode-hostpath
   # Node Agent needs SYS_ADMIN/SYS_PTRACE/NET_ADMIN/SYSLOG/SYS_RESOURCE/IPC_LOCK/NET_RAW for eBPF.
   - autogke-default-linux-capabilities
+  # Autoscaler mode adds a node.kubernetes.io/instance-type nodeSelector per node group, which
+  # Autopilot disallows without this exemption.
+  - autogke-node-affinity-selector-limitation
 matchingCriteria:
   hostPID: true
   containers:

--- a/scripts/gke-allowlist/build-allowlists.py
+++ b/scripts/gke-allowlist/build-allowlists.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Assemble the three GKE Autopilot WorkloadAllowlist files for the 1.40 charts.
+
+Source of truth is the GKE-generated baseline (gen/generated-public.yaml et al.);
+this script normalizes them into the final, submittable form:
+  - metadata.name = filename stem
+  - container images -> repo regex (tag-agnostic), per the approved 1.27 convention
+  - env per container = union/superset across the three charts (subset-matching safe)
+  - containerImageDigests appended for private-image-mirror support
+"""
+import os
+
+REPO = os.path.expanduser("~/projects/workspace-gke-autopilot-approval/gke-allow-list/ARMO")
+GEN = os.path.expanduser("~/projects/workspace-gke-autopilot-approval/gen")
+
+# --- digest blocks (read from the skopeo output, re-indented under imageDigests) ---
+def load_digests(path):
+    out = []
+    with open(path) as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if line.strip().startswith("#"):
+                out.append("      " + line.strip())
+            elif line.strip().startswith("- "):
+                out.append("      " + line.strip())
+    return "\n".join(out)
+
+KS_DIGESTS = load_digests(f"{GEN}/digests-kubescape-node-agent.txt")
+ARMO_DIGESTS = load_digests(f"{GEN}/digests-armosec-node-agent.txt")
+
+# --- canonical body (everything except metadata.name, the image regexes, digests) ---
+NODE_AGENT_ENV = [
+    "GOMEMLIMIT", "HOST_ROOT", "KS_LOGGER_LEVEL", "KS_LOGGER_NAME",
+    "OTEL_COLLECTOR_SVC", "CLAMAV_SOCKET", "SBOM_SCANNER_SOCKET", "SCANNER_MEMORY_LIMIT",
+    "NODE_NAME", "POD_NAME", "NAMESPACE_NAME", "KUBELET_ROOT", "AGENT_VERSION",
+    "NodeName", "IGNORERULEBINDINGS",
+]
+SBOM_ENV = ["GOMEMLIMIT", "SOCKET_PATH", "HOST_ROOT", "OTEL_COLLECTOR_SVC",
+            "NODE_NAME", "POD_NAME", "NAMESPACE", "CLUSTER_NAME"]
+
+
+def env_block(names, indent):
+    pad = " " * indent
+    return "\n".join(f"{pad}- name: {n}" for n in names)
+
+
+def build(name, node_agent_img, sbom_img, clamav_img, na_digests, sbom_digests):
+    return f"""apiVersion: auto.gke.io/v1
+kind: WorkloadAllowlist
+minGKEVersion: 1.32.0-gke.1000000
+metadata:
+  name: {name}
+  annotations:
+    autopilot.gke.io/no-connect: "true"
+exemptions:
+  # Node Agent monitors all processes/containers on the node, so it needs the host PID namespace.
+  - autogke-disallow-hostnamespaces
+  # Node Agent needs write access to parts of the host (container runtime socket, eBPF fs) for eBPF.
+  - autogke-no-write-mode-hostpath
+  # Node Agent needs SYS_ADMIN/SYS_PTRACE/NET_ADMIN/SYSLOG/SYS_RESOURCE/IPC_LOCK/NET_RAW for eBPF.
+  - autogke-default-linux-capabilities
+matchingCriteria:
+  hostPID: true
+  containers:
+    - name: clamav
+      image: {clamav_img}
+      securityContext:
+        capabilities:
+          add:
+            - SYS_PTRACE
+      volumeMounts:
+        - mountPath: /var/lib/clamav-tmp
+          name: clamdb
+        - mountPath: /run/clamav
+          name: clamrun
+        - mountPath: /etc/clamav
+          name: etc
+          readOnly: true
+    - name: sbom-scanner
+      image: {sbom_img}
+      command:
+        - /usr/bin/sbom-scanner
+      env:
+{env_block(SBOM_ENV, 8)}
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+      volumeMounts:
+        - mountPath: /sbom-comm
+          name: sbom-comm
+        - mountPath: /host
+          name: host
+          readOnly: true
+        - mountPath: /tmp
+          name: sbom-scanner-tmp
+    - name: node-agent
+      image: {node_agent_img}
+      env:
+{env_block(NODE_AGENT_ENV, 8)}
+      securityContext:
+        capabilities:
+          add:
+            - SYS_ADMIN
+            - SYS_PTRACE
+            - NET_ADMIN
+            - SYSLOG
+            - SYS_RESOURCE
+            - IPC_LOCK
+            - NET_RAW
+        privileged: false
+      volumeMounts:
+        - mountPath: /host
+          name: host
+          readOnly: true
+        - mountPath: /var/lib/kubelet
+          name: kubeletdir
+        - mountPath: /run
+          name: run
+        - mountPath: /var
+          name: var
+          readOnly: true
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/kernel/debug
+          name: debugfs
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+          readOnly: true
+        - mountPath: /sys/fs/bpf
+          name: bpffs
+        - mountPath: /data
+          name: data
+        - mountPath: /profiles
+          name: profiles
+        - mountPath: /boot
+          name: boot
+          readOnly: true
+        - mountPath: /clamav
+          name: clamrun
+        - mountPath: /sbom-comm
+          name: sbom-comm
+        - mountPath: /etc/credentials
+          name: cloud-secret
+          readOnly: true
+        - mountPath: /etc/config/clusterData.json
+          name: ks-cloud-config
+          readOnly: true
+          subPath: clusterData.json
+        - mountPath: /etc/config/config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+  securityContext:
+    appArmorProfile:
+      type: Unconfined
+  volumes:
+    - hostPath:
+        path: /
+      name: host
+    - hostPath:
+        path: /var/lib/kubelet
+      name: kubeletdir
+    - hostPath:
+        path: /run
+      name: run
+    - hostPath:
+        path: /var
+      name: var
+    - hostPath:
+        path: /sys/fs/cgroup
+      name: cgroup
+    - hostPath:
+        path: /lib/modules
+      name: modules
+    - hostPath:
+        path: /sys/fs/bpf
+      name: bpffs
+    - hostPath:
+        path: /sys/kernel/debug
+      name: debugfs
+    - hostPath:
+        path: /boot
+      name: boot
+    - name: data
+    - name: profiles
+    - hostPath:
+        path: /
+      name: host-filesystem
+    - name: clamdb
+    - name: clamrun
+    - configMap:
+        defaultMode: 420
+        name: clamav
+      name: etc
+    - name: sbom-comm
+    - name: sbom-scanner-tmp
+    - name: cloud-secret
+    - configMap:
+        defaultMode: 420
+        name: ks-cloud-config
+      name: ks-cloud-config
+    - configMap:
+        defaultMode: 420
+        name: node-agent
+      name: config
+containerImageDigests:
+  - containerName: node-agent
+    imageDigests:
+{na_digests}
+  - containerName: sbom-scanner
+    imageDigests:
+{sbom_digests}
+"""
+
+
+KS = r"^quay\.io/kubescape/node-agent$"
+ARMO = r"^quay\.io/(armosec|kubescape)/node-agent$"
+KLAMAV = r"^quay\.io/kubescape/klamav$"
+
+specs = [
+    # (dir, name, node-agent img, sbom img, clamav img, node-agent digests, sbom digests)
+    ("armo-kubescape-node-agent", "armo-kubescape-node-agent-1.40", KS, KS, KLAMAV, KS_DIGESTS, KS_DIGESTS),
+    ("armo-private-node-agent",   "armo-private-node-agent-1.40",   ARMO, ARMO, KLAMAV, ARMO_DIGESTS, ARMO_DIGESTS),
+    # Rapid7: node-agent uses armosec; sbom-scanner image rendered as kubescape (chart-values gap),
+    # both covered by the armosec|kubescape regex. Digests: node-agent=armosec, sbom-scanner=kubescape.
+    ("armo-rapid7-node-agent",    "armo-rapid7-node-agent-1.40",    ARMO, ARMO, KLAMAV, ARMO_DIGESTS, KS_DIGESTS),
+]
+
+for d, name, na, sbom, clam, nad, sbd in specs:
+    outdir = f"{REPO}/{d}/1.40"
+    os.makedirs(outdir, exist_ok=True)
+    path = f"{outdir}/{name}.yaml"
+    with open(path, "w") as f:
+        f.write(build(name, na, sbom, clam, nad, sbd))
+    print(f"wrote {path} ({sum(1 for _ in open(path))} lines)")

--- a/scripts/gke-allowlist/check-drift.sh
+++ b/scripts/gke-allowlist/check-drift.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# check-drift.sh — fail if a chart's node-agent render drifts from a vendored GKE
+# Autopilot WorkloadAllowlist. Used by the release CI drift gate and runnable locally.
+#
+# Usage:
+#   check-drift.sh <chart-dir> <allowlist-yaml> [--wrapper]
+#
+# --wrapper : the chart wraps the public kubescape-operator subchart, so values are
+#             nested under the `kubescape-operator.` key.
+#
+# Renders the node-agent with the FULL set of optional features enabled (server/API_URL,
+# proxy, custom runtime, kernel-check skip, full malware scan, ClamAV, SBOM scanner, OTEL)
+# so the check exercises the maximal privileged surface a customer could produce, then
+# verifies it is a subset of the approved allowlist. Exit 2 on drift.
+set -euo pipefail
+
+CHART="${1:?chart dir required}"
+ALLOWLIST="${2:?allowlist yaml required}"
+WRAPPER="${3:-}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+prefix=""
+[ "$WRAPPER" = "--wrapper" ] && prefix="kubescape-operator."
+
+helm dependency build "$CHART" >/dev/null
+
+exec python3 "$HERE/allowlist-drift.py" \
+  --chart "$CHART" --allowlist "$ALLOWLIST" ${WRAPPER:+$WRAPPER} \
+  --set "${prefix}server=api.example.com" \
+  --set "${prefix}accessKey=00000000-0000-0000-0000-000000000000" \
+  --set "${prefix}capabilities.malwareDetection=enable" \
+  --set "${prefix}capabilities.nodeSbomGeneration=enable" \
+  --set "${prefix}nodeAgent.sbomScanner.enabled=true" \
+  --set "${prefix}configurations.otelUrl=http://otel-collector:4317" \
+  --set "${prefix}global.httpsProxy=http://proxy:3128" \
+  --set "${prefix}global.overrideRuntimePath=/run/containerd/containerd.sock" \
+  --set "${prefix}nodeAgent.config.skipKernelVersionCheck=true" \
+  --set "${prefix}nodeAgent.config.malwareScanAllFiles=true"

--- a/scripts/gke-allowlist/refresh-digests.py
+++ b/scripts/gke-allowlist/refresh-digests.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Refresh containerImageDigests in approved GKE Autopilot allowlists.
+
+`containerImageDigests` is the ONLY mutable field of an approved WorkloadAllowlist,
+so when a new node-agent version ships you just append its SHA-256 digest to the
+existing file (no new allowlist version). This script automates that.
+
+It covers both registries:
+  - quay.io/kubescape/node-agent
+  - quay.io/armosec/node-agent
+
+For each allowlist file it finds every `containerImageDigests[].imageDigests` block,
+infers which registry the block tracks from its existing `# quay.io/<reg>/node-agent:vX`
+comments, fetches the latest release digests for that registry (skopeo), and reports
+any that are missing. With --apply it inserts the missing entries (newest first) at the
+top of the block, preserving the file's comment+digest format.
+
+Usage:
+  refresh-digests.py [--apply] [--max N] [FILE ...]
+Default FILEs are the three 1.40 allowlists. Dry-run by default (prints a report).
+Exit code: 0 = up to date, 10 = missing digests found (dry-run), 0 after --apply.
+"""
+import argparse, glob, os, re, subprocess, sys, json
+from functools import lru_cache
+
+REPO = os.path.expanduser("~/projects/workspace-gke-autopilot-approval/gke-allow-list/ARMO")
+DEFAULT_FILES = sorted(glob.glob(f"{REPO}/*/1.40/*-1.40.yaml"))
+TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
+REG_RE = re.compile(r"quay\.io/(armosec|kubescape)/node-agent")
+
+
+@lru_cache(maxsize=None)
+def latest(registry, maxn):
+    """Return list of (tag, digest) for the latest `maxn` vX.Y.Z tags, newest first."""
+    repo = f"quay.io/{registry}/node-agent"
+    tags = subprocess.run(["skopeo", "list-tags", f"docker://{repo}"],
+                          capture_output=True, text=True)
+    if tags.returncode != 0:
+        sys.exit(f"skopeo list-tags failed for {repo}:\n{tags.stderr}")
+    all_tags = [t for t in json.loads(tags.stdout)["Tags"] if TAG_RE.match(t)]
+    all_tags.sort(key=lambda t: [int(x) for x in t[1:].split(".")], reverse=True)
+    out = []
+    for t in all_tags[:maxn]:
+        ins = subprocess.run(["skopeo", "inspect", f"docker://{repo}:{t}"],
+                             capture_output=True, text=True)
+        if ins.returncode == 0:
+            d = json.loads(ins.stdout).get("Digest", "").replace("sha256:", "")
+            if d:
+                out.append((t, d))
+    return out
+
+
+def process(path, maxn, apply):
+    lines = open(path).read().splitlines()
+    # find each "imageDigests:" line and the extent of its block
+    blocks = []  # (insert_after_idx, end_idx, registry, existing_digests:set)
+    i = 0
+    while i < len(lines):
+        if re.match(r"^\s*imageDigests:\s*$", lines[i]):
+            indent = len(lines[i]) - len(lines[i].lstrip())
+            j = i + 1
+            existing, reg = set(), None
+            while j < len(lines):
+                ln = lines[j]
+                # block ends when indentation drops to <= the imageDigests indent on a non-blank, non-deeper line
+                if ln.strip() and (len(ln) - len(ln.lstrip())) <= indent:
+                    break
+                m = re.match(r"\s*-\s+([0-9a-f]{64})\s*$", ln)
+                if m:
+                    existing.add(m.group(1))
+                rm = REG_RE.search(ln)
+                if rm and reg is None:
+                    reg = rm.group(1)
+                j += 1
+            blocks.append([i, j, reg, existing])
+            i = j
+        else:
+            i += 1
+
+    report, additions = [], []  # additions: (insert_idx, [new lines])
+    for insert_after, _end, reg, existing in blocks:
+        if not reg:
+            report.append(f"  ! could not infer registry for block at line {insert_after+1}; skipping")
+            continue
+        latest_list = latest(reg, maxn)
+        missing = [(t, d) for (t, d) in latest_list if d not in existing]
+        report.append(f"  block@L{insert_after+1} [{reg}/node-agent]: "
+                      f"{len(existing)} present, {len(missing)} new")
+        for t, d in missing:
+            report.append(f"      + {t}  sha256:{d[:16]}…")
+        if missing:
+            # build new lines (newest first), matched to the block's digest indentation
+            digit_indent = " " * (len(lines[insert_after]) - len(lines[insert_after].lstrip()) + 2)
+            new = []
+            for t, d in missing:  # latest() is newest-first already
+                new.append(f"{digit_indent}# quay.io/{reg}/node-agent:{t}")
+                new.append(f"{digit_indent}- {d}")
+            additions.append((insert_after + 1, new))
+
+    total_new = sum(len(n)//2 for _, n in additions)
+    print(f"\n{os.path.relpath(path)}")
+    for r in report:
+        print(r)
+
+    if apply and additions:
+        # apply bottom-up so earlier insert indices stay valid
+        for idx, new in sorted(additions, key=lambda x: -x[0]):
+            lines[idx:idx] = new
+        open(path, "w").write("\n".join(lines) + "\n")
+        print(f"  -> applied: inserted {total_new} digest(s)")
+    return total_new
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("files", nargs="*", default=DEFAULT_FILES)
+    ap.add_argument("--apply", action="store_true", help="write changes in place")
+    ap.add_argument("--max", type=int, default=20, help="latest N release tags per registry")
+    args = ap.parse_args()
+    files = args.files or DEFAULT_FILES
+    total = sum(process(f, args.max, args.apply) for f in files)
+    print(f"\nTotal new digests {'applied' if args.apply else 'available'}: {total}")
+    if total and not args.apply:
+        print("Re-run with --apply to insert them, then commit + push to Gerrit refs/for/main.")
+        sys.exit(10)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gke-allowlist/refresh-digests.py
+++ b/scripts/gke-allowlist/refresh-digests.py
@@ -20,29 +20,39 @@ Usage:
 Default FILEs are the three 1.40 allowlists. Dry-run by default (prints a report).
 Exit code: 0 = up to date, 10 = missing digests found (dry-run), 0 after --apply.
 """
-import argparse, glob, os, re, subprocess, sys, json
+import argparse, glob, os, re, shutil, subprocess, sys, json
 from functools import lru_cache
 
-REPO = os.path.expanduser("~/projects/workspace-gke-autopilot-approval/gke-allow-list/ARMO")
+# Repo root of the ARMO allowlist checkout. Override with $GKE_ALLOWLIST_REPO; falls back to the
+# path used during development. If it doesn't exist, we fail loudly (see main) rather than silently
+# scanning nothing.
+REPO = os.environ.get(
+    "GKE_ALLOWLIST_REPO",
+    os.path.expanduser("~/projects/workspace-gke-autopilot-approval/gke-allow-list/ARMO"),
+)
 DEFAULT_FILES = sorted(glob.glob(f"{REPO}/*/1.40/*-1.40.yaml"))
 TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
 REG_RE = re.compile(r"quay\.io/(armosec|kubescape)/node-agent")
+
+
+def _skopeo(*args):
+    if shutil.which("skopeo") is None:
+        sys.exit("error: skopeo is not installed (needed to resolve image digests).")
+    return subprocess.run(["skopeo", *args], capture_output=True, text=True, timeout=120)
 
 
 @lru_cache(maxsize=None)
 def latest(registry, maxn):
     """Return list of (tag, digest) for the latest `maxn` vX.Y.Z tags, newest first."""
     repo = f"quay.io/{registry}/node-agent"
-    tags = subprocess.run(["skopeo", "list-tags", f"docker://{repo}"],
-                          capture_output=True, text=True)
+    tags = _skopeo("list-tags", f"docker://{repo}")
     if tags.returncode != 0:
         sys.exit(f"skopeo list-tags failed for {repo}:\n{tags.stderr}")
     all_tags = [t for t in json.loads(tags.stdout)["Tags"] if TAG_RE.match(t)]
     all_tags.sort(key=lambda t: [int(x) for x in t[1:].split(".")], reverse=True)
     out = []
     for t in all_tags[:maxn]:
-        ins = subprocess.run(["skopeo", "inspect", f"docker://{repo}:{t}"],
-                             capture_output=True, text=True)
+        ins = _skopeo("inspect", f"docker://{repo}:{t}")
         if ins.returncode == 0:
             d = json.loads(ins.stdout).get("Digest", "").replace("sha256:", "")
             if d:
@@ -118,6 +128,12 @@ def main():
     ap.add_argument("--max", type=int, default=20, help="latest N release tags per registry")
     args = ap.parse_args()
     files = args.files or DEFAULT_FILES
+    if not files:
+        sys.exit(f"error: no allowlist files given and none found under {REPO} "
+                 f"(set $GKE_ALLOWLIST_REPO or pass file paths).")
+    missing = [f for f in files if not os.path.isfile(f)]
+    if missing:
+        sys.exit("error: allowlist file(s) not found: " + ", ".join(missing))
     total = sum(process(f, args.max, args.apply) for f in files)
     print(f"\nTotal new digests {'applied' if args.apply else 'available'}: {total}")
     if total and not args.apply:


### PR DESCRIPTION
## What
Adds a **release-time drift gate** for the GKE Autopilot node-agent allowlist, plus the helper scripts it uses and a feature doc.

- `scripts/gke-allowlist/` — `allowlist-drift.py` (classifier), `check-drift.sh` (CI wrapper: renders the node-agent with all optional features on and checks it is a subset of the allowlist), `build-allowlists.py` / `refresh-digests.py` (allowlist-repo maintenance), and a README.
- `gke-allowlist/armo-kubescape-node-agent-1.40-v2.yaml` — vendored copy of the approved allowlist the gate checks against.
- `03-helm-release.yaml` — new `allowlist-drift-check` job gating the release.
- `docs/features/gke-autopilot-allowlist-tooling.md` — feature doc.

## Why
Autopilot admission is subset-based: if a chart change adds a node-agent env/mount/capability/container the approved allowlist doesn't list, customers can't install on Autopilot until a new allowlist is approved. The gate catches this before release.

## Bypass
If drift is intended (shipping a change that needs a new allowlist), open the Gerrit allowlist update, then re-run the release with **`BYPASS_ALLOWLIST_DRIFT: true`** — passes with a warning instead of failing.

## Validation
`check-drift.sh` run locally against the current chart + vendored allowlist → `no-op` (covered).

AI-skills: armosec-shared-rules:writing-docs,schedule,loop | cmds: /model,/login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a release-time gate to validate GKE Autopilot WorkloadAllowlist compatibility for Helm chart releases.
  * Added updated WorkloadAllowlist manifests for the node agent.
  * Added tooling to check allowlist drift, generate allowlists, and refresh approved image digests.
  * Introduced an optional override input to bypass drift failures with a warning.

* **Documentation**
  * Added a guide covering the allowlist tooling, drift behavior, local run instructions, and known check limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->