### PR TITLE
fix(kubescape): stop masking the baked policy library when downloads are off

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -122,7 +122,7 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | kubescape.affinity | object | `{}` | Assign custom [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) rules to the deployment |
 | kubescape.podLabels| object | `{}` | Optional labels to add to the pods |
 | kubescape.podAnnotations| object | `{}` | optional map of annotations to be applied to the Pods |
-| kubescape.downloadArtifacts | bool | `true` | download policies every scan, we recommend it should remain true, you should change to 'false' when running in an air-gapped environment or when scanning with high frequency (when running with Prometheus) |
+| kubescape.downloadArtifacts | bool | `true` | download policies every scan, we recommend it should remain true, you should change to 'false' when running in an air-gapped environment or when scanning with high frequency (when running with Prometheus). When 'false', the policy library baked into the image is used, so the controls are those of the image tag and do not change until the image does |
 | kubescape.enableHostScan | bool | `true` | enable [host scanner feature](https://kubescape.io/docs/components/host-sensor/) |
 | kubescape.image.repository | string | `"quay.io/kubescape/kubescape"` | [source code](https://github.com/kubescape/kubescape/tree/master/httphandler) (public repo) |
 | kubescape.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) |

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -240,9 +240,11 @@ spec:
         - name: {{ $components.cloudSecret.name }}
           mountPath: /etc/credentials
           readOnly: true
+        {{- if .Values.kubescape.downloadArtifacts }}
         - name: kubescape-volume
           mountPath: /home/nonroot/.kubescape
           subPath: config.json
+        {{- end }}
         - name: host-scanner-definition
           mountPath: /home/nonroot/.kubescape/host-scanner.yaml
           subPath: host-scanner-yaml
@@ -305,8 +307,10 @@ spec:
       - name: host-scanner-definition
         configMap:
           name: host-scanner-definition
+      {{- if .Values.kubescape.downloadArtifacts }}
       - name: kubescape-volume
         emptyDir: {}
+      {{- end }}
       - name: results
         emptyDir: {}
       - name: failed

--- a/charts/kubescape-operator/tests/kubescape_download_artifacts_test.yaml
+++ b/charts/kubescape-operator/tests/kubescape_download_artifacts_test.yaml
@@ -1,0 +1,65 @@
+suite: Kubescape downloadArtifacts tests
+tests:
+  - it: mounts the writable policy volume when artifacts are downloaded
+    template: kubescape/deployment.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+      kubescape.downloadArtifacts: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: kubescape-volume
+            mountPath: /home/nonroot/.kubescape
+            subPath: config.json
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: kubescape-volume
+            emptyDir: {}
+
+  - it: leaves the image's baked policy library visible when downloads are off
+    template: kubescape/deployment.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+      kubescape.downloadArtifacts: false
+    asserts:
+      # an emptyDir here masks the policies baked into /home/nonroot/.kubescape,
+      # leaving nothing for the scanner to fall back to
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: kubescape-volume
+            mountPath: /home/nonroot/.kubescape
+            subPath: config.json
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: kubescape-volume
+            emptyDir: {}
+
+  - it: keeps the host-scanner definition mounted either way
+    template: kubescape/deployment.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+      kubescape.downloadArtifacts: false
+    asserts:
+      # a file mounted inside the directory masks only itself, not the library
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: host-scanner-definition
+            mountPath: /home/nonroot/.kubescape/host-scanner.yaml
+            subPath: host-scanner-yaml

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -338,7 +338,7 @@ kubescape:
       cpu: 600m
       memory: 1Gi
 
-  # -- download policies every scan, we recommend it should remain true, you should change to 'false' when running in an air-gapped environment or when scanning with high frequency (when running with Prometheus)
+  # -- download policies every scan, we recommend it should remain true, you should change to 'false' when running in an air-gapped environment or when scanning with high frequency (when running with Prometheus). When 'false', the policy library baked into the image is used, so the controls are those of the image tag and do not change until the image does
   downloadArtifacts: true
 
   # -- skip check for a newer version


### PR DESCRIPTION
## Overview
Fixes `kubescape.downloadArtifacts: false`, which does not work today.
The image bakes the policy library into `/home/nonroot/.kubescape` (17 files, `nsa.json`, `security.json`, ...)
The chart mounts a writable `emptyDir` over that directory, so with downloads off there is nothing left to fall back to.

Nothing about the deployment looks wrong; only the scan fails:

* `failed to list frameworks … open /home/nonroot/.kubescape/security.json: no such file or directory` (#874)
* with no frameworks named: `unknown policy kind`
* with them named: `framework: nsa: framework from file not matching`
* each preceded by `failed to get policies from github release, loading policies from cache`, the fetch an air-gapped install cannot make

This makes the mount and the volume conditional on `downloadArtifacts`, so the baked library stays visible.
With downloads on (the default) nothing changes.

`readOnlyRootFilesystem: true` is why the volume exists at all: the scanner needs somewhere writable to download into.
With downloads off it writes nothing there.


## How to Test
```
helm template test charts/kubescape-operator --set clusterName=x | grep -A2 'name: kubescape-volume'
helm template test charts/kubescape-operator --set clusterName=x --set kubescape.downloadArtifacts=false | grep -A2 'name: kubescape-volume'
```
The first prints the mount and the volume. The second prints nothing.

Isolated to that one mount, using two containers from the same image with the same environment and a read-only root filesystem: without the mount a scan completes; with an empty volume over `~/.kubescape` it fails with `unknown policy kind`.

Confirmed in a cluster on a read-only root filesystem: the scan completes and persists its results, so nothing needs writing to ~/.kubescape when there is nothing to download.

## Related issues/PRs:

* Resolves #874
* Completes #857 — mounting the parent directory fixed the `config.json` crash and masked the
  baked library; this keeps the library and drops the mount only when it is not needed

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer documentation for the artifact download setting, including how bundled policies behave when downloads are disabled.
  * Downloads can now be disabled while retaining the policy library included in the container image.

* **Bug Fixes**
  * Prevented unnecessary writable policy storage from being mounted when artifact downloads are disabled.
  * Preserved host-scanner configuration mounting in this mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->