### PR TITLE
node-agent: install GKE Autopilot AllowlistSynchronizer when allowlist is enabled

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/allowlistsynchronizer.yaml
+++ b/charts/kubescape-operator/templates/node-agent/allowlistsynchronizer.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.nodeAgent.gke.allowlist.enabled }}
+{{- /*
+  Installs the GKE Autopilot AllowlistSynchronizer that pulls the node-agent's approved
+  WorkloadAllowlist from Google's managed repo into the cluster. Rendered only when the allowlist
+  feature is enabled. The path is derived from the allowlist name (ARMO/<name-without-version-suffix>/*)
+  unless nodeAgent.gke.allowlist.path is set explicitly.
+
+  The synchronizer is a cluster-scoped resource with a release-scoped name, so it does not collide
+  with an AllowlistSynchronizer a user may have created manually. If the target WorkloadAllowlist is
+  already installed in the cluster, the controller reconciles it asynchronously — it does not block
+  `helm install`.
+*/}}
+{{- $name := .Values.nodeAgent.gke.allowlist.name }}
+{{- $path := .Values.nodeAgent.gke.allowlist.path }}
+{{- if not $path }}
+{{- $dir := regexReplaceAll "-[0-9]+\\.[0-9]+(-v[0-9]+)?$" $name "" }}
+{{- $path = printf "ARMO/%s/*" $dir }}
+{{- end }}
+apiVersion: auto.gke.io/v1
+kind: AllowlistSynchronizer
+metadata:
+  name: {{ include "kubescape-operator.fullname" . }}-gke-allowlist
+  annotations:
+    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+  labels:
+    {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" .Values.nodeAgent.name "tier" .Values.global.namespaceTier) | nindent 4 }}
+spec:
+  allowlistPaths:
+  - {{ $path }}
+{{- end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2531,6 +2531,26 @@ all capabilities:
           served: true
           storage: true
   55: |
+    apiVersion: auto.gke.io/v1
+    kind: AllowlistSynchronizer
+    metadata:
+      annotations: null
+      labels:
+        app: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape-gke-allowlist
+    spec:
+      allowlistPaths:
+        - ARMO/armo-kubescape-node-agent/*
+  56: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -2687,7 +2707,7 @@ all capabilities:
           - patch
           - list
           - watch
-  56: |
+  57: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2712,7 +2732,7 @@ all capabilities:
       - kind: ServiceAccount
         name: node-agent
         namespace: kubescape
-  57: |
+  58: |
     apiVersion: v1
     data:
       config.json: |
@@ -2777,7 +2797,7 @@ all capabilities:
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
-  58: |
+  59: |
     apiVersion: v1
     data:
       clamd.conf: |-
@@ -2814,7 +2834,7 @@ all capabilities:
     metadata:
       name: clamav
       namespace: kubescape
-  59: |
+  60: |
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
@@ -3106,7 +3126,7 @@ all capabilities:
             - name: custom-ca-certificates
               secret:
                 secretName: custom-ca-certificates
-  60: |
+  61: |
     apiVersion: kubescape.io/v1
     kind: RuntimeRuleAlertBinding
     metadata:
@@ -3157,7 +3177,7 @@ all capabilities:
         - ruleName: Unexpected Egress Network Traffic
         - ruleName: Malicious Ptrace Usage
         - ruleName: Unexpected io_uring Operation Detected
-  61: |
+  62: |
     apiVersion: kubescape.io/v1
     kind: Rules
     metadata:
@@ -3879,7 +3899,7 @@ all capabilities:
             - context:kubernetes
             - admission
             - network
-  62: |
+  63: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -3938,7 +3958,7 @@ all capabilities:
           app.kubernetes.io/name: kubescape-operator
       policyTypes:
         - Egress
-  63: |
+  64: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -3964,7 +3984,7 @@ all capabilities:
       - kind: ServiceAccount
         name: node-agent
         namespace: kubescape
-  64: |
+  65: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -3992,7 +4012,7 @@ all capabilities:
         app.kubernetes.io/component: node-agent
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
-  65: |
+  66: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -4010,7 +4030,7 @@ all capabilities:
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
-  66: |
+  67: |
     apiVersion: v1
     data:
       tls.crt: bW9jay1jYS1jZXJ0
@@ -4033,7 +4053,7 @@ all capabilities:
       name: kubescape-admission-webhook-ca
       namespace: kubescape
     type: kubernetes.io/tls
-  67: |
+  68: |
     apiVersion: v1
     data:
       ca.crt: bW9jay1jYS1jZXJ0
@@ -4056,7 +4076,7 @@ all capabilities:
       name: kubescape-admission-webhook-tls
       namespace: kubescape
     type: kubernetes.io/tls
-  68: |
+  69: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -4083,7 +4103,7 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  69: |
+  70: |
     apiVersion: admissionregistration.k8s.io/v1
     kind: ValidatingWebhookConfiguration
     metadata:
@@ -4140,7 +4160,7 @@ all capabilities:
               - networkpolicies
             scope: '*'
         sideEffects: None
-  70: |
+  71: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -4299,7 +4319,7 @@ all capabilities:
           - delete
           - get
           - list
-  71: |
+  72: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -4324,7 +4344,7 @@ all capabilities:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  72: |
+  73: |
     apiVersion: v1
     data:
       config.json: |
@@ -4375,7 +4395,7 @@ all capabilities:
         tier: ks-control-plane
       name: operator
       namespace: kubescape
-  73: |
+  74: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -4570,7 +4590,7 @@ all capabilities:
                     path: matchingRules.json
                 name: cs-matching-rules
               name: cs-matching-rules
-  74: |
+  75: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -4658,7 +4678,7 @@ all capabilities:
         tier: ks-control-plane
       name: kubescape-cronjob-template
       namespace: kubescape
-  75: |
+  76: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -4746,7 +4766,7 @@ all capabilities:
         tier: ks-control-plane
       name: kubevuln-cronjob-template
       namespace: kubescape
-  76: |
+  77: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -4842,7 +4862,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  77: |
+  78: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -4930,7 +4950,7 @@ all capabilities:
         tier: ks-control-plane
       name: registry-scan-cronjob-template
       namespace: kubescape
-  78: |
+  79: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -4974,7 +4994,7 @@ all capabilities:
           - list
           - patch
           - delete
-  79: |
+  80: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -5000,7 +5020,7 @@ all capabilities:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  80: |
+  81: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -5026,7 +5046,7 @@ all capabilities:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  81: |
+  82: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -5054,7 +5074,7 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  82: |
+  83: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -5073,7 +5093,7 @@ all capabilities:
         tier: ks-control-plane
       name: operator
       namespace: kubescape
-  83: |
+  84: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -5101,7 +5121,7 @@ all capabilities:
           - get
           - watch
           - list
-  84: |
+  85: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -5125,7 +5145,7 @@ all capabilities:
       - kind: ServiceAccount
         name: prometheus-exporter
         namespace: kubescape
-  85: |
+  86: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -5232,7 +5252,7 @@ all capabilities:
                     path: clusterData.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  86: |
+  87: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -5291,7 +5311,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  87: |
+  88: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -5318,7 +5338,7 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: null
-  88: |
+  89: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -5336,7 +5356,7 @@ all capabilities:
         tier: ks-control-plane
       name: prometheus-exporter
       namespace: kubescape
-  89: |
+  90: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -5367,7 +5387,7 @@ all capabilities:
           app.kubernetes.io/component: prometheus-exporter
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kubescape-operator
-  90: |
+  91: |
     apiVersion: v1
     data:
       proxy.crt: foo
@@ -5391,7 +5411,7 @@ all capabilities:
       name: kubescape-proxy-certificate
       namespace: kubescape
     type: Opaque
-  91: |
+  92: |
     apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
@@ -5417,7 +5437,7 @@ all capabilities:
         namespace: kubescape
       version: v1beta1
       versionPriority: 15
-  92: |
+  93: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -5483,7 +5503,7 @@ all capabilities:
           - get
           - watch
           - list
-  93: |
+  94: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -5508,7 +5528,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  94: |
+  95: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -5533,7 +5553,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  95: |
+  96: |
     apiVersion: v1
     data:
       config.json: |
@@ -5565,7 +5585,7 @@ all capabilities:
         tier: ks-control-plane
       name: storage
       namespace: kubescape
-  96: |
+  97: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -5686,7 +5706,7 @@ all capabilities:
                     path: config.json
                 name: storage
               name: config
-  97: |
+  98: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -5745,7 +5765,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  98: |
+  99: |
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
@@ -5769,7 +5789,7 @@ all capabilities:
       resources:
         requests:
           storage: 5Gi
-  99: |
+  100: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -5795,7 +5815,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  100: |
+  101: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -5821,7 +5841,7 @@ all capabilities:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  101: |
+  102: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -6145,7 +6165,7 @@ all capabilities:
           storage: true
           subresources:
             status: {}
-  102: |
+  103: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -6174,7 +6194,7 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  103: |
+  104: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -6192,7 +6212,7 @@ all capabilities:
         tier: ks-control-plane
       name: storage
       namespace: kubescape
-  104: |
+  105: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -6432,7 +6452,7 @@ all capabilities:
         verbs:
           - update
           - patch
-  105: |
+  106: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -6456,7 +6476,7 @@ all capabilities:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  106: |
+  107: |
     apiVersion: v1
     data:
       config.json: |
@@ -6771,7 +6791,7 @@ all capabilities:
         tier: ks-control-plane
       name: synchronizer
       namespace: kubescape
-  107: |
+  108: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -6916,7 +6936,7 @@ all capabilities:
                     path: config.json
                 name: synchronizer
               name: config
-  108: |
+  109: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -6984,7 +7004,7 @@ all capabilities:
       policyTypes:
         - Ingress
         - Egress
-  109: |
+  110: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -7027,7 +7047,7 @@ all capabilities:
           - list
           - patch
           - delete
-  110: |
+  111: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -7052,7 +7072,7 @@ all capabilities:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  111: |
+  112: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -7077,7 +7097,7 @@ all capabilities:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  112: |
+  113: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -7104,7 +7124,7 @@ all capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  113: |
+  114: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -39888,6 +39908,26 @@ multiple node agents:
           served: true
           storage: true
   55: |
+    apiVersion: auto.gke.io/v1
+    kind: AllowlistSynchronizer
+    metadata:
+      annotations: null
+      labels:
+        app: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape-gke-allowlist
+    spec:
+      allowlistPaths:
+        - ARMO/armo-kubescape-node-agent/*
+  56: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -40044,7 +40084,7 @@ multiple node agents:
           - patch
           - list
           - watch
-  56: |
+  57: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -40069,7 +40109,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: node-agent
         namespace: kubescape
-  57: |
+  58: |
     apiVersion: v1
     data:
       config.json: |
@@ -40134,7 +40174,7 @@ multiple node agents:
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
-  58: |
+  59: |
     apiVersion: v1
     data:
       clamd.conf: |-
@@ -40171,7 +40211,7 @@ multiple node agents:
     metadata:
       name: clamav
       namespace: kubescape
-  59: |
+  60: |
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
@@ -40464,7 +40504,7 @@ multiple node agents:
             - name: custom-ca-certificates
               secret:
                 secretName: custom-ca-certificates
-  60: |
+  61: |
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
@@ -40757,7 +40797,7 @@ multiple node agents:
             - name: custom-ca-certificates
               secret:
                 secretName: custom-ca-certificates
-  61: |
+  62: |
     apiVersion: kubescape.io/v1
     kind: RuntimeRuleAlertBinding
     metadata:
@@ -40808,7 +40848,7 @@ multiple node agents:
         - ruleName: Unexpected Egress Network Traffic
         - ruleName: Malicious Ptrace Usage
         - ruleName: Unexpected io_uring Operation Detected
-  62: |
+  63: |
     apiVersion: kubescape.io/v1
     kind: Rules
     metadata:
@@ -41530,7 +41570,7 @@ multiple node agents:
             - context:kubernetes
             - admission
             - network
-  63: |
+  64: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -41589,7 +41629,7 @@ multiple node agents:
           app.kubernetes.io/name: kubescape-operator
       policyTypes:
         - Egress
-  64: |
+  65: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -41615,7 +41655,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: node-agent
         namespace: kubescape
-  65: |
+  66: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -41643,7 +41683,7 @@ multiple node agents:
         app.kubernetes.io/component: node-agent
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
-  66: |
+  67: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -41661,7 +41701,7 @@ multiple node agents:
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
-  67: |
+  68: |
     apiVersion: v1
     data:
       tls.crt: bW9jay1jYS1jZXJ0
@@ -41684,7 +41724,7 @@ multiple node agents:
       name: kubescape-admission-webhook-ca
       namespace: kubescape
     type: kubernetes.io/tls
-  68: |
+  69: |
     apiVersion: v1
     data:
       ca.crt: bW9jay1jYS1jZXJ0
@@ -41707,7 +41747,7 @@ multiple node agents:
       name: kubescape-admission-webhook-tls
       namespace: kubescape
     type: kubernetes.io/tls
-  69: |
+  70: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -41734,7 +41774,7 @@ multiple node agents:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  70: |
+  71: |
     apiVersion: admissionregistration.k8s.io/v1
     kind: ValidatingWebhookConfiguration
     metadata:
@@ -41791,7 +41831,7 @@ multiple node agents:
               - networkpolicies
             scope: '*'
         sideEffects: None
-  71: |
+  72: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -41950,7 +41990,7 @@ multiple node agents:
           - delete
           - get
           - list
-  72: |
+  73: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -41975,7 +42015,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  73: |
+  74: |
     apiVersion: v1
     data:
       config.json: |
@@ -42026,7 +42066,7 @@ multiple node agents:
         tier: ks-control-plane
       name: operator
       namespace: kubescape
-  74: |
+  75: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -42221,7 +42261,7 @@ multiple node agents:
                     path: matchingRules.json
                 name: cs-matching-rules
               name: cs-matching-rules
-  75: |
+  76: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -42309,7 +42349,7 @@ multiple node agents:
         tier: ks-control-plane
       name: kubescape-cronjob-template
       namespace: kubescape
-  76: |
+  77: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -42397,7 +42437,7 @@ multiple node agents:
         tier: ks-control-plane
       name: kubevuln-cronjob-template
       namespace: kubescape
-  77: |
+  78: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -42493,7 +42533,7 @@ multiple node agents:
       policyTypes:
         - Ingress
         - Egress
-  78: |
+  79: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -42581,7 +42621,7 @@ multiple node agents:
         tier: ks-control-plane
       name: registry-scan-cronjob-template
       namespace: kubescape
-  79: |
+  80: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -42625,7 +42665,7 @@ multiple node agents:
           - list
           - patch
           - delete
-  80: |
+  81: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -42651,7 +42691,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  81: |
+  82: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -42677,7 +42717,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  82: |
+  83: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -42705,7 +42745,7 @@ multiple node agents:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  83: |
+  84: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -42724,7 +42764,7 @@ multiple node agents:
         tier: ks-control-plane
       name: operator
       namespace: kubescape
-  84: |
+  85: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -42752,7 +42792,7 @@ multiple node agents:
           - get
           - watch
           - list
-  85: |
+  86: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -42776,7 +42816,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: prometheus-exporter
         namespace: kubescape
-  86: |
+  87: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -42883,7 +42923,7 @@ multiple node agents:
                     path: clusterData.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  87: |
+  88: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -42942,7 +42982,7 @@ multiple node agents:
       policyTypes:
         - Ingress
         - Egress
-  88: |
+  89: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -42969,7 +43009,7 @@ multiple node agents:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: null
-  89: |
+  90: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -42987,7 +43027,7 @@ multiple node agents:
         tier: ks-control-plane
       name: prometheus-exporter
       namespace: kubescape
-  90: |
+  91: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -43018,7 +43058,7 @@ multiple node agents:
           app.kubernetes.io/component: prometheus-exporter
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kubescape-operator
-  91: |
+  92: |
     apiVersion: v1
     data:
       proxy.crt: foo
@@ -43042,7 +43082,7 @@ multiple node agents:
       name: kubescape-proxy-certificate
       namespace: kubescape
     type: Opaque
-  92: |
+  93: |
     apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
@@ -43068,7 +43108,7 @@ multiple node agents:
         namespace: kubescape
       version: v1beta1
       versionPriority: 15
-  93: |
+  94: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -43134,7 +43174,7 @@ multiple node agents:
           - get
           - watch
           - list
-  94: |
+  95: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -43159,7 +43199,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  95: |
+  96: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -43184,7 +43224,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  96: |
+  97: |
     apiVersion: v1
     data:
       config.json: |
@@ -43216,7 +43256,7 @@ multiple node agents:
         tier: ks-control-plane
       name: storage
       namespace: kubescape
-  97: |
+  98: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -43337,7 +43377,7 @@ multiple node agents:
                     path: config.json
                 name: storage
               name: config
-  98: |
+  99: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -43396,7 +43436,7 @@ multiple node agents:
       policyTypes:
         - Ingress
         - Egress
-  99: |
+  100: |
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
@@ -43420,7 +43460,7 @@ multiple node agents:
       resources:
         requests:
           storage: 5Gi
-  100: |
+  101: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -43446,7 +43486,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  101: |
+  102: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -43472,7 +43512,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  102: |
+  103: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -43796,7 +43836,7 @@ multiple node agents:
           storage: true
           subresources:
             status: {}
-  103: |
+  104: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -43825,7 +43865,7 @@ multiple node agents:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  104: |
+  105: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -43843,7 +43883,7 @@ multiple node agents:
         tier: ks-control-plane
       name: storage
       namespace: kubescape
-  105: |
+  106: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -44083,7 +44123,7 @@ multiple node agents:
         verbs:
           - update
           - patch
-  106: |
+  107: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -44107,7 +44147,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  107: |
+  108: |
     apiVersion: v1
     data:
       config.json: |
@@ -44422,7 +44462,7 @@ multiple node agents:
         tier: ks-control-plane
       name: synchronizer
       namespace: kubescape
-  108: |
+  109: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -44567,7 +44607,7 @@ multiple node agents:
                     path: config.json
                 name: synchronizer
               name: config
-  109: |
+  110: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -44635,7 +44675,7 @@ multiple node agents:
       policyTypes:
         - Ingress
         - Egress
-  110: |
+  111: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -44678,7 +44718,7 @@ multiple node agents:
           - list
           - patch
           - delete
-  111: |
+  112: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -44703,7 +44743,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  112: |
+  113: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -44728,7 +44768,7 @@ multiple node agents:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  113: |
+  114: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -44755,7 +44795,7 @@ multiple node agents:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  114: |
+  115: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -55413,6 +55453,26 @@ skipPersistence enabled:
           served: true
           storage: true
   55: |
+    apiVersion: auto.gke.io/v1
+    kind: AllowlistSynchronizer
+    metadata:
+      annotations: null
+      labels:
+        app: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.2
+        helm.sh/chart: kubescape-operator-1.40.2
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape-gke-allowlist
+    spec:
+      allowlistPaths:
+        - ARMO/armo-kubescape-node-agent/*
+  56: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -55569,7 +55629,7 @@ skipPersistence enabled:
           - patch
           - list
           - watch
-  56: |
+  57: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -55594,7 +55654,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: node-agent
         namespace: kubescape
-  57: |
+  58: |
     apiVersion: v1
     data:
       config.json: |
@@ -55659,7 +55719,7 @@ skipPersistence enabled:
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
-  58: |
+  59: |
     apiVersion: v1
     data:
       clamd.conf: |-
@@ -55696,7 +55756,7 @@ skipPersistence enabled:
     metadata:
       name: clamav
       namespace: kubescape
-  59: |
+  60: |
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
@@ -55988,7 +56048,7 @@ skipPersistence enabled:
             - name: custom-ca-certificates
               secret:
                 secretName: custom-ca-certificates
-  60: |
+  61: |
     apiVersion: kubescape.io/v1
     kind: RuntimeRuleAlertBinding
     metadata:
@@ -56039,7 +56099,7 @@ skipPersistence enabled:
         - ruleName: Unexpected Egress Network Traffic
         - ruleName: Malicious Ptrace Usage
         - ruleName: Unexpected io_uring Operation Detected
-  61: |
+  62: |
     apiVersion: kubescape.io/v1
     kind: Rules
     metadata:
@@ -56761,7 +56821,7 @@ skipPersistence enabled:
             - context:kubernetes
             - admission
             - network
-  62: |
+  63: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -56820,7 +56880,7 @@ skipPersistence enabled:
           app.kubernetes.io/name: kubescape-operator
       policyTypes:
         - Egress
-  63: |
+  64: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -56846,7 +56906,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: node-agent
         namespace: kubescape
-  64: |
+  65: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -56874,7 +56934,7 @@ skipPersistence enabled:
         app.kubernetes.io/component: node-agent
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
-  65: |
+  66: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -56892,7 +56952,7 @@ skipPersistence enabled:
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
-  66: |
+  67: |
     apiVersion: v1
     data:
       tls.crt: bW9jay1jYS1jZXJ0
@@ -56915,7 +56975,7 @@ skipPersistence enabled:
       name: kubescape-admission-webhook-ca
       namespace: kubescape
     type: kubernetes.io/tls
-  67: |
+  68: |
     apiVersion: v1
     data:
       ca.crt: bW9jay1jYS1jZXJ0
@@ -56938,7 +56998,7 @@ skipPersistence enabled:
       name: kubescape-admission-webhook-tls
       namespace: kubescape
     type: kubernetes.io/tls
-  68: |
+  69: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -56965,7 +57025,7 @@ skipPersistence enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  69: |
+  70: |
     apiVersion: admissionregistration.k8s.io/v1
     kind: ValidatingWebhookConfiguration
     metadata:
@@ -57022,7 +57082,7 @@ skipPersistence enabled:
               - networkpolicies
             scope: '*'
         sideEffects: None
-  70: |
+  71: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -57181,7 +57241,7 @@ skipPersistence enabled:
           - delete
           - get
           - list
-  71: |
+  72: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -57206,7 +57266,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  72: |
+  73: |
     apiVersion: v1
     data:
       config.json: |
@@ -57257,7 +57317,7 @@ skipPersistence enabled:
         tier: ks-control-plane
       name: operator
       namespace: kubescape
-  73: |
+  74: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -57452,7 +57512,7 @@ skipPersistence enabled:
                     path: matchingRules.json
                 name: cs-matching-rules
               name: cs-matching-rules
-  74: |
+  75: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -57540,7 +57600,7 @@ skipPersistence enabled:
         tier: ks-control-plane
       name: kubescape-cronjob-template
       namespace: kubescape
-  75: |
+  76: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -57628,7 +57688,7 @@ skipPersistence enabled:
         tier: ks-control-plane
       name: kubevuln-cronjob-template
       namespace: kubescape
-  76: |
+  77: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -57724,7 +57784,7 @@ skipPersistence enabled:
       policyTypes:
         - Ingress
         - Egress
-  77: |
+  78: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -57812,7 +57872,7 @@ skipPersistence enabled:
         tier: ks-control-plane
       name: registry-scan-cronjob-template
       namespace: kubescape
-  78: |
+  79: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -57856,7 +57916,7 @@ skipPersistence enabled:
           - list
           - patch
           - delete
-  79: |
+  80: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -57882,7 +57942,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  80: |
+  81: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -57908,7 +57968,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  81: |
+  82: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -57936,7 +57996,7 @@ skipPersistence enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  82: |
+  83: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -57955,7 +58015,7 @@ skipPersistence enabled:
         tier: ks-control-plane
       name: operator
       namespace: kubescape
-  83: |
+  84: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -57983,7 +58043,7 @@ skipPersistence enabled:
           - get
           - watch
           - list
-  84: |
+  85: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -58007,7 +58067,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: prometheus-exporter
         namespace: kubescape
-  85: |
+  86: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -58114,7 +58174,7 @@ skipPersistence enabled:
                     path: clusterData.json
                 name: ks-cloud-config
               name: ks-cloud-config
-  86: |
+  87: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -58173,7 +58233,7 @@ skipPersistence enabled:
       policyTypes:
         - Ingress
         - Egress
-  87: |
+  88: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -58200,7 +58260,7 @@ skipPersistence enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: null
-  88: |
+  89: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -58218,7 +58278,7 @@ skipPersistence enabled:
         tier: ks-control-plane
       name: prometheus-exporter
       namespace: kubescape
-  89: |
+  90: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -58249,7 +58309,7 @@ skipPersistence enabled:
           app.kubernetes.io/component: prometheus-exporter
           app.kubernetes.io/instance: RELEASE-NAME
           app.kubernetes.io/name: kubescape-operator
-  90: |
+  91: |
     apiVersion: v1
     data:
       proxy.crt: foo
@@ -58273,7 +58333,7 @@ skipPersistence enabled:
       name: kubescape-proxy-certificate
       namespace: kubescape
     type: Opaque
-  91: |
+  92: |
     apiVersion: apiregistration.k8s.io/v1
     kind: APIService
     metadata:
@@ -58299,7 +58359,7 @@ skipPersistence enabled:
         namespace: kubescape
       version: v1beta1
       versionPriority: 15
-  92: |
+  93: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -58365,7 +58425,7 @@ skipPersistence enabled:
           - get
           - watch
           - list
-  93: |
+  94: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -58390,7 +58450,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  94: |
+  95: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -58415,7 +58475,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  95: |
+  96: |
     apiVersion: v1
     data:
       config.json: |
@@ -58447,7 +58507,7 @@ skipPersistence enabled:
         tier: ks-control-plane
       name: storage
       namespace: kubescape
-  96: |
+  97: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -58568,7 +58628,7 @@ skipPersistence enabled:
                     path: config.json
                 name: storage
               name: config
-  97: |
+  98: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -58627,7 +58687,7 @@ skipPersistence enabled:
       policyTypes:
         - Ingress
         - Egress
-  98: |
+  99: |
     apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
@@ -58651,7 +58711,7 @@ skipPersistence enabled:
       resources:
         requests:
           storage: 5Gi
-  99: |
+  100: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -58677,7 +58737,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  100: |
+  101: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -58703,7 +58763,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: storage
         namespace: kubescape
-  101: |
+  102: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -59027,7 +59087,7 @@ skipPersistence enabled:
           storage: true
           subresources:
             status: {}
-  102: |
+  103: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -59056,7 +59116,7 @@ skipPersistence enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  103: |
+  104: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -59074,7 +59134,7 @@ skipPersistence enabled:
         tier: ks-control-plane
       name: storage
       namespace: kubescape
-  104: |
+  105: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -59314,7 +59374,7 @@ skipPersistence enabled:
         verbs:
           - update
           - patch
-  105: |
+  106: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -59338,7 +59398,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  106: |
+  107: |
     apiVersion: v1
     data:
       config.json: |
@@ -59653,7 +59713,7 @@ skipPersistence enabled:
         tier: ks-control-plane
       name: synchronizer
       namespace: kubescape
-  107: |
+  108: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -59798,7 +59858,7 @@ skipPersistence enabled:
                     path: config.json
                 name: synchronizer
               name: config
-  108: |
+  109: |
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -59866,7 +59926,7 @@ skipPersistence enabled:
       policyTypes:
         - Ingress
         - Egress
-  109: |
+  110: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -59909,7 +59969,7 @@ skipPersistence enabled:
           - list
           - patch
           - delete
-  110: |
+  111: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -59934,7 +59994,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  111: |
+  112: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -59959,7 +60019,7 @@ skipPersistence enabled:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  112: |
+  113: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -59986,7 +60046,7 @@ skipPersistence enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  113: |
+  114: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -641,8 +641,13 @@ nodeAgent:
   # GKE Autopilot allowlist
   gke:
     allowlist:
+      # When enabled, the node-agent is labeled to match `name`, AND the chart installs an
+      # AllowlistSynchronizer that pulls that allowlist from Google's managed repo into the cluster.
       enabled: false
       name: armo-kubescape-node-agent-1.40-v2
+      # AllowlistSynchronizer path. Leave empty to derive it from `name`
+      # (ARMO/<name-without-version-suffix>/*); set explicitly to override.
+      path: ""
 
   # prometheus (operator) service monitor
   serviceMonitor:

--- a/docs/features/gke-autopilot-allowlist-synchronizer.md
+++ b/docs/features/gke-autopilot-allowlist-synchronizer.md
@@ -1,0 +1,45 @@
+# GKE Autopilot: automatic AllowlistSynchronizer
+
+## Overview
+
+To run the node-agent on **GKE Autopilot**, two things must be true:
+
+1. The node-agent pod carries the `cloud.google.com/matching-allowlist` label naming its approved
+   `WorkloadAllowlist`.
+2. That `WorkloadAllowlist` is installed in the cluster — which GKE does via an `AllowlistSynchronizer`
+   that pulls the allowlist from Google's managed repo.
+
+Previously the chart did (1) but not (2): enabling `nodeAgent.gke.allowlist.enabled` only added the
+label, and operators had to create the `AllowlistSynchronizer` separately. This feature makes the chart
+also install the synchronizer, so enabling the allowlist is a single step.
+
+## Behavior
+
+When `nodeAgent.gke.allowlist.enabled=true`, the chart now renders an `AllowlistSynchronizer`
+(`templates/node-agent/allowlistsynchronizer.yaml`) alongside the label:
+
+- **Path** — derived from `nodeAgent.gke.allowlist.name` as `ARMO/<name-without-version-suffix>/*`
+  (e.g. `armo-private-node-agent-1.40-v2` → `ARMO/armo-private-node-agent/*`). Override with
+  `nodeAgent.gke.allowlist.path` if needed.
+- **Name** — release-scoped (`<fullname>-gke-allowlist`), so it does not collide with an
+  `AllowlistSynchronizer` an operator may already have created manually.
+- **Cluster-scoped** — like the `WorkloadAllowlist` objects it manages.
+
+When `nodeAgent.gke.allowlist.enabled=false` (the default), nothing is rendered — behavior is unchanged.
+
+## Does not block `helm install`
+
+The synchronizer only creates a synchronizer object; the actual `WorkloadAllowlist` install is
+reconciled asynchronously by the GKE controller. If the target allowlist is **already present** in the
+cluster (installed manually or by another synchronizer), the controller reconciles it in the
+background — it does **not** fail `helm install`/`upgrade`.
+
+## Values
+
+| Value | Default | Purpose |
+|-------|---------|---------|
+| `nodeAgent.gke.allowlist.enabled` | `false` | Label the node-agent **and** install the AllowlistSynchronizer. |
+| `nodeAgent.gke.allowlist.name` | `armo-kubescape-node-agent-<minor>` | Allowlist to match / sync. |
+| `nodeAgent.gke.allowlist.path` | `""` | Synchronizer path; empty = derive from `name`. |
+
+See also: [GKE Autopilot install guide](https://kubescape.io/docs/integrations/kubescape-integration-with-cloud-providers/running-armokubescape-node-agents-on-gke-autopilot-clusters/).


### PR DESCRIPTION
## What
When `nodeAgent.gke.allowlist.enabled=true`, the chart now **also installs an `AllowlistSynchronizer`** that pulls the node-agent's approved `WorkloadAllowlist` from Google's managed repo — not just the `cloud.google.com/matching-allowlist` label. Enabling the allowlist becomes a single step.

## Details
- **No new opt-in value** — gated on the existing `nodeAgent.gke.allowlist.enabled`.
- **Path** derived from `nodeAgent.gke.allowlist.name` (`ARMO/<name-without-version-suffix>/*`), overridable via new `nodeAgent.gke.allowlist.path`.
- **Release-scoped name** (`<fullname>-gke-allowlist`) so it won't collide with a manually-created synchronizer.
- **Doesn't block `helm install`** if the allowlist is already present: the synchronizer only creates a synchronizer object; the `WorkloadAllowlist` install is reconciled asynchronously by the GKE controller.
- Renders nothing when disabled (default) — no behavior change for existing users.

Inherited by the ARMO/Rapid7 wrapper charts via the subchart (their name override yields the right path).

## Test
`helm template` verified: disabled → no synchronizer; enabled → `ARMO/armo-kubescape-node-agent/*` (and `armo-private`/`armo-rapid7` with the wrapper name overrides); explicit `path` override respected.

Docs: `docs/features/gke-autopilot-allowlist-synchronizer.md`. (Install-guide simplification will follow once a chart with this change is released.)

AI-skills: armosec-shared-rules:writing-docs,schedule,loop | cmds: /model,/login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional GKE Autopilot allowlist synchronization for the node agent via a Helm-rendered `AllowlistSynchronizer`.
  * Allowlist path is now configurable: use an explicit override, or let it be derived from the configured allowlist name.
  * The synchronizer is rendered only when enabled and reconciliation occurs asynchronously without blocking Helm installs or upgrades.

* **Documentation**
  * Added a dedicated guide covering feature behavior and the relevant `nodeAgent.gke.allowlist.*` configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->