### PR TITLE
bump operator to v0.2.162 for the bottlerocket detection

### DIFF
--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -4498,7 +4498,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -9467,7 +9467,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -13757,7 +13757,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19043,7 +19043,7 @@ backend-storage enabled allows scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21089,7 +21089,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21400,7 +21400,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22073,7 +22073,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22647,7 +22647,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23211,7 +23211,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23522,7 +23522,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24015,7 +24015,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24465,7 +24465,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -28430,7 +28430,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -33158,7 +33158,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -37645,7 +37645,7 @@ minimal capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -43682,7 +43682,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -48873,7 +48873,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -53226,7 +53226,7 @@ relevancy only:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -58963,7 +58963,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.161
+              image: quay.io/kubescape/operator:v0.2.162
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -375,7 +375,7 @@ operator:
   image:
     # -- source code: https://github.com/kubescape/operator
     repository: quay.io/kubescape/operator
-    tag: v0.2.161
+    tag: v0.2.162
     pullPolicy: IfNotPresent
 
   nodeSelector:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kubescape operator to image version `v0.2.162`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->