### PR TITLE
fix(ci): pin Helm in pr-allowlist-drift instead of working around old Helm

### DIFF
--- a/.github/workflows/03-helm-release.yaml
+++ b/.github/workflows/03-helm-release.yaml
@@ -75,6 +75,11 @@ jobs:
           persist-credentials: false
       - name: Install Helm
         uses: azure/setup-helm@v3.5
+        with:
+          # Keep in sync with pr-allowlist-drift.yaml — the release gate and the PR check
+          # must render with the same Helm or they can disagree. See that workflow for why
+          # the default `version: latest` silently installs v3.9.0.
+          version: v3.19.0
       - name: Install Python
         uses: actions/setup-python@v5
         with:
@@ -128,8 +133,10 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3.5
-        # with:
-        #   version: v3.4.0
+        with:
+          # Pinned: this Helm packages the released chart, so it must not drift silently.
+          # The default `version: latest` needs a token to resolve and falls back to v3.9.0.
+          version: v3.19.0
 
       - name: Install chart-releaser CLI
         env:

--- a/.github/workflows/04-helm-release-no-tests.yaml
+++ b/.github/workflows/04-helm-release-no-tests.yaml
@@ -45,8 +45,10 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3.5
-        # with:
-        #   version: v3.4.0
+        with:
+          # Pinned: this Helm packages the released chart, so it must not drift silently.
+          # The default `version: latest` needs a token to resolve and falls back to v3.9.0.
+          version: v3.19.0
 
       - name: Install chart-releaser CLI
         env:

--- a/.github/workflows/pr-allowlist-drift.yaml
+++ b/.github/workflows/pr-allowlist-drift.yaml
@@ -24,7 +24,10 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write   # post/update the sticky drift comment
+  pull-requests: write   # post/update/delete the sticky drift comment (PR comments are
+                         # scoped to `pull-requests`, not `issues`, even though they go
+                         # through the issues API). A PR from a fork gets a read-only
+                         # token regardless, so the comment calls below tolerate a 403.
 
 jobs:
   allowlist-drift:
@@ -40,6 +43,13 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3.5
+        with:
+          # Pin. With the default `latest`, setup-helm needs a token to resolve the newest
+          # release and silently falls back to Helm v3.9.0 (Go 1.17) when it can't — and
+          # Go only made text/template `and`/`or` short-circuit in 1.18, so any
+          # `and X (len X)` guard in the chart blows up with "len of nil pointer" there.
+          # A drift check that renders on a 2022 Helm isn't checking what users deploy.
+          version: v3.19.0
 
       - name: Install Python
         uses: actions/setup-python@v5
@@ -84,19 +94,34 @@ jobs:
             const author = pr.user.login;
             const acked = (pr.labels || []).map(l => l.name).includes(ackLabel);
 
+            // Deliberately NOT wrapped in try/catch: if listing fails we must not fall
+            // through to createComment and leave a second sticky comment behind.
             async function findSticky() {
               const cs = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
               return cs.find(c => c.body && c.body.includes(marker));
             }
+            // Commenting is best-effort — on a fork PR the token is read-only and every
+            // call below 403s. Never let that mask the drift verdict itself, but never
+            // swallow the report either: mirror it into the job summary so the author
+            // still has something to read.
             async function upsert(body) {
-              body = marker + '\n' + body;
-              const existing = await findSticky();
-              if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-              else await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              try {
+                const existing = await findSticky();
+                const withMarker = marker + '\n' + body;
+                if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: withMarker });
+                else await github.rest.issues.createComment({ owner, repo, issue_number, body: withMarker });
+              } catch (err) {
+                core.warning('Could not post/update the sticky PR comment: ' + err.message);
+              }
+              await core.summary.addRaw(body).write();
             }
             async function clear() {
-              const existing = await findSticky();
-              if (existing) await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+              try {
+                const existing = await findSticky();
+                if (existing) await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+              } catch (err) {
+                core.warning('Could not delete the sticky PR comment: ' + err.message);
+              }
             }
 
             if (rc === '0') {

--- a/charts/kubescape-operator/templates/operator/configmap.yaml
+++ b/charts/kubescape-operator/templates/operator/configmap.yaml
@@ -54,8 +54,9 @@ data:
         "operatorDeploymentName": "{{ .Values.operator.name }}",
         "goMemLimitPercentage": {{ .Values.nodeAgent.gomemlimitPercentage }}
       }
-        {{- if and .Values.imageScanning.privateRegistries.credentials (gt (len .Values.imageScanning.privateRegistries.credentials) 0) }}
-        {{- $cred := index .Values.imageScanning.privateRegistries.credentials 0 }}
+        {{- $creds := ((.Values.imageScanning).privateRegistries).credentials }}
+        {{- if $creds }}
+        {{- $cred := index $creds 0 }}
         {{- if $cred.skipTlsVerify }},
       "registryScanningSkipTlsVerify": {{ $cred.skipTlsVerify }}
         {{- end }}

--- a/scripts/gke-allowlist/README.md
+++ b/scripts/gke-allowlist/README.md
@@ -34,6 +34,14 @@ scripts/gke-allowlist/check-drift.sh charts/kubescape-operator \
 Exit 0 = covered; exit 2 = drift (the render needs something the allowlist lacks — the output names
 each missing env/mount/container).
 
+Use a **Helm ≥ 3.18** matching the pinned `version:` in `.github/workflows/pr-allowlist-drift.yaml`.
+The check is only meaningful if it renders the chart the way users' Helm does, and old Helm can
+differ enough to break the render outright: Helm ≤ 3.10 is built with Go < 1.18, where template
+`and`/`or` evaluate every argument instead of short-circuiting, so a guard like
+`and .X (gt (len .X) 0)` fails with `len of nil pointer`. Don't leave the workflow's `setup-helm`
+on the default `version: latest` — without a token it can't resolve "latest" and silently installs
+v3.9.0.
+
 ## When the drift gate fails on a release
 
 1. The node-agent's privileged surface changed and needs a **new allowlist version**.


### PR DESCRIPTION
`azure/setup-helm` was left on the default `version: latest`, which needs a GitHub token to resolve the newest release. Without one it warns and silently installs **Helm v3.9.0** (2022, Go 1.17) — that is what actually broke the workflow.

Go only made text/template `and`/`or` short-circuit in **Go 1.18**, so on v3.9.0 the guard `and .X (gt (len .X) 0)` in the operator configmap evaluated `len` on a nil `imageScanning.privateRegistries.credentials` and died:

```
configmap.yaml:57:76: executing ... at <len .Values.imageScanning.privateRegistries.credentials>:
error calling len: len of nil pointer
```

Verified on unmodified `main`:

| Helm | Result |
|---|---|
| v3.9.0 (Go 1.17) | `len of nil pointer` |
| v3.11.0 (Go 1.18) | renders fine |
| v3.19.0 | renders fine |

Beyond the crash, a drift gate whose entire job is to render *what customers deploy* was rendering with a four-year-old Helm. **Pinned to v3.19.0**; the drift check still classifies `no-op` against the approved allowlist.

### Also

- Collapsed the credentials guard to a single `if` — Go templates already treat an empty slice as false, so `gt (len ...) 0` was dead code — and read the path through parens so a nil `imageScanning`/`privateRegistries` doesn't panic either.
- Kept `pull-requests: write`. PR comments are scoped to `pull-requests`, not `issues`, even though they go through the issues API, and the sticky comment demonstrably worked under this permission — there was never a permissions bug.
- Comment calls tolerate a 403 (a fork PR gets a read-only token) but the report is mirrored into the **job summary**, so a failed comment never silently swallows the drift detail. `findSticky()` deliberately still throws, so a failed list can't fall through to `createComment` and leave a duplicate sticky comment.
- Documented the Helm version requirement in `scripts/gke-allowlist/README.md`, since the check is also runnable locally.

### Second commit: the release workflows had the same bug

`03-helm-release.yaml` (×2) and `04-helm-release-no-tests.yaml` were also on the default `version: latest`, so the release pipeline was running Helm v3.9.0 too — both for the release-gate drift check and for the `helm dependency update` + `helm package` that produce the **published chart**. All three are now pinned to v3.19.0, so every `setup-helm` in the repo is pinned:

| Workflow | Job | Version |
|---|---|---|
| `pr-allowlist-drift.yaml` | `allowlist-drift` | v3.19.0 |
| `03-helm-release.yaml` | `allowlist-drift-check` | v3.19.0 |
| `03-helm-release.yaml` | `helm-chart-release` | v3.19.0 |
| `04-helm-release-no-tests.yaml` | `helm-chart-release` | v3.19.0 |

The release gate and the PR check must share a Helm or they can disagree on the same chart. Verified `helm dependency update`, `helm package` and `helm lint` give the same result on v3.9.0 and v3.19.0 (`kubescape-operator-1.40.2.tgz`, lint clean) — this changes the Helm doing the packaging, not the output.

