### PR TITLE
[ LFX 2026 ] fix(kubevuln): grant get on workloads and namespaces for SecurityException selectors

### DIFF
--- a/charts/kubescape-operator/templates/kubevuln/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/clusterrole.yaml
@@ -19,5 +19,17 @@ rules:
   - apiGroups: ["kubescape.io"]
     resources: ["securityexceptions", "clustersecurityexceptions"]
     verbs: ["get", "list", "watch"]
+  # Evaluating a SecurityException's match.objectSelector / match.namespaceSelector
+  # requires reading the labels of the scanned workload and its namespace. Without
+  # these, such exceptions fail closed and silently never apply.
+  - apiGroups: [""]
+    resources: ["namespaces", "pods", "replicationcontrollers"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+    verbs: ["get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get"]
 {{- end }}
 {{- end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1826,6 +1826,30 @@ all capabilities:
           - get
           - list
           - watch
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+          - pods
+          - replicationcontrollers
+        verbs:
+          - get
+      - apiGroups:
+          - apps
+        resources:
+          - deployments
+          - statefulsets
+          - daemonsets
+          - replicasets
+        verbs:
+          - get
+      - apiGroups:
+          - batch
+        resources:
+          - jobs
+          - cronjobs
+        verbs:
+          - get
   38: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -39203,6 +39227,30 @@ multiple node agents:
           - get
           - list
           - watch
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+          - pods
+          - replicationcontrollers
+        verbs:
+          - get
+      - apiGroups:
+          - apps
+        resources:
+          - deployments
+          - statefulsets
+          - daemonsets
+          - replicasets
+        verbs:
+          - get
+      - apiGroups:
+          - batch
+        resources:
+          - jobs
+          - cronjobs
+        verbs:
+          - get
   38: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -54748,6 +54796,30 @@ skipPersistence enabled:
           - get
           - list
           - watch
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+          - pods
+          - replicationcontrollers
+        verbs:
+          - get
+      - apiGroups:
+          - apps
+        resources:
+          - deployments
+          - statefulsets
+          - daemonsets
+          - replicasets
+        verbs:
+          - get
+      - apiGroups:
+          - batch
+        resources:
+          - jobs
+          - cronjobs
+        verbs:
+          - get
   38: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding


### PR DESCRIPTION
## Overview

This is the RBAC counterpart to kubescape/kubevuln#383, which scopes vulnerability `SecurityException` / `ClusterSecurityException` CRDs by their `spec.match` selectors.

Two of those selectors, `match.objectSelector` and `match.namespaceSelector`, are evaluated against real labels. To read them, the `kubevuln` scanner now does live `GET` calls through the dynamic client: it reads the labels of the scanned workload (for `objectSelector`) and the labels of that workload's namespace (for `namespaceSelector`).

Today the `kubevuln` ClusterRole does not grant `get` on those workload kinds or on `namespaces`. Without the grant, every label lookup returns `403 Forbidden`. The scanner treats that as a failure and fails closed, so the exception does not apply and the CVE is reported again, with only a `Warning` log line as a signal. In practice that looks like "selector-based exceptions randomly stopped working." Matthias raised exactly this in the kubevuln#383 review, so this PR closes the gap.

## What changed

One template, `charts/kubescape-operator/templates/kubevuln/clusterrole.yaml`, gets three read-only rules, added inside the existing `capabilities.riskAcceptance == "enable"` block right next to the `securityexceptions` grant, so the gating matches the rest of the feature:

```yaml
# Evaluating a SecurityException's match.objectSelector / match.namespaceSelector
# requires reading the labels of the scanned workload and its namespace. Without
# these, such exceptions fail closed and silently never apply.
- apiGroups: [""]
  resources: ["namespaces", "pods", "replicationcontrollers"]
  verbs: ["get"]
- apiGroups: ["apps"]
  resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
  verbs: ["get"]
- apiGroups: ["batch"]
  resources: ["jobs", "cronjobs"]
  verbs: ["get"]
```

Notes:

- Verbs are `get` only. No `list` or `watch`, and no wildcards.
- The kind list is the standard set of workload kinds a vulnerability scan can target. It matches the list documented in the kubevuln design doc (`docs/security-exception-design.md`).
- These lookups fail closed. If the scanner cannot read a workload's or namespace's labels, the exception does not apply and the finding is reported, so a missing grant can never widen suppression, only narrow it.
- A selector-based exception that targets a kind outside this list (for example a custom workload CRD) will not apply until the scanner is granted `get` on that kind. This is called out in the design doc as an accepted limitation.

## Testing

- `charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap` is regenerated. The new rules show up in the `all capabilities`, `multiple node agents`, and `skipPersistence enabled` fixtures, which are the ones that render the ClusterRole with risk acceptance on.

## Related

- kubescape/kubevuln#383 (the code that needs this grant)
- kubescape/helm-charts#875 (the equivalent grant for the `kubescape` posture component)
- Parent issue: kubescape/kubescape#1982 (SecurityException CRD)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled selector-based security exceptions to evaluate namespace and workload labels when risk acceptance is enabled.

* **Documentation**
  * Added explanatory comments describing the permissions required for security exception matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->