### PR TITLE
fix(node-agent): add OTEL_METRICS_EXPORTER env var for Prometheus exporter

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/_node-agent.tpl
+++ b/charts/kubescape-operator/templates/node-agent/_node-agent.tpl
@@ -60,6 +60,10 @@ Parameters:
 - name: OTEL_COLLECTOR_SVC
   value: {{ .Values.configurations.otelUrl }}
 {{- end }}
+{{- if eq .Values.nodeAgent.config.prometheusExporter "enable" }}
+- name: OTEL_METRICS_EXPORTER
+  value: "prometheus"
+{{- end }}
 {{- if and .components.clamAV.enabled (not .autoscalerMode) }}
 - name: CLAMAV_SOCKET
   value: "/clamav/clamd.sock"

--- a/charts/kubescape-operator/tests/node_agent_prometheus_exporter_test.yaml
+++ b/charts/kubescape-operator/tests/node_agent_prometheus_exporter_test.yaml
@@ -37,3 +37,4 @@ tests:
           content:
             name: OTEL_METRICS_EXPORTER
             value: "prometheus"
+            

--- a/charts/kubescape-operator/tests/node_agent_prometheus_exporter_test.yaml
+++ b/charts/kubescape-operator/tests/node_agent_prometheus_exporter_test.yaml
@@ -1,0 +1,39 @@
+suite: node-agent Prometheus exporter OTEL env var
+templates:
+  - configs/components-configmap.yaml
+  - configs/cloudapi-configmap.yaml
+  - configs/cloud-secret.yaml
+  - configs/matchingRules-configmap.yaml
+  - node-agent/configmap.yaml
+  - node-agent/daemonset.yaml
+  - operator/configmap.yaml
+  - proxy-support/proxy-secret.yaml
+  - storage/certgen/configmap.yaml
+  - storage/configmap.yaml
+  - synchronizer/configmap.yaml
+  - operator/admission-webhook/configmap.yaml
+tests:
+  - it: sets OTEL_METRICS_EXPORTER when nodeAgent.config.prometheusExporter is enable
+    template: node-agent/daemonset.yaml
+    set:
+      unittest: true
+      clusterName: kind-kind
+      nodeAgent.config.prometheusExporter: enable
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_METRICS_EXPORTER
+            value: "prometheus"
+
+  - it: does not set OTEL_METRICS_EXPORTER by default
+    template: node-agent/daemonset.yaml
+    set:
+      unittest: true
+      clusterName: kind-kind
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_METRICS_EXPORTER
+            value: "prometheus"


### PR DESCRIPTION
## Overview
It was added in `templates/node-agent/_node-agent.tpl` the env OTEL_METRICS_EXPORTER which is a must for `prometheusExporterEnabled`


## Additional Information

- Root cause: [`pkg/otelsetup/setup.go`](https://github.com/kubescape/node-agent/blob/6a86345e3b2c91635df705ab99ea14cd27bc02e3/pkg/otelsetup/setup.go#L64-L104)
  only calls `initPrometheusMeterProvider` when `OTEL_METRICS_EXPORTER=prometheus` is set;
  otherwise no listener starts, full stop.


## How to Test

- **Unit tests** — added `tests/node_agent_prometheus_exporter_test.yaml` (asserts the env
  var is present when enabled, absent by default). 
- Use helm template by adding `prometheusExporterEnabled` and verify if OTEL_METRICS_EXPORTER is present

- **End-to-end**, on a local Flux-managed kind cluster (kind v0.31.0, kubernetes v1.35.0,
Flux v2.7.5 — helm-controller v1.4.5, kustomize-controller v1.7.3, source-controller
v1.7.4 — Helm v4.1.0), with this branch wired in as a Flux `GitRepository` HelmRelease
source: deployed alongside kube-prometheus-stack chart 88.0.0 (v0.93.0) + Grafana chart
10.5.15 (v12.3.1), scraped node-agent's existing `ServiceMonitor`, and confirmed real
Prometheus-format output on `:8080/metrics`. 

## Examples/Screenshots

<img width="1410" height="881" alt="image" src="https://github.com/user-attachments/assets/c32059a6-ab33-44d7-9d12-66dd02366907" />

<img width="746" height="291" alt="image" src="https://github.com/user-attachments/assets/f9d90f8e-8c56-4cdd-bd84-dec4ef7c365c" />

<img width="746" height="159" alt="image" src="https://github.com/user-attachments/assets/9a869849-3909-45ae-b835-a2c92773e0e1" />

## Related issues/PRs:
Resolved #889 

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `main` branch**

-->
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Prometheus metrics exporter support for the node agent when enabled in configuration.

- **Bug Fixes**
  - Ensured the exporter environment setting is omitted when Prometheus export is disabled or left at its default.

- **Tests**
  - Added coverage verifying both enabled and default configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->