### PR TITLE
Bump storage image to v0.0.298 and ignore local CLI files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.antigravitycli
+.omc
 .vscode
 .idea
 charts/kubescape-operator/Chart.lock

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -5668,7 +5668,7 @@ all capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -10238,7 +10238,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -14526,7 +14526,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19792,7 +19792,7 @@ backend-storage enabled allows scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21260,7 +21260,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21673,7 +21673,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22321,7 +22321,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22997,7 +22997,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23382,7 +23382,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23739,7 +23739,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24195,7 +24195,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24691,7 +24691,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -29289,7 +29289,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -33903,7 +33903,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -38388,7 +38388,7 @@ minimal capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -44838,7 +44838,7 @@ multiple node agents:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -49613,7 +49613,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -53954,7 +53954,7 @@ relevancy only:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -60113,7 +60113,7 @@ skipPersistence enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.297
+              image: quay.io/kubescape/storage:v0.0.298
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -537,7 +537,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: quay.io/kubescape/storage
-    tag: v0.0.297
+    tag: v0.0.298
     pullPolicy: IfNotPresent
 
   nodeSelector:


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `main` branch**

-->
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated default deployment configuration to use the newer Kubescape storage service image.
  - Added local tooling files to the project’s ignore list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->