### PR TITLE
feat: expose defaultFrameworks in kubescape-operator chart

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -101,6 +101,7 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| defaultFrameworks | list | `[]` | Install-time posture frameworks when a scan omits `targetNames`. Empty = operator legacy fallbacks. Clear with `--set defaultFrameworks=null`. |
 | global.networkPolicy.enabled | bool | `false` | Create NetworkPolicies for all components |
 | global.networkPolicy.createEgressRules | bool | `false` | Create common Egress rules for NetworkPolicies |
 | global.kubescapePsp.enabled | bool | `false` | Enable all privileges in Pod Security Policies for Kubescape namespace |

--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -56,9 +56,20 @@ data:
 {{- end }}
       "relevantImageVulnerabilitiesConfiguration": "{{ .Values.capabilities.relevancy }}",
       "riskAcceptance": {{ eq .Values.capabilities.riskAcceptance "enable" }}
-      {{- if .Values.defaultFrameworks }},
-      "defaultFrameworks": {{ .Values.defaultFrameworks | toJson }}
-      {{- end }}
+{{- if .Values.defaultFrameworks }}
+{{- if not (kindIs "slice" .Values.defaultFrameworks) }}
+{{- fail (printf "defaultFrameworks must be a list of framework names, got %s (use --set 'defaultFrameworks={nsa,mitre}')" (kindOf .Values.defaultFrameworks)) }}
+{{- end }}
+{{- $frameworks := list }}
+{{- range .Values.defaultFrameworks }}
+{{- if and . (ne (trim . | toString) "") }}
+{{- $frameworks = append $frameworks . }}
+{{- end }}
+{{- end }}
+{{- if $frameworks }},
+      "defaultFrameworks": {{ $frameworks | toJson }}
+{{- end }}
+{{- end }}
       {{- if .Values.kubevuln.config.proxyRegistryMap }},
       "proxyRegistryMap": {{ toJson .Values.kubevuln.config.proxyRegistryMap }}
       {{- end }}

--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -56,6 +56,9 @@ data:
 {{- end }}
       "relevantImageVulnerabilitiesConfiguration": "{{ .Values.capabilities.relevancy }}",
       "riskAcceptance": {{ eq .Values.capabilities.riskAcceptance "enable" }}
+      {{- if .Values.defaultFrameworks }},
+      "defaultFrameworks": {{ .Values.defaultFrameworks | toJson }}
+      {{- end }}
       {{- if .Values.kubevuln.config.proxyRegistryMap }},
       "proxyRegistryMap": {{ toJson .Values.kubevuln.config.proxyRegistryMap }}
       {{- end }}

--- a/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
+++ b/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml
@@ -56,14 +56,18 @@ data:
 {{- end }}
       "relevantImageVulnerabilitiesConfiguration": "{{ .Values.capabilities.relevancy }}",
       "riskAcceptance": {{ eq .Values.capabilities.riskAcceptance "enable" }}
-{{- if .Values.defaultFrameworks }}
+{{- if not (kindIs "invalid" .Values.defaultFrameworks) }}
 {{- if not (kindIs "slice" .Values.defaultFrameworks) }}
 {{- fail (printf "defaultFrameworks must be a list of framework names, got %s (use --set 'defaultFrameworks={nsa,mitre}')" (kindOf .Values.defaultFrameworks)) }}
 {{- end }}
 {{- $frameworks := list }}
 {{- range .Values.defaultFrameworks }}
-{{- if and . (ne (trim . | toString) "") }}
-{{- $frameworks = append $frameworks . }}
+{{- if not (kindIs "string" .) }}
+{{- fail (printf "defaultFrameworks entries must be strings, got %s" (kindOf .)) }}
+{{- end }}
+{{- $name := trim . }}
+{{- if ne $name "" }}
+{{- $frameworks = append $frameworks $name }}
 {{- end }}
 {{- end }}
 {{- if $frameworks }},

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -4496,7 +4496,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -9463,7 +9463,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -13751,7 +13751,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19035,7 +19035,7 @@ backend-storage enabled allows scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21081,7 +21081,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21392,7 +21392,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22065,7 +22065,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22639,7 +22639,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23203,7 +23203,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23514,7 +23514,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24007,7 +24007,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24457,7 +24457,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -28420,7 +28420,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -33146,7 +33146,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -37631,7 +37631,7 @@ minimal capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -43666,7 +43666,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -48855,7 +48855,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -53206,7 +53206,7 @@ relevancy only:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -58941,7 +58941,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.159
+              image: quay.io/kubescape/operator:v0.2.161
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/kubescape-operator/tests/default_frameworks_test.yaml
+++ b/charts/kubescape-operator/tests/default_frameworks_test.yaml
@@ -52,3 +52,34 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "defaultFrameworks must be a list of framework names, got string (use --set 'defaultFrameworks={nsa,mitre}')"
+
+  - it: should fail when defaultFrameworks is a falsy non-list
+    set:
+      unittest: true
+      clusterName: kind-kind
+      defaultFrameworks: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "defaultFrameworks must be a list of framework names, got bool (use --set 'defaultFrameworks={nsa,mitre}')"
+
+  - it: should fail when an entry is not a string
+    set:
+      unittest: true
+      clusterName: kind-kind
+      defaultFrameworks:
+        - 1
+    asserts:
+      - failedTemplate:
+          errorMessage: "defaultFrameworks entries must be strings, got float64"
+
+  - it: should trim framework names
+    set:
+      unittest: true
+      clusterName: kind-kind
+      defaultFrameworks:
+        - "  nsa  "
+        - mitre
+    asserts:
+      - matchRegex:
+          path: data.clusterData
+          pattern: '"defaultFrameworks":\s*\["nsa","mitre"\]'

--- a/charts/kubescape-operator/tests/default_frameworks_test.yaml
+++ b/charts/kubescape-operator/tests/default_frameworks_test.yaml
@@ -1,0 +1,33 @@
+suite: defaultFrameworks in clusterData
+templates:
+  - configs/cloudapi-configmap.yaml
+tests:
+  - it: should render default frameworks into clusterData
+    set:
+      unittest: true
+      clusterName: kind-kind
+    asserts:
+      - matchRegex:
+          path: data.clusterData
+          pattern: '"defaultFrameworks":\s*\["allcontrols","nsa","mitre"\]'
+
+  - it: should allow overriding default frameworks
+    set:
+      unittest: true
+      clusterName: kind-kind
+      defaultFrameworks:
+        - cis-aks-t1.2.0
+    asserts:
+      - matchRegex:
+          path: data.clusterData
+          pattern: '"defaultFrameworks":\s*\["cis-aks-t1.2.0"\]'
+
+  - it: should omit defaultFrameworks when empty
+    set:
+      unittest: true
+      clusterName: kind-kind
+      defaultFrameworks: []
+    asserts:
+      - notMatchRegex:
+          path: data.clusterData
+          pattern: '"defaultFrameworks"'

--- a/charts/kubescape-operator/tests/default_frameworks_test.yaml
+++ b/charts/kubescape-operator/tests/default_frameworks_test.yaml
@@ -2,14 +2,14 @@ suite: defaultFrameworks in clusterData
 templates:
   - configs/cloudapi-configmap.yaml
 tests:
-  - it: should render default frameworks into clusterData
+  - it: should omit defaultFrameworks when empty (chart default)
     set:
       unittest: true
       clusterName: kind-kind
     asserts:
-      - matchRegex:
+      - notMatchRegex:
           path: data.clusterData
-          pattern: '"defaultFrameworks":\s*\["allcontrols","nsa","mitre"\]'
+          pattern: '"defaultFrameworks"'
 
   - it: should allow overriding default frameworks
     set:
@@ -20,9 +20,9 @@ tests:
     asserts:
       - matchRegex:
           path: data.clusterData
-          pattern: '"defaultFrameworks":\s*\["cis-aks-t1.2.0"\]'
+          pattern: '"defaultFrameworks":\s*\["cis-aks-t1\.2\.0"\]'
 
-  - it: should omit defaultFrameworks when empty
+  - it: should omit defaultFrameworks when explicitly empty
     set:
       unittest: true
       clusterName: kind-kind
@@ -31,3 +31,24 @@ tests:
       - notMatchRegex:
           path: data.clusterData
           pattern: '"defaultFrameworks"'
+
+  - it: should omit blank-only entries
+    set:
+      unittest: true
+      clusterName: kind-kind
+      defaultFrameworks:
+        - ""
+        - "  "
+    asserts:
+      - notMatchRegex:
+          path: data.clusterData
+          pattern: '"defaultFrameworks"'
+
+  - it: should fail when defaultFrameworks is not a list
+    set:
+      unittest: true
+      clusterName: kind-kind
+      defaultFrameworks: nsa
+    asserts:
+      - failedTemplate:
+          errorMessage: "defaultFrameworks must be a list of framework names, got string (use --set 'defaultFrameworks={nsa,mitre}')"

--- a/charts/kubescape-operator/tests/offline_mode_test.yaml
+++ b/charts/kubescape-operator/tests/offline_mode_test.yaml
@@ -102,5 +102,6 @@ tests:
               "storeFilteredSbom": false,
               "continuousPostureScan": false,
               "relevantImageVulnerabilitiesConfiguration": "enable",
-              "riskAcceptance": false
+              "riskAcceptance": false,
+              "defaultFrameworks": ["allcontrols","nsa","mitre"]
             }

--- a/charts/kubescape-operator/tests/offline_mode_test.yaml
+++ b/charts/kubescape-operator/tests/offline_mode_test.yaml
@@ -102,6 +102,5 @@ tests:
               "storeFilteredSbom": false,
               "continuousPostureScan": false,
               "relevantImageVulnerabilitiesConfiguration": "enable",
-              "riskAcceptance": false,
-              "defaultFrameworks": ["allcontrols","nsa","mitre"]
+              "riskAcceptance": false
             }

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -13,15 +13,15 @@ fullnameOverride: "kubescape"
 # --set clusterName=`kubectl config current-context`
 clusterName: "cluster"
 
-# Default posture frameworks used when a scan does not specify frameworks
-# (startup scan, empty scheduler scanV1, exception-triggered rescan).
-# Explicit API / scanV1 targetNames override this list.
-# Example (AKS): --set defaultFrameworks={cis-aks-t1.2.0}
-# Example (GKE): --set 'defaultFrameworks={allcontrols,cis-v1.23-t1.0.1}'
-defaultFrameworks:
-  - allcontrols
-  - nsa
-  - mitre
+# Default posture frameworks used when a scan has no targetNames
+# (empty scheduler scanV1, startup scan, exception-triggered rescan).
+# Empty by default (opt-in) so upgrades do not narrow scheduled scans from "all".
+# Explicit scanV1/API targetNames override this list.
+# Clear with: --set defaultFrameworks=null
+# Example (AKS CIS): --set 'defaultFrameworks={cis-aks-t1.2.0}'
+# Example (allcontrols + current CIS): --set 'defaultFrameworks={allcontrols,cis-v1.10.0}'
+# Note: when triggerSecurityFramework is true (default), "security" is also scanned.
+defaultFrameworks: []
 
 # The namespace for running the chart
 # If you wish to run the chart in a different namespace, make sure to update this value

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -13,6 +13,16 @@ fullnameOverride: "kubescape"
 # --set clusterName=`kubectl config current-context`
 clusterName: "cluster"
 
+# Default posture frameworks used when a scan does not specify frameworks
+# (startup scan, empty scheduler scanV1, exception-triggered rescan).
+# Explicit API / scanV1 targetNames override this list.
+# Example (AKS): --set defaultFrameworks={cis-aks-t1.2.0}
+# Example (GKE): --set 'defaultFrameworks={allcontrols,cis-v1.23-t1.0.1}'
+defaultFrameworks:
+  - allcontrols
+  - nsa
+  - mitre
+
 # The namespace for running the chart
 # If you wish to run the chart in a different namespace, make sure to update this value
 ksNamespace: kubescape
@@ -1076,13 +1086,14 @@ helmReleaseUpgrader:
 kubescapeScheduler:
   # scan scheduler container name
   name: kubescape-scheduler
-  # Detemines what to scan. By default it will scan all resources in the cluster for all frameworks.
-  # Further details can be found here: https://github.com/kubescape/operator?tab=readme-ov-file#trigger-kubescape-scanning
+  # Determines what to scan. With an empty scanV1, the operator uses defaultFrameworks
+  # from clusterData. Set scanV1.targetNames to override those install-time defaults.
+  # Further details: https://github.com/kubescape/operator?tab=readme-ov-file#trigger-kubescape-scanning
   requestBody:
     commands:
       - CommandName: "kubescapeScan"
         args:
-          # To scan only specific frameworks, provide the list of frameworks to scan:
+          # Override defaultFrameworks for this CronJob only:
           # scanV1: {"targetType": "framework", "targetNames": [ "nsa" ] }
           scanV1: {}
 

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -20,7 +20,7 @@ clusterName: "cluster"
 # Clear with: --set defaultFrameworks=null
 # Example (AKS CIS): --set 'defaultFrameworks={cis-aks-t1.2.0}'
 # Example (allcontrols + current CIS): --set 'defaultFrameworks={allcontrols,cis-v1.10.0}'
-# Note: when triggerSecurityFramework is true (default), "security" is also scanned.
+# Note: when operator.triggerSecurityFramework is true (default), "security" is also scanned.
 defaultFrameworks: []
 
 # The namespace for running the chart
@@ -375,7 +375,7 @@ operator:
   image:
     # -- source code: https://github.com/kubescape/operator
     repository: quay.io/kubescape/operator
-    tag: v0.2.159
+    tag: v0.2.161
     pullPolicy: IfNotPresent
 
   nodeSelector:


### PR DESCRIPTION
## Overview
Add `defaultFrameworks` to the kubescape-operator chart and render it into `clusterData`, so users can pick posture frameworks at install time (e.g. `--set defaultFrameworks={cis-aks-t1.2.0}`).

## How to Test
```bash
helm template test . --set clusterName=x | grep -A2 defaultFrameworks
helm template test . --set clusterName=x --set defaultFrameworks={cis-aks-t1.2.0} | grep -A2 defaultFrameworks
```

## Related issues/PRs:
* Resolved #566
* Companion operator PR: https://github.com/kubescape/operator/pull/398

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm configuration for defining default posture frameworks during installation.
  * Scheduler scans now use these defaults when no specific frameworks are requested.
  * Explicit scan targets continue to override configured defaults.
  * Framework entries are trimmed and validated, with empty values omitted.

* **Documentation**
  * Updated chart value and scheduler configuration documentation with setup details, fallback behavior, and override options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->