### PR TITLE
chore: deprecate old profiletypes in favor of containerprofiles

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -15,14 +15,14 @@ kubeVersion: ">=1.28.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.40.3-sbob-rc5k
+version: 1.40.3-sbob-rc5l
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: "sbob-rc5k"
+appVersion: "sbob-rc5l"
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -15,14 +15,14 @@ kubeVersion: ">=1.28.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.40.3-sbob-rc5l
+version: 1.40.3-sbob-rc5s
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: "sbob-rc5l"
+appVersion: "sbob-rc5s"
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -15,14 +15,14 @@ kubeVersion: ">=1.28.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.40.3-sbob-rc5d
+version: 1.40.3-sbob-rc5k
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: "sbob-rc5d"
+appVersion: "sbob-rc5k"
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -15,14 +15,14 @@ kubeVersion: ">=1.28.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.40.3-sbob-rc5s
+version: 1.40.3-v0.3.171
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: "sbob-rc5s"
+appVersion: "v0.3.171"
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -15,14 +15,14 @@ kubeVersion: ">=1.28.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.40.3
+version: 1.40.3-sbob-rc5d
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.40.3
+appVersion: "sbob-rc5d"
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -457,8 +457,7 @@ class ksCm,recurringScanCm,operator,er,store,masterSync,recurringScanCj,recurrin
 * **Responsibility:** This component has multiple purposes all bound to information available on Kubernetes nodes:
   * Produces SBOMs from the images avialable on the node (used by *KubeVuln*)
   * Produces information from the configurations of the Linux host of the Kubernetes node (used by *Kubescape*)
-  * Creates *ApplicationProfile* using [Inspektor Gadget](https://inspektor-gadget.io) and eBPF. These profiles log the behavior of each container on the node (file access, processes launched, capabilities used, system calls done) into *ApplicationProfile* objects stored in the *Storage* component via the Kubernetes API and optionally sent to external API endpoints.
-  * Creates *NetworkNeighborhood* objects using [Inspektor Gadget](https://inspektor-gadget.io) and eBPF. These profiles log the network activity of each container and they stored as objects in the *Storage* component via the Kubernetes API and optionally sent to external API endpoints.
+  * Creates *ContainerProfile* objects using [Inspektor Gadget](https://inspektor-gadget.io) and eBPF. These profiles log the behavior of each container on the node (file access, processes launched, capabilities used, system calls done) together with its network activity, stored in the *Storage* component via the Kubernetes API and optionally sent to external API endpoints.
   * Monitors container activity via eBPF and evaluates them using its own rule engine that combines static detection rules and anomaly detection to produce alerts that can be exported to AlertManager, Syslog, HTTP endpoints, STDOUT stream and other.
 
 ```mermaid

--- a/charts/kubescape-operator/templates/node-agent/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/node-agent/clusterrole.yaml
@@ -24,9 +24,6 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments", "daemonsets", "statefulsets", "replicasets"]
   verbs: ["get", "watch", "list"]
-- apiGroups: ["spdx.softwarecomposition.kubescape.io"]
-  resources: ["applicationprofiles", "networkneighborhoods"]
-  verbs: ["get", "watch", "list"]
 {{- if eq .Values.capabilities.seccompProfileBackend "crd" }}
 - apiGroups: ["kubescape.io"]
   resources: ["seccompprofiles"]

--- a/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
@@ -28,7 +28,7 @@ rules:
     resources: ["networkpolicies", "ingresses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
-    resources: ["applicationprofiles", "networkneighborhoods", "containerprofiles"]
+    resources: ["containerprofiles"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
     resources: ["knownservers"]

--- a/charts/kubescape-operator/templates/synchronizer/configmap.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/configmap.yaml
@@ -163,12 +163,6 @@ data:
           {
             "group": "spdx.softwarecomposition.kubescape.io",
             "version": "v1beta1",
-            "resource": "applicationprofiles",
-            "strategy": "copy"
-          },
-          {
-            "group": "spdx.softwarecomposition.kubescape.io",
-            "version": "v1beta1",
             "resource": "containerprofiles",
             "strategy": "copy"
           },
@@ -176,12 +170,6 @@ data:
             "group": "spdx.softwarecomposition.kubescape.io",
             "version": "v1beta1",
             "resource": "knownservers",
-            "strategy": "copy"
-          },
-          {
-            "group": "spdx.softwarecomposition.kubescape.io",
-            "version": "v1beta1",
-            "resource": "networkneighborhoods",
             "strategy": "copy"
           },
           {{- if eq .Values.capabilities.syncSBOM "enable" }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2643,15 +2643,6 @@ all capabilities:
           - watch
           - list
       - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
           - kubescape.io
         resources:
           - seccompprofiles
@@ -5590,7 +5581,7 @@ all capabilities:
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
-          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "kindQueues": {"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "serverBindPort": "8443"
         }
     kind: ConfigMap
@@ -5642,7 +5633,7 @@ all capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
-            checksum/storage-config: 2bfab29c4f2202642843536de82e3599252f3db66aa3b8429db6fc662544401c
+            checksum/storage-config: 40c4167c273a8515740c76d3f4546512d0f5bf68031ef8de4960b5c4fb2cce60
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -6319,8 +6310,6 @@ all capabilities:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -6649,12 +6638,6 @@ all capabilities:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -6662,12 +6645,6 @@ all capabilities:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -6850,7 +6827,7 @@ all capabilities:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: cb62da628f5afa9a6ea3abdcf39087e081964cb1f377a58b82bf2c90abbe81c7
+            checksum/synchronizer-configmap: f1c83380b4ab227f8219ffd32e23133bbf93d37a08f4f07e3c91063394ec0ad5
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -8814,15 +8791,6 @@ autoscaler mode with sbom sidecar:
           - watch
           - list
       - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
           - kubescape.io
         resources:
           - seccompprofiles
@@ -10157,7 +10125,7 @@ autoscaler mode with sbom sidecar:
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
-          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "kindQueues": {"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -10212,7 +10180,7 @@ autoscaler mode with sbom sidecar:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+            checksum/storage-config: 17d7ae24f7ee217cb20681b90c2c424655e97a2912856df270566bf9adfbf3d2
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -10807,8 +10775,6 @@ autoscaler mode with sbom sidecar:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -11068,12 +11034,6 @@ autoscaler mode with sbom sidecar:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -11081,12 +11041,6 @@ autoscaler mode with sbom sidecar:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -11250,7 +11204,7 @@ autoscaler mode with sbom sidecar:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
+            checksum/synchronizer-configmap: 77923ccf52f639e2212347cf07ac28648c138fca84b2d9e99a7a92121d01941c
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -13102,15 +13056,6 @@ autoscaler mode without sbom sidecar:
           - watch
           - list
       - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
           - kubescape.io
         resources:
           - seccompprofiles
@@ -14445,7 +14390,7 @@ autoscaler mode without sbom sidecar:
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
-          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "kindQueues": {"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -14500,7 +14445,7 @@ autoscaler mode without sbom sidecar:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+            checksum/storage-config: 17d7ae24f7ee217cb20681b90c2c424655e97a2912856df270566bf9adfbf3d2
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -15095,8 +15040,6 @@ autoscaler mode without sbom sidecar:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -15356,12 +15299,6 @@ autoscaler mode without sbom sidecar:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -15369,12 +15306,6 @@ autoscaler mode without sbom sidecar:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -15538,7 +15469,7 @@ autoscaler mode without sbom sidecar:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
+            checksum/synchronizer-configmap: 77923ccf52f639e2212347cf07ac28648c138fca84b2d9e99a7a92121d01941c
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -17387,15 +17318,6 @@ backend-storage enabled allows scanning capabilities:
           - daemonsets
           - statefulsets
           - replicasets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
         verbs:
           - get
           - watch
@@ -19711,7 +19633,7 @@ backend-storage enabled allows scanning capabilities:
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
-          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "kindQueues": {"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -19766,7 +19688,7 @@ backend-storage enabled allows scanning capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+            checksum/storage-config: 17d7ae24f7ee217cb20681b90c2c424655e97a2912856df270566bf9adfbf3d2
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -20361,8 +20283,6 @@ backend-storage enabled allows scanning capabilities:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -20622,12 +20542,6 @@ backend-storage enabled allows scanning capabilities:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -20635,12 +20549,6 @@ backend-storage enabled allows scanning capabilities:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -20804,7 +20712,7 @@ backend-storage enabled allows scanning capabilities:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: 89c4293fcd32cc7a3ee95ac49975a088c1eee7af72a1712948fa24960c0dcd6a
+            checksum/synchronizer-configmap: c43947fbb741972e7be667da7aa9ab69b0e998bde2e48d33c7f9b53c00a384f0
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -21234,7 +21142,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: bacd8615629fc0d8d77c7fa095084e77313ab6666170a7985820f92dfc40670a
+            checksum/storage-config: ccd692765007942c70917c9924c3354729389d7c867b7debe88af5300f17cedb
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -21647,7 +21555,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/storage-certgen-scripts: 0437bf4a87439f0a5e709a25751946c2ea0940389b61c553aeac7c899fc362a4
-            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
+            checksum/storage-config: c9bcadae760b5855e67622d6fc0d2cce13652505ba4abbf6293dba21a15f22a4
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -22295,7 +22203,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: bacd8615629fc0d8d77c7fa095084e77313ab6666170a7985820f92dfc40670a
+            checksum/storage-config: ccd692765007942c70917c9924c3354729389d7c867b7debe88af5300f17cedb
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -22971,7 +22879,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/storage-certgen-scripts: 0437bf4a87439f0a5e709a25751946c2ea0940389b61c553aeac7c899fc362a4
-            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
+            checksum/storage-config: c9bcadae760b5855e67622d6fc0d2cce13652505ba4abbf6293dba21a15f22a4
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -23356,7 +23264,7 @@ cert strategy template, admission disabled, mtls disabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: bacd8615629fc0d8d77c7fa095084e77313ab6666170a7985820f92dfc40670a
+            checksum/storage-config: ccd692765007942c70917c9924c3354729389d7c867b7debe88af5300f17cedb
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -23713,7 +23621,7 @@ cert strategy template, admission disabled, mtls enabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
+            checksum/storage-config: c9bcadae760b5855e67622d6fc0d2cce13652505ba4abbf6293dba21a15f22a4
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -24169,7 +24077,7 @@ cert strategy template, admission enabled, mtls disabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: bacd8615629fc0d8d77c7fa095084e77313ab6666170a7985820f92dfc40670a
+            checksum/storage-config: ccd692765007942c70917c9924c3354729389d7c867b7debe88af5300f17cedb
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -24665,7 +24573,7 @@ cert strategy template, admission enabled, mtls enabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
+            checksum/storage-config: c9bcadae760b5855e67622d6fc0d2cce13652505ba4abbf6293dba21a15f22a4
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -26836,15 +26744,6 @@ default capabilities:
           - daemonsets
           - statefulsets
           - replicasets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
         verbs:
           - get
           - watch
@@ -29208,7 +29107,7 @@ default capabilities:
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
-          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "kindQueues": {"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -29263,7 +29162,7 @@ default capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+            checksum/storage-config: 17d7ae24f7ee217cb20681b90c2c424655e97a2912856df270566bf9adfbf3d2
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -29909,8 +29808,6 @@ default capabilities:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -30170,12 +30067,6 @@ default capabilities:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -30183,12 +30074,6 @@ default capabilities:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -30353,7 +30238,7 @@ default capabilities:
             checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
+            checksum/synchronizer-configmap: 77923ccf52f639e2212347cf07ac28648c138fca84b2d9e99a7a92121d01941c
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -32279,15 +32164,6 @@ disable otel:
           - watch
           - list
       - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
           - kubescape.io
         resources:
           - seccompprofiles
@@ -33822,7 +33698,7 @@ disable otel:
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
-          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "kindQueues": {"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -33877,7 +33753,7 @@ disable otel:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+            checksum/storage-config: 17d7ae24f7ee217cb20681b90c2c424655e97a2912856df270566bf9adfbf3d2
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -34472,8 +34348,6 @@ disable otel:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -34733,12 +34607,6 @@ disable otel:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -34746,12 +34614,6 @@ disable otel:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -34915,7 +34777,7 @@ disable otel:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
+            checksum/synchronizer-configmap: 77923ccf52f639e2212347cf07ac28648c138fca84b2d9e99a7a92121d01941c
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -36767,15 +36629,6 @@ minimal capabilities:
           - watch
           - list
       - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
           - kubescape.io
         resources:
           - seccompprofiles
@@ -38307,7 +38160,7 @@ minimal capabilities:
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
-          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "kindQueues": {"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -38362,7 +38215,7 @@ minimal capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
-            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
+            checksum/storage-config: c9bcadae760b5855e67622d6fc0d2cce13652505ba4abbf6293dba21a15f22a4
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -41514,15 +41367,6 @@ multiple node agents:
           - daemonsets
           - statefulsets
           - replicasets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
         verbs:
           - get
           - watch
@@ -44760,7 +44604,7 @@ multiple node agents:
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
-          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "kindQueues": {"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "serverBindPort": "8443"
         }
     kind: ConfigMap
@@ -44812,7 +44656,7 @@ multiple node agents:
         metadata:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
-            checksum/storage-config: 2bfab29c4f2202642843536de82e3599252f3db66aa3b8429db6fc662544401c
+            checksum/storage-config: 40c4167c273a8515740c76d3f4546512d0f5bf68031ef8de4960b5c4fb2cce60
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -45489,8 +45333,6 @@ multiple node agents:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -45819,12 +45661,6 @@ multiple node agents:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -45832,12 +45668,6 @@ multiple node agents:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -46020,7 +45850,7 @@ multiple node agents:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: cb62da628f5afa9a6ea3abdcf39087e081964cb1f377a58b82bf2c90abbe81c7
+            checksum/synchronizer-configmap: f1c83380b4ab227f8219ffd32e23133bbf93d37a08f4f07e3c91063394ec0ad5
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -47988,15 +47818,6 @@ priority class scheduling:
           - watch
           - list
       - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
           - kubescape.io
         resources:
           - seccompprofiles
@@ -49532,7 +49353,7 @@ priority class scheduling:
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
-          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "kindQueues": {"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -49587,7 +49408,7 @@ priority class scheduling:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+            checksum/storage-config: 17d7ae24f7ee217cb20681b90c2c424655e97a2912856df270566bf9adfbf3d2
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -50183,8 +50004,6 @@ priority class scheduling:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -50444,12 +50263,6 @@ priority class scheduling:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -50457,12 +50270,6 @@ priority class scheduling:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -50626,7 +50433,7 @@ priority class scheduling:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
+            checksum/synchronizer-configmap: 77923ccf52f639e2212347cf07ac28648c138fca84b2d9e99a7a92121d01941c
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -52472,15 +52279,6 @@ relevancy only:
           - watch
           - list
       - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
           - kubescape.io
         resources:
           - seccompprofiles
@@ -53873,7 +53671,7 @@ relevancy only:
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
-          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "kindQueues": {"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -53928,7 +53726,7 @@ relevancy only:
         metadata:
           annotations:
             checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
-            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
+            checksum/storage-config: c9bcadae760b5855e67622d6fc0d2cce13652505ba4abbf6293dba21a15f22a4
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -57088,15 +56886,6 @@ skipPersistence enabled:
           - watch
           - list
       - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
           - kubescape.io
         resources:
           - seccompprofiles
@@ -60035,7 +59824,7 @@ skipPersistence enabled:
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
-          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "kindQueues": {"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "serverBindPort": "8443"
         }
     kind: ConfigMap
@@ -60087,7 +59876,7 @@ skipPersistence enabled:
         metadata:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
-            checksum/storage-config: 2bfab29c4f2202642843536de82e3599252f3db66aa3b8429db6fc662544401c
+            checksum/storage-config: 40c4167c273a8515740c76d3f4546512d0f5bf68031ef8de4960b5c4fb2cce60
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -60764,8 +60553,6 @@ skipPersistence enabled:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -61094,12 +60881,6 @@ skipPersistence enabled:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -61107,12 +60888,6 @@ skipPersistence enabled:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -61295,7 +61070,7 @@ skipPersistence enabled:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: cb62da628f5afa9a6ea3abdcf39087e081964cb1f377a58b82bf2c90abbe81c7
+            checksum/synchronizer-configmap: f1c83380b4ab227f8219ffd32e23133bbf93d37a08f4f07e3c91063394ec0ad5
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -537,7 +537,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: ghcr.io/k8sstormcenter/storage
-    tag: sbob-rc5l
+    tag: sbob-rc5s
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -598,7 +598,7 @@ nodeAgent:
   image:
     # -- source code: https://github.com/kubescape/node-agent
     repository: ghcr.io/k8sstormcenter/node-agent
-    tag: sbob-rc5l
+    tag: sbob-rc5s
     pullPolicy: IfNotPresent
 
   config:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -536,8 +536,8 @@ storage:
   # -- source code: https://github.com/kubescape/storage
   image:
     # -- source code: https://github.com/kubescape/storage
-    repository: quay.io/kubescape/storage
-    tag: v0.0.297
+    repository: ghcr.io/k8sstormcenter/storage
+    tag: sbob-rc5d
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -597,8 +597,8 @@ nodeAgent:
   gomemlimitPercentage: 0.8
   image:
     # -- source code: https://github.com/kubescape/node-agent
-    repository: quay.io/kubescape/node-agent
-    tag: v0.3.158
+    repository: ghcr.io/k8sstormcenter/node-agent
+    tag: sbob-rc5d
     pullPolicy: IfNotPresent
 
   config:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -566,18 +566,10 @@ storage:
   defaultMaxObjectSize: 400000 # in bytes, this is the maximum size of an object that can be stored in the storage service
   kindQueues:
     # -- set the queues for the different kinds, the default is to use the default queue length and worker count
-    applicationprofiles:
-      queueLength: 50
-      workerCount: 2
-      maxObjectSize: 20000000
     containerprofiles:
       queueLength: 50
       workerCount: 2
       maxObjectSize: 2500000
-    networkneighborhoods:
-      queueLength: 50
-      workerCount: 2
-      maxObjectSize: 10000000
     openvulnerabilityexchangecontainers:
       queueLength: 50
       workerCount: 1

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -555,9 +555,8 @@ storage:
 
   # -- source code: https://github.com/kubescape/storage
   image:
-    # -- source code: https://github.com/kubescape/storage
-    repository: ghcr.io/k8sstormcenter/storage
-    tag: sbob-rc5s
+    repository: quay.io/kubescape/storage
+    tag: v0.0.304
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -617,8 +616,8 @@ nodeAgent:
   gomemlimitPercentage: 0.8
   image:
     # -- source code: https://github.com/kubescape/node-agent
-    repository: ghcr.io/k8sstormcenter/node-agent
-    tag: v0.3.171
+    repository: quay.io/kubescape/node-agent
+    tag: MUSTBERELEASED
     pullPolicy: IfNotPresent
 
   config:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -537,7 +537,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: ghcr.io/k8sstormcenter/storage
-    tag: sbob-rc5k
+    tag: sbob-rc5l
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -598,7 +598,7 @@ nodeAgent:
   image:
     # -- source code: https://github.com/kubescape/node-agent
     repository: ghcr.io/k8sstormcenter/node-agent
-    tag: sbob-rc5k
+    tag: sbob-rc5l
     pullPolicy: IfNotPresent
 
   config:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -598,7 +598,7 @@ nodeAgent:
   image:
     # -- source code: https://github.com/kubescape/node-agent
     repository: ghcr.io/k8sstormcenter/node-agent
-    tag: sbob-rc5s
+    tag: v0.3.171
     pullPolicy: IfNotPresent
 
   config:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -537,7 +537,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: ghcr.io/k8sstormcenter/storage
-    tag: sbob-rc5d
+    tag: sbob-rc5k
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -598,7 +598,7 @@ nodeAgent:
   image:
     # -- source code: https://github.com/kubescape/node-agent
     repository: ghcr.io/k8sstormcenter/node-agent
-    tag: sbob-rc5d
+    tag: sbob-rc5k
     pullPolicy: IfNotPresent
 
   config:


### PR DESCRIPTION
We are removing all occurences of AP NN and ug


This helm chart is being build on the fork to serve as part of the component-testing
-> before merging, please build a new storage and nodeagent image and use those in lieu of the k8sstormcenter images



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Node Agent documentation now reflects ContainerProfile collection, including network activity.
* Storage synchronization now includes ContainerProfile and Known Server resources.
* Updated storage and operator component images to newer releases.

## Bug Fixes

* Removed obsolete permissions and queue settings for ApplicationProfile and NetworkNeighborhood resources.
* Updated chart metadata to accurately reflect the current operator release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->