### PR TITLE
feat(storage): allow running the APIServer on the host network

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -162,6 +162,7 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | operator.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) |
 | operator.volumes | object | `[]` | Additional volumes for the web socket |
 | operator.volumeMounts | object | `[]` | Additional volumeMounts for the web socket |
+| storage.hostNetwork | bool | `false` | Bind the storage APIServer to the host network. Required when using a custom CNI where the control plane cannot reach pod IPs |
 | nodeAgent.autoscaler.bottlerocketAutoDetect | bool | `true` | When the autoscaler is enabled, auto-detect AWS Bottlerocket nodes and set `seLinuxType: super_t` on the node-agent DaemonSet rendered for that node group, so you don't need to `--set nodeAgent.seLinuxType=super_t` manually |
 | prometheusExporter.serviceMonitor.enabled | bool | `false` | enable/disable service monitor for prometheus-exporter integration |
 | awsIamRoleArn | string | `nil` | AWS IAM arn role |

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -48,6 +48,10 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{ .Values.storage.name }}
+      {{- if .Values.storage.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/charts/kubescape-operator/tests/storage_host_network_test.yaml
+++ b/charts/kubescape-operator/tests/storage_host_network_test.yaml
@@ -1,0 +1,51 @@
+suite: Storage hostNetwork tests
+tests:
+  - it: keeps the storage APIServer off the host network by default
+    template: storage/deployment.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostNetwork
+      - notExists:
+          path: spec.template.spec.dnsPolicy
+
+  - it: runs the storage APIServer on the host network when enabled
+    template: storage/deployment.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+      storage.hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      # without this the pod inherits the node's resolv.conf and cannot resolve in-cluster Services
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: keeps the served port under storage.serverPort when on the host network
+    template: storage/deployment.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+      storage.hostNetwork: true
+      storage.serverPort: 8444
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8444
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8444

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -539,6 +539,8 @@ storage:
       retries: 60
       retryIntervalSeconds: 5
   serverPort: 8443
+  # -- Bind the storage APIServer to the host network. Required when using a custom CNI where the control plane cannot reach pod IPs
+  hostNetwork: false
   service:
     type: ClusterIP
     annotations: {}


### PR DESCRIPTION
## Overview
Adds `storage.hostNetwork` (default `false`) so the storage APIServer can run on the host
network. Without it, the aggregated APIService stays unavailable on clusters whose control
plane has no route to pod addresses, and no posture result is ever written or read.

Nothing signals the failure: every component reports `Running` and the PVC binds. The API
group simply isn't served, so:

* `kubectl get workloadconfigurationscansummaries` returns `the server doesn't have a resource type`
* `prometheus-exporter` logs a failure on every poll
* on EKS the apiserver reports `Available: False … Address is not allowed`

Enabling it also sets `dnsPolicy: ClusterFirstWithHostNet`; without that the pod inherits the
node's `resolv.conf` and can no longer resolve cluster Services. Note that
`storage.serverPort` must then be free on every node the component can schedule to.


## How to Test
```
helm template test charts/kubescape-operator --kube-version 1.28.0 --set clusterName=x | grep -E 'hostNetwork: |dnsPolicy: '
helm template test charts/kubescape-operator --kube-version 1.28.0 --set clusterName=x --set storage.hostNetwork=true | grep -E 'hostNetwork: |dnsPolicy: '
```
The first command prints nothing. The second prints `hostNetwork: true` and
`dnsPolicy: ClusterFirstWithHostNet` on the storage deployment.


## Related issues/PRs:

* Resolves #453
* Prior art: [cert-manager#3113](https://github.com/cert-manager/cert-manager/pull/3113) added
  the same option for its webhook, and
  [cert-manager#6156](https://github.com/cert-manager/cert-manager/pull/6156) added the
  `ClusterFirstWithHostNet` pairing in a follow-up, so this PR includes it from the start.
  [aws/eks-charts#336](https://github.com/aws/eks-charts/pull/336) documents the same condition
  for a custom CNI on EKS.


## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `storage.hostNetwork` setting for deploying the storage API server on the host network.
  * Configured compatible DNS behavior when host networking is enabled.
  * The option is disabled by default and can support environments where control-plane access to pod IPs is limited.

* **Documentation**
  * Documented the new storage networking option and its configuration details.

* **Tests**
  * Added coverage for default behavior, host-network activation, DNS settings, and probe port preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->