### PR TITLE
docs: remove dead kubescape.submit value from README

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -127,7 +127,6 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | kubescape.serviceMonitor.enabled | bool | `false` | enable/disable service monitor for prometheus (operator) integration |
 | kubescape.skipUpdateCheck | bool | `false` | skip check for a newer version |
 | kubescape.labels | `[]` | adds labels to the kubescape microservice |
-| kubescape.submit | bool | `true` | submit results to Kubescape SaaS: <https://cloud.armosec.io/> |
 | kubescape.volumes | object | `[]` | Additional volumes for Kubescape |
 | kubescape.volumeMounts | object | `[]` | Additional volumeMounts for Kubescape |
 | kubescapeScheduler.enabled | bool | `true` | enable/disable a kubescape scheduled scan using a CronJob |


### PR DESCRIPTION
## Overview

`kubescape.submit` is documented in `charts/kubescape-operator/README.md` as a real toggle (`bool, default true, submit results to Kubescape SaaS`), but it's not a key in `values.yaml` and no template ever consumes it (no `KS_SUBMIT` env var or equivalent is set anywhere in the chart). The chart's own internal `$submit` variable (`templates/_common.tpl:23`, `not (empty .Values.server)`) is a separate, same-named value used only to derive capability defaults (`continuousScan`, `virtualCrds`, `networkStreaming`) - it never reaches the kubescape container.

This is what led to [kubescape/kubescape#2555](https://github.com/kubescape/kubescape/issues/2555): a user set `kubescape.submit: false` expecting it to disable SaaS submission, but it had no effect since the value is dead. This PR just removes the misleading doc row; the actual submission-gating fix lives in the paired [kubescape/kubescape PR #2556](https://github.com/kubescape/kubescape/pull/2556).

## Related issues/PRs

* Resolved #2555 (partial - doc side; see kubescape/kubescape#2556 for the code fix)

## How to Test

Diff-only change to README.md; no template/values behavior affected. Confirmed no other reference to `kubescape.submit` exists in the repo:

```
grep -rln "kubescape.submit" . --include="*.md" --include="*.yaml" --include="*.tpl"
```

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

AI-skills: none