### PR TITLE
ci: run GKE Autopilot allowlist drift check on PRs

### DIFF
--- a/.github/workflows/pr-allowlist-drift.yaml
+++ b/.github/workflows/pr-allowlist-drift.yaml
@@ -4,6 +4,12 @@ name: pr-allowlist-drift
 # BYPASS_ALLOWLIST_DRIFT input), a PR is automated — so on drift this notifies the PR author
 # with a sticky comment and fails the check until a maintainer adds the `allowlist-drift-ack`
 # label (the PR-flow equivalent of "set as pass after you opened Gerrit to allowlist").
+#
+# This check is advisory (a notification), not a required status. Do NOT mark it required in
+# branch protection while the `paths:` filter below is in place: GitHub skips a path-filtered
+# workflow on PRs that don't match, and a required check that never runs blocks the PR forever
+# on "Expected — waiting for status". To make it a hard gate, drop the paths filter and no-op
+# early inside the job instead.
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
@@ -22,6 +28,9 @@ permissions:
 
 jobs:
   allowlist-drift:
+    # Only the `allowlist-drift-ack` label affects this check, so skip label events for any
+    # other label instead of re-running the whole checkout + helm + drift check needlessly.
+    if: ${{ !((github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'allowlist-drift-ack') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -50,18 +59,16 @@ jobs:
           set -e
           echo "$OUT"
           # rc: 0 = OK, 2 = spec-drift (ack-able), anything else = the check crashed.
+          # Pass the report through base64 so an arbitrary multiline blob can't break the
+          # step output (no heredoc delimiter to collide with / inject through).
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
-          {
-            echo "report<<DRIFT_EOF"
-            echo "$OUT"
-            echo "DRIFT_EOF"
-          } >> "$GITHUB_OUTPUT"
+          echo "report_b64=$(printf '%s' "$OUT" | base64 -w0)" >> "$GITHUB_OUTPUT"
 
       - name: Notify author & conclude
         uses: actions/github-script@v7
         env:
           RC: ${{ steps.drift.outputs.rc }}
-          REPORT: ${{ steps.drift.outputs.report }}
+          REPORT_B64: ${{ steps.drift.outputs.report_b64 }}
           ACK_LABEL: allowlist-drift-ack
           ALLOWLIST: armo-kubescape-node-agent-1.40-v2
         with:
@@ -70,6 +77,7 @@ jobs:
             const rc = process.env.RC;
             const ackLabel = process.env.ACK_LABEL;
             const allowlist = process.env.ALLOWLIST;
+            const report = Buffer.from(process.env.REPORT_B64 || '', 'base64').toString('utf8').trim();
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
             const issue_number = pr.number;
@@ -105,8 +113,14 @@ jobs:
             }
 
             // rc === '2' : spec drift
-            const detail = '<details><summary>Drift detail</summary>\n\n```\n'
-              + (process.env.REPORT || '').trim() + '\n```\n</details>';
+            if (acked) {
+              await upsert('✅ **GKE Autopilot allowlist drift acknowledged** via the `' + ackLabel + '` label — '
+                + 'the node-agent drifts from `' + allowlist + '`, but a maintainer has confirmed a Gerrit allowlist update is open. This check passes.');
+              core.notice('Drift acknowledged via the `' + ackLabel + '` label — check passes.');
+              return;
+            }
+
+            const detail = '<details><summary>Drift detail</summary>\n\n```\n' + report + '\n```\n</details>';
             const body = [
               '⚠️ **@' + author + '** — this PR\'s node-agent render **drifts from the approved GKE Autopilot allowlist** (`' + allowlist + '`).',
               '',
@@ -119,9 +133,4 @@ jobs:
               detail,
             ].join('\n');
             await upsert(body);
-
-            if (acked) {
-              core.notice('Drift acknowledged via the `' + ackLabel + '` label — check passes.');
-            } else {
-              core.setFailed('node-agent drifts from the approved allowlist `' + allowlist + '`. Open a Gerrit update, then add the `' + ackLabel + '` label.');
-            }
+            core.setFailed('node-agent drifts from the approved allowlist `' + allowlist + '`. Open a Gerrit update, then add the `' + ackLabel + '` label.');

--- a/.github/workflows/pr-allowlist-drift.yaml
+++ b/.github/workflows/pr-allowlist-drift.yaml
@@ -1,0 +1,127 @@
+name: pr-allowlist-drift
+# Runs the GKE Autopilot allowlist drift check on every PR that touches the node-agent
+# render, the vendored allowlist, or the drift tooling. Unlike the release gate (a manual
+# BYPASS_ALLOWLIST_DRIFT input), a PR is automated — so on drift this notifies the PR author
+# with a sticky comment and fails the check until a maintainer adds the `allowlist-drift-ack`
+# label (the PR-flow equivalent of "set as pass after you opened Gerrit to allowlist").
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+    paths:
+      - 'charts/kubescape-operator/**'
+      - 'gke-allowlist/**'
+      - 'scripts/gke-allowlist/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write   # post/update the sticky drift comment
+
+jobs:
+  allowlist-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3.5
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - run: pip install pyyaml
+
+      - name: Check node-agent vs approved allowlist
+        id: drift
+        run: |
+          set +e
+          OUT=$(scripts/gke-allowlist/check-drift.sh \
+            charts/kubescape-operator \
+            gke-allowlist/armo-kubescape-node-agent-1.40-v2.yaml 2>&1)
+          rc=$?
+          set -e
+          echo "$OUT"
+          # rc: 0 = OK, 2 = spec-drift (ack-able), anything else = the check crashed.
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          {
+            echo "report<<DRIFT_EOF"
+            echo "$OUT"
+            echo "DRIFT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify author & conclude
+        uses: actions/github-script@v7
+        env:
+          RC: ${{ steps.drift.outputs.rc }}
+          REPORT: ${{ steps.drift.outputs.report }}
+          ACK_LABEL: allowlist-drift-ack
+          ALLOWLIST: armo-kubescape-node-agent-1.40-v2
+        with:
+          script: |
+            const marker = '<!-- allowlist-drift -->';
+            const rc = process.env.RC;
+            const ackLabel = process.env.ACK_LABEL;
+            const allowlist = process.env.ALLOWLIST;
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const issue_number = pr.number;
+            const author = pr.user.login;
+            const acked = (pr.labels || []).map(l => l.name).includes(ackLabel);
+
+            async function findSticky() {
+              const cs = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+              return cs.find(c => c.body && c.body.includes(marker));
+            }
+            async function upsert(body) {
+              body = marker + '\n' + body;
+              const existing = await findSticky();
+              if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              else await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+            async function clear() {
+              const existing = await findSticky();
+              if (existing) await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+            }
+
+            if (rc === '0') {
+              await clear();
+              core.info('node-agent matches the approved allowlist — no drift.');
+              return;
+            }
+
+            if (rc !== '2') {
+              await upsert('🛑 The GKE Autopilot allowlist drift check **failed to run** (exit `' + rc + '`). '
+                + 'This is not a drift result, so the `' + ackLabel + '` label does **not** bypass it — please fix the check.');
+              core.setFailed('allowlist drift check crashed (exit ' + rc + ')');
+              return;
+            }
+
+            // rc === '2' : spec drift
+            const detail = '<details><summary>Drift detail</summary>\n\n```\n'
+              + (process.env.REPORT || '').trim() + '\n```\n</details>';
+            const body = [
+              '⚠️ **@' + author + '** — this PR\'s node-agent render **drifts from the approved GKE Autopilot allowlist** (`' + allowlist + '`).',
+              '',
+              'On GKE Autopilot the node-agent would be rejected by GKE Warden until Google approves a matching allowlist, so customers could not install this chart version.',
+              '',
+              '**To unblock this PR:**',
+              '1. Open a Gerrit allowlist update at `gke-ap-allowlist.googlesource.com/ARMO` (see `scripts/gke-allowlist/README.md`), then update the vendored `gke-allowlist/` copy once approved.',
+              '2. A maintainer adds the **`' + ackLabel + '`** label to this PR to acknowledge the drift and pass the check.',
+              '',
+              detail,
+            ].join('\n');
+            await upsert(body);
+
+            if (acked) {
+              core.notice('Drift acknowledged via the `' + ackLabel + '` label — check passes.');
+            } else {
+              core.setFailed('node-agent drifts from the approved allowlist `' + allowlist + '`. Open a Gerrit update, then add the `' + ackLabel + '` label.');
+            }

--- a/docs/features/gke-autopilot-allowlist-tooling.md
+++ b/docs/features/gke-autopilot-allowlist-tooling.md
@@ -46,6 +46,26 @@ The `03-helm-release.yaml` workflow runs an `allowlist-drift-check` job before p
 When drift is intentional, also update the vendored `gke-allowlist/` copy and the chart's
 `nodeAgent.gke.allowlist.name` default to the new allowlist once it is approved.
 
+## PR behavior
+
+The same check also runs on pull requests (`pr-allowlist-drift.yaml`) for PRs that touch the
+node-agent render, the vendored allowlist, or the drift tooling — so drift is caught at review time,
+not only at release. A PR is automated (no manual `BYPASS_ALLOWLIST_DRIFT` input to type), so instead:
+
+- **No drift** → the check passes and any prior drift comment is removed.
+- **Drift detected** → the workflow posts (and keeps updated) a **sticky comment that @-mentions the PR
+  author** with the specific missing fields and the next step, and the check **fails**.
+- **Acknowledged drift** → after opening the Gerrit allowlist update, a maintainer adds the
+  **`allowlist-drift-ack`** label to the PR. The check re-runs on the label and passes (the PR-flow
+  equivalent of "set as pass after you opened Gerrit to allowlist").
+- **Check crashed** (any non-`0`/`2` exit) → hard failure; the `allowlist-drift-ack` label does **not**
+  bypass a crash, so a broken check can't be silently acknowledged.
+
+Make the check a required status in branch protection to block merge on un-acknowledged drift; otherwise
+it stays a loud-but-non-blocking signal. For PRs from forks (which get a read-only token), the sticky
+comment cannot be posted directly — move the comment step to a `workflow_run`-triggered companion if the
+repo accepts fork PRs.
+
 ## Run locally
 
 ```bash

--- a/docs/features/gke-autopilot-allowlist-tooling.md
+++ b/docs/features/gke-autopilot-allowlist-tooling.md
@@ -61,10 +61,15 @@ not only at release. A PR is automated (no manual `BYPASS_ALLOWLIST_DRIFT` input
 - **Check crashed** (any non-`0`/`2` exit) → hard failure; the `allowlist-drift-ack` label does **not**
   bypass a crash, so a broken check can't be silently acknowledged.
 
-Make the check a required status in branch protection to block merge on un-acknowledged drift; otherwise
-it stays a loud-but-non-blocking signal. For PRs from forks (which get a read-only token), the sticky
-comment cannot be posted directly — move the comment step to a `workflow_run`-triggered companion if the
-repo accepts fork PRs.
+The check is **advisory** — a loud, self-clearing notification, not a required status. It is scoped with a
+`paths:` filter (node-agent render / vendored allowlist / drift tooling), so it does not run on unrelated
+PRs. Do **not** mark it a required status in branch protection while that filter is in place: GitHub skips
+a path-filtered workflow on non-matching PRs, and a required check that never runs would block those PRs
+forever on "Expected — waiting for status". To turn it into a hard gate, first drop the `paths:` filter and
+no-op early inside the job, then require it.
+
+For PRs from forks (which get a read-only token), the sticky comment cannot be posted directly — move the
+comment step to a `workflow_run`-triggered companion if the repo accepts fork PRs.
 
 ## Run locally
 


### PR DESCRIPTION
## What

Runs the GKE Autopilot allowlist drift check on **pull requests**, not only at release. Adds `.github/workflows/pr-allowlist-drift.yaml`, which reuses the same `scripts/gke-allowlist/check-drift.sh` and vendored allowlist as the release gate.

Triggers on `pull_request` (`opened`, `reopened`, `synchronize`, `ready_for_review`, `labeled`, `unlabeled`) for PRs that touch `charts/kubescape-operator/**`, `gke-allowlist/**`, or `scripts/gke-allowlist/**`.

## Why

A chart change can add an env/mount/capability the approved `WorkloadAllowlist` doesn't cover — which silently breaks installs on GKE Autopilot until Google approves a new allowlist. Catching it at review time (not just at release) means the PR author is told before merge.

## Behavior

Unlike the release gate there's no `BYPASS_ALLOWLIST_DRIFT` input to type on a PR, so:

- **No drift** → check passes; any prior drift comment is removed.
- **Drift** → posts/updates a **sticky comment @-mentioning the PR author** with the missing fields + next step, and **fails** the check.
- **Acknowledged** → after opening the Gerrit allowlist update, a maintainer adds the **`allowlist-drift-ack`** label; the check re-runs on the label and passes ("set as pass after you opened Gerrit").
- **Crashed** (non-`0`/`2` exit) → hard-fails; the label does **not** bypass a crash.

Make it a required status in branch protection to block merge on un-acked drift.

## Notes

- **Stacked on #876** (`gke-allowlist-drift-ci`) — the check-drift script + vendored allowlist land there. Base is set to that branch; merge after #876. Rebase onto `main` once #876 merges.
- Uses only first-party actions (`actions/github-script`), no third-party comment action.
- **Fork PRs** get a read-only token and can't post the sticky comment — if this repo accepts fork PRs, move the comment step to a `workflow_run` companion. Documented in `docs/features/gke-autopilot-allowlist-tooling.md`.

AI-skills: armosec-shared-rules:writing-docs,schedule,loop | cmds: /model,/login,/compact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request checks to detect drift between the GKE Autopilot node-agent configuration and its vendored allowlist.
  * Checks post or update a status comment with results, including details when drift is detected.
  * Drift can be acknowledged with the designated label after the allowlist is updated.

* **Documentation**
  * Documented check triggers, outcomes, acknowledgements, failures, and fork pull request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->