### PR TITLE
fix(components): re-gate node/config/vuln scans and storage on backend-storage

### DIFF
--- a/charts/kubescape-operator/templates/_common.tpl
+++ b/charts/kubescape-operator/templates/_common.tpl
@@ -63,9 +63,9 @@ submit: {{ $submit }}
 
 {{- define "components" -}}
 {{- $configurations := fromYaml (include "configurations" .) }}
-{{- $nodeScanEnabled := eq .Values.capabilities.nodeScan "enable" }}
-{{- $configurationScanEnabled := eq .Values.capabilities.configurationScan "enable" }}
-{{- $vulnerabilityScanEnabled := eq .Values.capabilities.vulnerabilityScan "enable" }}
+{{- $nodeScanEnabled := and (eq .Values.capabilities.nodeScan "enable") (not $configurations.backendStorageEnabled) }}
+{{- $configurationScanEnabled := and (eq .Values.capabilities.configurationScan "enable") (not $configurations.backendStorageEnabled) }}
+{{- $vulnerabilityScanEnabled := and (eq .Values.capabilities.vulnerabilityScan "enable") (not $configurations.backendStorageEnabled) }}
 kubescape:
   enabled: {{ $configurationScanEnabled }}
 kubescapeScheduler:
@@ -89,7 +89,7 @@ operator:
 serviceDiscovery:
   enabled: {{ $configurations.submit }}
 storage:
-  enabled: {{ .Values.storage.enabled }}
+  enabled: {{ and .Values.storage.enabled (not $configurations.backendStorageEnabled) }}
 prometheusExporter:
   enabled: {{ eq .Values.capabilities.prometheusExporter "enable" }}
 cloudSecret:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -15748,20 +15748,12 @@ autoscaler mode without sbom sidecar:
         tier: ks-control-plane
       name: synchronizer
       namespace: kubescape
-backend-storage enabled allows scanning capabilities:
+backend-storage enabled disables scanning capabilities:
   1: |+
     raw: |+
       Thank you for installing kubescape-operator version 1.40.3.
-      View your cluster's configuration scanning schedule:
-      > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
-      To change the schedule, set `.spec.schedule`:
-      > kubectl -n kubescape edit cj kubescape-scheduler
-      View your cluster's image scanning schedule:
-      > kubectl -n kubescape get cj kubevuln-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
-      To change the schedule, edit `.spec.schedule`:
-      > kubectl -n kubescape edit cj kubevuln-scheduler
 
       View your image vulnerabilities scan summaries:
       > kubectl get vulnerabilitymanifestsummaries -A
@@ -15807,11 +15799,11 @@ backend-storage enabled allows scanning capabilities:
           "kubevulnURL": "kubevuln:8080",
           "kubescapeURL": "kubescape:8080",
           "clusterName": "kind-kind",
-          "storage": true,
+          "storage": false,
           "relevantImageVulnerabilitiesEnabled": true,
           "namespace": "kubescape",
-          "imageVulnerabilitiesScanningEnabled": true,
-          "postureScanEnabled": true,
+          "imageVulnerabilitiesScanningEnabled": false,
+          "postureScanEnabled": false,
           "nodeAgent": "true",
           "maxImageSize": 5.36870912e+09,
           "maxSBOMSize": 2.097152e+07,
@@ -15852,7 +15844,7 @@ backend-storage enabled allows scanning capabilities:
           "capabilities":{"admissionController":"enable","agentRuntimePosture":"disable","autoUpgrading":"disable","backend-storage":"enable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","remediation":"disable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
           "effectiveCapabilities":{"configurationScan":"backend","httpDetection":"disable","networkEventsStreaming":"enable","nodeProfileService":"enable","nodeScan":"backend","vulnerabilityScan":"backend"},
           "capabilityWarnings":["capabilities.httpDetection=enable but capabilities.runtimeDetection is not enabled. HTTP detection runs on top of runtime detection, so httpDetectionEnabled renders as FALSE in the node-agent configmap. To use it, set capabilities.runtimeDetection=enable."],
-          "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":true},"synchronizer":{"enabled":true}},
+          "components":{"autoUpdater":{"enabled":false},"clamAV":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":false},"kubescapeScheduler":{"enabled":false},"kubevuln":{"enabled":false},"kubevulnScheduler":{"enabled":false},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":true},"storage":{"enabled":false},"synchronizer":{"enabled":true}},
           "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
           "serviceScanConfig" :{"enabled":false,"interval":"1h"}
         }
@@ -15916,1051 +15908,6 @@ backend-storage enabled allows scanning capabilities:
       name: kubescape-critical
     value: 1.000001e+08
   7: |
-    apiVersion: v1
-    data:
-      request-body.json: '{"commands":[{"CommandName":"kubescapeScan","args":{"scanV1":{}}}]}'
-    kind: ConfigMap
-    metadata:
-      annotations: null
-      labels:
-        app: kubescape-scheduler
-        app.kubernetes.io/component: kubescape-scheduler
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        kubescape.io/tier: core
-        tier: ks-control-plane
-      name: kubescape-scheduler
-      namespace: kubescape
-  8: |
-    apiVersion: batch/v1
-    kind: CronJob
-    metadata:
-      annotations: null
-      labels:
-        app: kubescape-scheduler
-        app.kubernetes.io/component: kubescape-scheduler
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        kubescape.io/tier: core
-        tier: ks-control-plane
-      name: kubescape-scheduler
-      namespace: kubescape
-    spec:
-      failedJobsHistoryLimit: 1
-      jobTemplate:
-        spec:
-          template:
-            metadata:
-              annotations: null
-              labels:
-                app: kubescape-scheduler
-                app.kubernetes.io/component: kubescape-scheduler
-                app.kubernetes.io/instance: RELEASE-NAME
-                app.kubernetes.io/managed-by: Helm
-                app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
-                armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.3
-                kubescape.io/ignore: "true"
-                kubescape.io/tier: core
-                tier: ks-control-plane
-            spec:
-              affinity: null
-              automountServiceAccountToken: false
-              containers:
-                - args:
-                    - -method=post
-                    - -scheme=http
-                    - -host=operator:4002
-                    - -path=v1/triggerAction
-                    - -headers=Content-Type:application/json
-                    - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
-                  imagePullPolicy: IfNotPresent
-                  name: kubescape-scheduler
-                  resources:
-                    limits:
-                      cpu: 10m
-                      memory: 20Mi
-                    requests:
-                      cpu: 1m
-                      memory: 10Mi
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    readOnlyRootFilesystem: true
-                    runAsNonRoot: true
-                    runAsUser: 100
-                  volumeMounts:
-                    - mountPath: /home/ks/request-body.json
-                      name: kubescape-scheduler
-                      readOnly: true
-                      subPath: request-body.json
-              nodeSelector:
-                kubernetes.io/os: linux
-              restartPolicy: Never
-              securityContext:
-                seccompProfile:
-                  type: RuntimeDefault
-              serviceAccountName: kubescape
-              tolerations: null
-              volumes:
-                - configMap:
-                    name: kubescape-scheduler
-                  name: kubescape-scheduler
-      schedule: 0 4 * * *
-      successfulJobsHistoryLimit: 3
-  9: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      annotations: null
-      labels:
-        app: kubescape
-        app.kubernetes.io/component: kubescape
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: kubescape
-    rules:
-      - apiGroups:
-          - ""
-        resources:
-          - pods
-          - pods/proxy
-          - namespaces
-          - nodes
-          - configmaps
-          - services
-          - serviceaccounts
-          - endpoints
-          - persistentvolumeclaims
-          - persistentvolumes
-          - limitranges
-          - replicationcontrollers
-          - podtemplates
-          - resourcequotas
-          - events
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - ""
-        resources:
-          - secrets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - admissionregistration.k8s.io
-        resources:
-          - mutatingwebhookconfigurations
-          - validatingwebhookconfigurations
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - apiregistration.k8s.io
-        resources:
-          - apiservices
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - apps
-        resources:
-          - deployments
-          - statefulsets
-          - daemonsets
-          - replicasets
-          - controllerrevisions
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - autoscaling
-        resources:
-          - horizontalpodautoscalers
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - batch
-        resources:
-          - jobs
-          - cronjobs
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - coordination.k8s.io
-        resources:
-          - leases
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - discovery.k8s.io
-        resources:
-          - endpointslices
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - events.k8s.io
-        resources:
-          - events
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - hostdata.kubescape.cloud
-        resources:
-          - APIServerInfo
-          - ControlPlaneInfo
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - networking.k8s.io
-        resources:
-          - networkpolicies
-          - Ingress
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - cilium.io
-        resources:
-          - ciliumnetworkpolicies
-          - ciliumclusterwidenetworkpolicies
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - projectcalico.org
-        resources:
-          - networkpolicies
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - networking.istio.io
-        resources:
-          - gateways
-          - virtualservices
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - security.istio.io
-        resources:
-          - authorizationpolicies
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - policy
-        resources:
-          - poddisruptionbudgets
-          - podsecuritypolicies
-          - PodSecurityPolicy
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - rbac.authorization.k8s.io
-        resources:
-          - clusterroles
-          - clusterrolebindings
-          - roles
-          - rolebindings
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - storage.k8s.io
-        resources:
-          - csistoragecapacities
-          - storageclasses
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - networking.k8s.io
-        resources:
-          - ingresses
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - extensions
-        resources:
-          - Ingress
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - gateway.networking.k8s.io
-        resources:
-          - httproutes
-          - gateways
-          - gatewayclasses
-          - tcproutes
-          - tlsroutes
-          - udproutes
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - ""
-        resources:
-          - namespaces
-        verbs:
-          - update
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - workloadconfigurationscans
-          - workloadconfigurationscansummaries
-        verbs:
-          - create
-          - get
-          - update
-          - patch
-      - apiGroups:
-          - kubescape.io
-        resources:
-          - servicesscanresults
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - hostdata.kubescape.cloud
-        resources:
-          - osreleasefiles
-          - kernelversions
-          - linuxsecurityhardeningstatuses
-          - openportslists
-          - linuxkernelvariables
-          - kubeletinfos
-          - kubeproxyinfos
-          - controlplaneinfos
-          - cloudproviderinfos
-          - cniinfos
-        verbs:
-          - get
-          - list
-          - watch
-  10: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      annotations: null
-      labels:
-        app: kubescape
-        app.kubernetes.io/component: kubescape
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: kubescape
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: kubescape
-    subjects:
-      - kind: ServiceAccount
-        name: kubescape
-        namespace: kubescape
-  11: |
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      annotations: null
-      labels:
-        app: kubescape
-        app.kubernetes.io/component: kubescape
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        kubescape.io/tier: core
-        tier: ks-control-plane
-      name: kubescape
-      namespace: kubescape
-    spec:
-      replicas: 1
-      revisionHistoryLimit: 2
-      selector:
-        matchLabels:
-          app.kubernetes.io/component: kubescape
-          app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: kubescape-operator
-      strategy:
-        rollingUpdate:
-          maxSurge: 0%
-          maxUnavailable: 100%
-        type: RollingUpdate
-      template:
-        metadata:
-          annotations:
-            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-          labels:
-            app: kubescape
-            app.kubernetes.io/component: kubescape
-            app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
-            kubescape.io/ignore: "true"
-            kubescape.io/tier: core
-            tier: ks-control-plane
-        spec:
-          affinity: null
-          automountServiceAccountToken: true
-          containers:
-            - command:
-                - ksserver
-              env:
-                - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
-                - name: KS_LOGGER_LEVEL
-                  value: info
-                - name: KS_LOGGER_NAME
-                  value: zap
-                - name: KS_DOWNLOAD_ARTIFACTS
-                  value: "true"
-                - name: KS_DEFAULT_CONFIGMAP_NAME
-                  value: kubescape-config
-                - name: KS_DEFAULT_CONFIGMAP_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                - name: KS_CONTEXT
-                  value: kind-kind
-                - name: KS_DEFAULT_CLOUD_CONFIGMAP_NAME
-                  value: ks-cloud-config
-                - name: KS_ENABLE_HOST_SCANNER
-                  value: "true"
-                - name: KS_SKIP_UPDATE_CHECK
-                  value: "false"
-                - name: KS_HOST_SCAN_YAML
-                  value: /home/nonroot/.kubescape/host-scanner.yaml
-                - name: LARGE_CLUSTER_SIZE
-                  value: "1500"
-                - name: API_URL
-                  value: https://api.armosec.io
-                - name: KS_EXCLUDE_NAMESPACES
-                  value: kubescape,kube-system,kube-public,kube-node-lease
-              image: quay.io/kubescape/kubescape:v4.0.11
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /livez
-                  port: 8080
-                initialDelaySeconds: 3
-                periodSeconds: 3
-              name: kubescape
-              ports:
-                - containerPort: 8080
-                  name: http
-                  protocol: TCP
-              readinessProbe:
-                httpGet:
-                  path: /readyz
-                  port: 8080
-                initialDelaySeconds: 3
-                periodSeconds: 3
-              resources:
-                limits:
-                  cpu: 600m
-                  memory: 1Gi
-                requests:
-                  cpu: 250m
-                  memory: 400Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-              volumeMounts:
-                - mountPath: /etc/credentials
-                  name: cloud-secret
-                  readOnly: true
-                - mountPath: /home/nonroot/.kubescape
-                  name: kubescape-volume
-                  subPath: config.json
-                - mountPath: /home/nonroot/.kubescape/host-scanner.yaml
-                  name: host-scanner-definition
-                  subPath: host-scanner-yaml
-                - mountPath: /home/nonroot/results
-                  name: results
-                - mountPath: /home/nonroot/failed
-                  name: failed
-                - mountPath: /etc/config/clusterData.json
-                  name: ks-cloud-config
-                  readOnly: true
-                  subPath: clusterData.json
-          nodeSelector:
-            kubernetes.io/os: linux
-          securityContext:
-            fsGroup: 65532
-            runAsUser: 65532
-            seccompProfile:
-              type: RuntimeDefault
-          serviceAccountName: kubescape
-          tolerations: null
-          volumes:
-            - name: cloud-secret
-              secret:
-                secretName: cloud-secret
-            - configMap:
-                items:
-                  - key: clusterData
-                    path: clusterData.json
-                name: ks-cloud-config
-              name: ks-cloud-config
-            - configMap:
-                name: host-scanner-definition
-              name: host-scanner-definition
-            - emptyDir: {}
-              name: kubescape-volume
-            - emptyDir: {}
-              name: results
-            - emptyDir: {}
-              name: failed
-  12: |
-    apiVersion: v1
-    data:
-      host-scanner-yaml: ""
-    kind: ConfigMap
-    metadata:
-      annotations: null
-      labels:
-        app: ks-cloud-config
-        app.kubernetes.io/component: ks-cloud-config
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        kubescape.io/tier: core
-        tier: ks-control-plane
-      name: host-scanner-definition
-      namespace: kubescape
-  13: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-      annotations: null
-      labels:
-        app: kubescape
-        app.kubernetes.io/component: kubescape
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: kubescape
-      namespace: kubescape
-    rules:
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-        verbs:
-          - create
-          - get
-          - update
-          - watch
-          - list
-          - patch
-          - delete
-  14: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-      annotations: null
-      labels:
-        app: kubescape
-        app.kubernetes.io/component: kubescape
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: kubescape
-      namespace: kubescape
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: Role
-      name: kubescape
-    subjects:
-      - kind: ServiceAccount
-        name: kubescape
-        namespace: kubescape
-  15: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations: null
-      labels:
-        app: kubescape
-        app.kubernetes.io/component: kubescape
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: kubescape
-      namespace: kubescape
-    spec:
-      ports:
-        - name: http
-          port: 8080
-          protocol: TCP
-          targetPort: 8080
-      selector:
-        app.kubernetes.io/component: kubescape
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: kubescape-operator
-      type: ClusterIP
-  16: |
-    apiVersion: v1
-    automountServiceAccountToken: false
-    kind: ServiceAccount
-    metadata:
-      annotations: null
-      labels:
-        app: kubescape
-        app.kubernetes.io/component: kubescape
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: kubescape
-      namespace: kubescape
-  17: |
-    apiVersion: v1
-    data:
-      request-body.json: '{"commands":[{"commandName":"scan","designators":[{"designatorType":"Attributes","attributes":{}}]}]}'
-    kind: ConfigMap
-    metadata:
-      labels:
-        app: kubevuln-scheduler
-        app.kubernetes.io/component: kubevuln-scheduler
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        kubescape.io/tier: core
-        tier: ks-control-plane
-      name: kubevuln-scheduler
-      namespace: kubescape
-  18: |
-    apiVersion: batch/v1
-    kind: CronJob
-    metadata:
-      annotations: null
-      labels:
-        app: kubevuln-scheduler
-        app.kubernetes.io/component: kubevuln-scheduler
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        kubescape.io/tier: core
-        tier: ks-control-plane
-      name: kubevuln-scheduler
-      namespace: kubescape
-    spec:
-      failedJobsHistoryLimit: 1
-      jobTemplate:
-        spec:
-          template:
-            metadata:
-              annotations: null
-              labels:
-                app: kubevuln-scheduler
-                app.kubernetes.io/component: kubevuln-scheduler
-                app.kubernetes.io/instance: RELEASE-NAME
-                app.kubernetes.io/managed-by: Helm
-                app.kubernetes.io/name: kubescape-operator
-                app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
-                armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
-                kubescape.io/ignore: "true"
-                kubescape.io/tier: core
-                tier: ks-control-plane
-            spec:
-              affinity: null
-              automountServiceAccountToken: false
-              containers:
-                - args:
-                    - -method=post
-                    - -scheme=http
-                    - -host=operator:4002
-                    - -path=v1/triggerAction
-                    - -headers=Content-Type:application/json
-                    - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
-                  imagePullPolicy: IfNotPresent
-                  name: kubevuln-scheduler
-                  resources:
-                    limits:
-                      cpu: 10m
-                      memory: 20Mi
-                    requests:
-                      cpu: 1m
-                      memory: 10Mi
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    readOnlyRootFilesystem: true
-                    runAsNonRoot: true
-                    runAsUser: 100
-                  volumeMounts:
-                    - mountPath: /home/ks/request-body.json
-                      name: kubevuln-scheduler
-                      readOnly: true
-                      subPath: request-body.json
-              nodeSelector:
-                kubernetes.io/os: linux
-              restartPolicy: Never
-              securityContext:
-                seccompProfile:
-                  type: RuntimeDefault
-              serviceAccountName: kubevuln
-              tolerations: null
-              volumes:
-                - configMap:
-                    name: kubevuln-scheduler
-                  name: kubevuln-scheduler
-      schedule: 0 4 * * *
-      successfulJobsHistoryLimit: 3
-  19: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      annotations: null
-      labels:
-        app: kubevuln
-        app.kubernetes.io/component: kubevuln
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: kubevuln
-    rules:
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - vulnerabilitymanifests
-          - vulnerabilitymanifestsummaries
-          - openvulnerabilityexchangecontainers
-          - sbomsyfts
-          - sbomsyftfiltereds
-        verbs:
-          - create
-          - get
-          - update
-          - watch
-          - list
-          - patch
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - containerprofiles
-        verbs:
-          - get
-          - watch
-          - list
-  20: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      annotations: null
-      labels:
-        app: kubevuln
-        app.kubernetes.io/component: kubevuln
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: kubevuln
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: kubevuln
-    subjects:
-      - kind: ServiceAccount
-        name: kubevuln
-        namespace: kubescape
-  21: |
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      annotations: null
-      labels:
-        app: kubevuln
-        app.kubernetes.io/component: kubevuln
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        kubescape.io/tier: core
-        tier: ks-control-plane
-      name: kubevuln
-      namespace: kubescape
-    spec:
-      replicas: 1
-      revisionHistoryLimit: 2
-      selector:
-        matchLabels:
-          app.kubernetes.io/component: kubevuln
-          app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: kubescape-operator
-      strategy:
-        type: Recreate
-      template:
-        metadata:
-          annotations:
-            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-          labels:
-            app: kubevuln
-            app.kubernetes.io/component: kubevuln
-            app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
-            kubescape.io/ignore: "true"
-            kubescape.io/tier: core
-            tier: ks-control-plane
-        spec:
-          affinity: null
-          automountServiceAccountToken: true
-          containers:
-            - args:
-                - -alsologtostderr
-                - -v=4
-                - 2>&1
-              env:
-                - name: GOMEMLIMIT
-                  value: 4000MiB
-                - name: KS_LOGGER_LEVEL
-                  value: info
-                - name: KS_LOGGER_NAME
-                  value: zap
-                - name: PRINT_POST_JSON
-                  value: ""
-                - name: API_URL
-                  value: https://api.armosec.io
-                - name: CA_MAX_VULN_SCAN_ROUTINES
-                  value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.159
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /v1/liveness
-                  port: 8080
-                initialDelaySeconds: 3
-                periodSeconds: 3
-              name: kubevuln
-              ports:
-                - containerPort: 8080
-                  protocol: TCP
-              readinessProbe:
-                httpGet:
-                  path: /v1/readiness
-                  port: 8080
-              resources:
-                limits:
-                  cpu: 1500m
-                  ephemeral-storage: 10Gi
-                  memory: 5000Mi
-                requests:
-                  cpu: 300m
-                  ephemeral-storage: 5Gi
-                  memory: 1000Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-              volumeMounts:
-                - mountPath: /etc/credentials
-                  name: cloud-secret
-                  readOnly: true
-                - mountPath: /tmp
-                  name: tmp-dir
-                - mountPath: /home/nonroot/anchore-resources/db
-                  name: grype-db-cache
-                - mountPath: /etc/config/clusterData.json
-                  name: ks-cloud-config
-                  readOnly: true
-                  subPath: clusterData.json
-                - mountPath: /home/nonroot/.cache/grype
-                  name: grype-db
-          nodeSelector:
-            kubernetes.io/os: linux
-          securityContext:
-            fsGroup: 65532
-            runAsUser: 65532
-            seccompProfile:
-              type: RuntimeDefault
-          serviceAccountName: kubevuln
-          tolerations: null
-          volumes:
-            - name: cloud-secret
-              secret:
-                secretName: cloud-secret
-            - emptyDir: {}
-              name: tmp-dir
-            - emptyDir: {}
-              name: grype-db-cache
-            - configMap:
-                items:
-                  - key: clusterData
-                    path: clusterData.json
-                name: ks-cloud-config
-              name: ks-cloud-config
-            - emptyDir: {}
-              name: grype-db
-  22: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations: null
-      labels:
-        app: kubevuln
-        app.kubernetes.io/component: kubevuln
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: kubevuln
-      namespace: kubescape
-    spec:
-      ports:
-        - port: 8080
-          protocol: TCP
-          targetPort: 8080
-      selector:
-        app.kubernetes.io/component: kubevuln
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: kubescape-operator
-      type: ClusterIP
-  23: |
-    apiVersion: v1
-    automountServiceAccountToken: false
-    kind: ServiceAccount
-    metadata:
-      annotations: null
-      labels:
-        app: kubevuln
-        app.kubernetes.io/component: kubevuln
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: kubevuln
-      namespace: kubescape
-  24: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -16994,7 +15941,7 @@ backend-storage enabled allows scanning capabilities:
               type: object
           served: true
           storage: true
-  25: |
+  8: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -17028,7 +15975,7 @@ backend-storage enabled allows scanning capabilities:
               type: object
           served: true
           storage: true
-  26: |
+  9: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -17062,7 +16009,7 @@ backend-storage enabled allows scanning capabilities:
               type: object
           served: true
           storage: true
-  27: |
+  10: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -17096,7 +16043,7 @@ backend-storage enabled allows scanning capabilities:
               type: object
           served: true
           storage: true
-  28: |
+  11: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -17130,7 +16077,7 @@ backend-storage enabled allows scanning capabilities:
               type: object
           served: true
           storage: true
-  29: |
+  12: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -17164,7 +16111,7 @@ backend-storage enabled allows scanning capabilities:
               type: object
           served: true
           storage: true
-  30: |
+  13: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -17198,7 +16145,7 @@ backend-storage enabled allows scanning capabilities:
               type: object
           served: true
           storage: true
-  31: |
+  14: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -17232,7 +16179,7 @@ backend-storage enabled allows scanning capabilities:
               type: object
           served: true
           storage: true
-  32: |
+  15: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -17266,7 +16213,7 @@ backend-storage enabled allows scanning capabilities:
               type: object
           served: true
           storage: true
-  33: |
+  16: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -17329,7 +16276,7 @@ backend-storage enabled allows scanning capabilities:
               type: object
           served: true
           storage: true
-  34: |
+  17: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -17486,7 +16433,7 @@ backend-storage enabled allows scanning capabilities:
           - patch
           - list
           - watch
-  35: |
+  18: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -17511,7 +16458,7 @@ backend-storage enabled allows scanning capabilities:
       - kind: ServiceAccount
         name: node-agent
         namespace: kubescape
-  36: |
+  19: |
     apiVersion: v1
     data:
       config.json: |
@@ -17576,7 +16523,7 @@ backend-storage enabled allows scanning capabilities:
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
-  37: |
+  20: |
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
@@ -17604,7 +16551,7 @@ backend-storage enabled allows scanning capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
+            checksum/cloud-config: d0e00780bee5d2b3a068ad95ac2665cea1cb3b89c3aae81a1fe7659701877dda
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/node-agent-config: eb96c3c46f1b0866faae15793e5b3f9d521ee6d48ac042d8fdc9bef3347b0868
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
@@ -17815,7 +16762,7 @@ backend-storage enabled allows scanning capabilities:
                     path: config.json
                 name: node-agent
               name: config
-  38: |
+  21: |
     apiVersion: kubescape.io/v1
     kind: RuntimeRuleAlertBinding
     metadata:
@@ -17869,7 +16816,7 @@ backend-storage enabled allows scanning capabilities:
         - ruleName: Unexpected Egress Network Traffic
         - ruleName: Malicious Ptrace Usage
         - ruleName: Unexpected io_uring Operation Detected
-  39: |
+  22: |
     apiVersion: kubescape.io/v1
     kind: Rules
     metadata:
@@ -18591,7 +17538,7 @@ backend-storage enabled allows scanning capabilities:
             - context:kubernetes
             - admission
             - network
-  40: |
+  23: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -18619,7 +17566,7 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/component: node-agent
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
-  41: |
+  24: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
@@ -18637,7 +17584,7 @@ backend-storage enabled allows scanning capabilities:
         tier: ks-control-plane
       name: node-agent
       namespace: kubescape
-  42: |
+  25: |
     apiVersion: v1
     data:
       tls.crt: bW9jay1jYS1jZXJ0
@@ -18660,7 +17607,7 @@ backend-storage enabled allows scanning capabilities:
       name: kubescape-admission-webhook-ca
       namespace: kubescape
     type: kubernetes.io/tls
-  43: |
+  26: |
     apiVersion: v1
     data:
       ca.crt: bW9jay1jYS1jZXJ0
@@ -18683,7 +17630,7 @@ backend-storage enabled allows scanning capabilities:
       name: kubescape-admission-webhook-tls
       namespace: kubescape
     type: kubernetes.io/tls
-  44: |
+  27: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -18710,7 +17657,7 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  45: |
+  28: |
     apiVersion: admissionregistration.k8s.io/v1
     kind: ValidatingWebhookConfiguration
     metadata:
@@ -18767,7 +17714,7 @@ backend-storage enabled allows scanning capabilities:
               - networkpolicies
             scope: '*'
         sideEffects: None
-  46: |
+  29: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -18893,7 +17840,7 @@ backend-storage enabled allows scanning capabilities:
           - list
           - update
           - patch
-  47: |
+  30: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -18918,7 +17865,7 @@ backend-storage enabled allows scanning capabilities:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  48: |
+  31: |
     apiVersion: v1
     data:
       config.json: |
@@ -18971,7 +17918,7 @@ backend-storage enabled allows scanning capabilities:
         tier: ks-control-plane
       name: operator
       namespace: kubescape
-  49: |
+  32: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -19006,8 +17953,8 @@ backend-storage enabled allows scanning capabilities:
       template:
         metadata:
           annotations:
-            checksum/capabilities-config: fe0bd16d7d5ae1e8cc766e60a28e64ea4f3ccb0cea645d37d90a917be584d16c
-            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
+            checksum/capabilities-config: 42ac87519e041e56c305503810c69c60d606e32ab588b42fe6bf152c38f1b65a
+            checksum/cloud-config: d0e00780bee5d2b3a068ad95ac2665cea1cb3b89c3aae81a1fe7659701877dda
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
             checksum/operator-config: 4ad609dc7d0f0afc334677d308402b8217902ddecb7a91f33611200c81802a2b
@@ -19146,7 +18093,7 @@ backend-storage enabled allows scanning capabilities:
                     path: matchingRules.json
                 name: cs-matching-rules
               name: cs-matching-rules
-  50: |
+  33: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -19231,7 +18178,7 @@ backend-storage enabled allows scanning capabilities:
         tier: ks-control-plane
       name: kubescape-cronjob-template
       namespace: kubescape
-  51: |
+  34: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -19316,7 +18263,7 @@ backend-storage enabled allows scanning capabilities:
         tier: ks-control-plane
       name: kubevuln-cronjob-template
       namespace: kubescape
-  52: |
+  35: |
     apiVersion: v1
     data:
       cronjobTemplate: |-
@@ -19401,7 +18348,7 @@ backend-storage enabled allows scanning capabilities:
         tier: ks-control-plane
       name: registry-scan-cronjob-template
       namespace: kubescape
-  53: |
+  36: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -19445,7 +18392,7 @@ backend-storage enabled allows scanning capabilities:
           - list
           - patch
           - delete
-  54: |
+  37: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -19471,7 +18418,7 @@ backend-storage enabled allows scanning capabilities:
       - kind: ServiceAccount
         name: operator
         namespace: kubescape
-  55: |
+  38: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -19499,7 +18446,7 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  56: |
+  39: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount
@@ -19518,33 +18465,7 @@ backend-storage enabled allows scanning capabilities:
         tier: ks-control-plane
       name: operator
       namespace: kubescape
-  57: |
-    apiVersion: apiregistration.k8s.io/v1
-    kind: APIService
-    metadata:
-      annotations: null
-      labels:
-        app: storage
-        app.kubernetes.io/component: storage
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: v1beta1.spdx.softwarecomposition.kubescape.io
-    spec:
-      caBundle: bW9jay1jYS1jZXJ0
-      group: spdx.softwarecomposition.kubescape.io
-      groupPriorityMinimum: 1000
-      service:
-        name: storage
-        namespace: kubescape
-      version: v1beta1
-      versionPriority: 15
-  58: |
+  40: |
     apiVersion: v1
     data:
       tls.crt: bW9jay1jYS1jZXJ0
@@ -19567,7 +18488,7 @@ backend-storage enabled allows scanning capabilities:
       name: storage-tls-ca
       namespace: kubescape
     type: kubernetes.io/tls
-  59: |
+  41: |
     apiVersion: v1
     data:
       ca.crt: bW9jay1jYS1jZXJ0
@@ -19590,332 +18511,7 @@ backend-storage enabled allows scanning capabilities:
       name: storage-tls
       namespace: kubescape
     type: kubernetes.io/tls
-  60: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      annotations: null
-      labels:
-        app: storage
-        app.kubernetes.io/component: storage
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: storage
-    rules:
-      - apiGroups:
-          - ""
-        resources:
-          - namespaces
-          - pods
-          - services
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - admissionregistration.k8s.io
-        resources:
-          - mutatingwebhookconfigurations
-          - validatingwebhookconfigurations
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - apps
-        resources:
-          - daemonsets
-          - deployments
-          - replicasets
-          - statefulsets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - batch
-        resources:
-          - cronjobs
-          - jobs
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - flowcontrol.apiserver.k8s.io
-        resources:
-          - prioritylevelconfigurations
-          - flowschemas
-        verbs:
-          - get
-          - watch
-          - list
-  61: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      annotations: null
-      labels:
-        app: storage
-        app.kubernetes.io/component: storage
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: storage:system:auth-delegator
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: system:auth-delegator
-    subjects:
-      - kind: ServiceAccount
-        name: storage
-        namespace: kubescape
-  62: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      annotations: null
-      labels:
-        app: storage
-        app.kubernetes.io/component: storage
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: storage
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: storage
-    subjects:
-      - kind: ServiceAccount
-        name: storage
-        namespace: kubescape
-  63: |
-    apiVersion: v1
-    data:
-      config.json: |
-        {
-          "cleanupInterval": "6h",
-          "disableVirtualCRDs": true,
-          "disableSeccompProfileEndpoint": true,
-          "excludeJsonPaths": null,
-          "defaultQueueLength": 100,
-          "defaultWorkerCount": 2,
-          "defaultMaxObjectSize": 400000,
-          "queueManagerEnabled": true,
-          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
-          "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
-          "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
-          "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
-          "serverBindPort": "8443"
-        }
-    kind: ConfigMap
-    metadata:
-      labels:
-        app: storage
-        app.kubernetes.io/component: storage
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        kubescape.io/tier: core
-        tier: ks-control-plane
-      name: storage
-      namespace: kubescape
-  64: |
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      annotations: null
-      labels:
-        app: storage
-        app.kubernetes.io/component: storage
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        kubescape.io/tier: core
-        tier: ks-control-plane
-      name: storage
-      namespace: kubescape
-    spec:
-      replicas: 1
-      revisionHistoryLimit: 2
-      selector:
-        matchLabels:
-          app.kubernetes.io/component: storage
-          app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: kubescape-operator
-      strategy:
-        type: Recreate
-      template:
-        metadata:
-          annotations:
-            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
-          labels:
-            app: storage
-            app.kubernetes.io/component: storage
-            app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kubescape-operator
-            app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
-            kubescape.io/ignore: "true"
-            kubescape.io/tier: core
-            tier: ks-control-plane
-        spec:
-          affinity: null
-          containers:
-            - env:
-                - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
-                - name: KS_LOGGER_LEVEL
-                  value: info
-                - name: KS_LOGGER_NAME
-                  value: zap
-              image: quay.io/kubescape/storage:v0.0.298
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /livez
-                  port: 8443
-                  scheme: HTTPS
-              name: apiserver
-              readinessProbe:
-                httpGet:
-                  path: /readyz
-                  port: 8443
-                  scheme: HTTPS
-              resources:
-                limits:
-                  cpu: 1500m
-                  memory: 1500Mi
-                requests:
-                  cpu: 100m
-                  memory: 400Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                runAsNonRoot: true
-              volumeMounts:
-                - mountPath: /data
-                  name: data
-                - mountPath: /etc/config/clusterData.json
-                  name: ks-cloud-config
-                  readOnly: true
-                  subPath: clusterData.json
-                - mountPath: /etc/config/config.json
-                  name: config
-                  readOnly: true
-                  subPath: config.json
-                - mountPath: /etc/storage-ca-certificates
-                  name: ca-certificates
-                  readOnly: true
-          nodeSelector:
-            kubernetes.io/os: linux
-          securityContext:
-            fsGroup: 65532
-            runAsUser: 65532
-            seccompProfile:
-              type: RuntimeDefault
-          serviceAccountName: storage
-          tolerations: null
-          volumes:
-            - name: data
-              persistentVolumeClaim:
-                claimName: kubescape-storage
-            - configMap:
-                items:
-                  - key: clusterData
-                    path: clusterData.json
-                name: ks-cloud-config
-              name: ks-cloud-config
-            - configMap:
-                items:
-                  - key: config.json
-                    path: config.json
-                name: storage
-              name: config
-            - name: ca-certificates
-              secret:
-                secretName: storage-tls
-  65: |
-    apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      annotations: null
-      labels:
-        app: storage
-        app.kubernetes.io/component: storage
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: kubescape-storage
-      namespace: kubescape
-    spec:
-      accessModes:
-        - ReadWriteOnce
-      resources:
-        requests:
-          storage: 5Gi
-  66: |
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-      annotations: null
-      labels:
-        app: storage
-        app.kubernetes.io/component: storage
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: storage-auth-reader
-      namespace: kube-system
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: Role
-      name: extension-apiserver-authentication-reader
-    subjects:
-      - kind: ServiceAccount
-        name: storage
-        namespace: kubescape
-  67: |
+  42: |
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -20239,54 +18835,7 @@ backend-storage enabled allows scanning capabilities:
           storage: true
           subresources:
             status: {}
-  68: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations: null
-      labels:
-        app: storage
-        app.kubernetes.io/component: storage
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: storage
-      namespace: kubescape
-    spec:
-      ports:
-        - name: https
-          port: 443
-          protocol: TCP
-          targetPort: 8443
-      selector:
-        app.kubernetes.io/component: storage
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: kubescape-operator
-      type: ClusterIP
-  69: |
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      annotations: null
-      labels:
-        app: storage
-        app.kubernetes.io/component: storage
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kubescape-operator
-        app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
-        kubescape.io/ignore: "true"
-        tier: ks-control-plane
-      name: storage
-      namespace: kubescape
-  70: |
+  43: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -20457,7 +19006,7 @@ backend-storage enabled allows scanning capabilities:
           - update
           - patch
           - delete
-  71: |
+  44: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -20481,7 +19030,7 @@ backend-storage enabled allows scanning capabilities:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  72: |
+  45: |
     apiVersion: v1
     data:
       config.json: |
@@ -20628,30 +19177,6 @@ backend-storage enabled allows scanning capabilities:
                 "strategy": "patch"
               },
               {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "containerprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
-                "strategy": "copy"
-              },
-              {
                 "group": "cilium.io",
                 "version": "v2",
                 "resource": "ciliumnetworkpolicies",
@@ -20778,7 +19303,7 @@ backend-storage enabled allows scanning capabilities:
         tier: ks-control-plane
       name: synchronizer
       namespace: kubescape
-  73: |
+  46: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -20810,9 +19335,9 @@ backend-storage enabled allows scanning capabilities:
       template:
         metadata:
           annotations:
-            checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
+            checksum/cloud-config: d0e00780bee5d2b3a068ad95ac2665cea1cb3b89c3aae81a1fe7659701877dda
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: 89c4293fcd32cc7a3ee95ac49975a088c1eee7af72a1712948fa24960c0dcd6a
+            checksum/synchronizer-configmap: 5b74632f016d9c39500eebe8e60adaa9f8543666d1517cd2dfb68f0a695ba41a
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -20903,7 +19428,7 @@ backend-storage enabled allows scanning capabilities:
                     path: config.json
                 name: synchronizer
               name: config
-  74: |
+  47: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -20946,7 +19471,7 @@ backend-storage enabled allows scanning capabilities:
           - list
           - patch
           - delete
-  75: |
+  48: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -20971,7 +19496,7 @@ backend-storage enabled allows scanning capabilities:
       - kind: ServiceAccount
         name: synchronizer
         namespace: kubescape
-  76: |
+  49: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -20998,7 +19523,7 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: kubescape-operator
       type: ClusterIP
-  77: |
+  50: |
     apiVersion: v1
     automountServiceAccountToken: false
     kind: ServiceAccount

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -515,7 +515,7 @@ tests:
         enableWorkloadMetrics: true
         serviceMonitor:
           enabled: true
-  - it: backend-storage enabled allows scanning capabilities
+  - it: backend-storage enabled disables scanning capabilities
     asserts:
       - matchSnapshot: {}
     capabilities:


### PR DESCRIPTION
## Overview

**Current behavior.** With `capabilities.backend-storage=enable`, the chart deploys
`kubevuln`, `kubevuln-scheduler`, `kubescape`, `kubescape-scheduler`, the in-cluster
`storage` aggregated APIServer and its `APIService` — while the *same* render emits:

- `effectiveCapabilities.vulnerabilityScan: backend` (and `configurationScan`, `nodeScan`)
  into `ks-capabilities`
- `backendStorageEnabled: true` into the node-agent `config.json`

So the cluster is told scanning happens in the backend, and then also runs the in-cluster
scanners. node-agent ships SBOMs to the backend while a local `kubevuln` scans the same
workloads — double scanning, plus a storage server and a cluster-scoped `APIService` that
the mode is meant to remove.

**Future behavior.** The three scan flags are ANDed with `backendStorageEnabled` again and
`storage.enabled` is gated on it, so the rendered workloads match the
`effectiveCapabilities` contract the chart already emits.

This restores gating removed in #850 (`79bd478f`) while **keeping** the explicit
`storage.enabled` knob that PR introduced — the knob still works for everyone not using
backend-storage.

```diff
-{{- $nodeScanEnabled := eq .Values.capabilities.nodeScan "enable" }}
-{{- $configurationScanEnabled := eq .Values.capabilities.configurationScan "enable" }}
-{{- $vulnerabilityScanEnabled := eq .Values.capabilities.vulnerabilityScan "enable" }}
+{{- $nodeScanEnabled := and (eq .Values.capabilities.nodeScan "enable") (not $configurations.backendStorageEnabled) }}
+{{- $configurationScanEnabled := and (eq .Values.capabilities.configurationScan "enable") (not $configurations.backendStorageEnabled) }}
+{{- $vulnerabilityScanEnabled := and (eq .Values.capabilities.vulnerabilityScan "enable") (not $configurations.backendStorageEnabled) }}
 storage:
-  enabled: {{ .Values.storage.enabled }}
+  enabled: {{ and .Values.storage.enabled (not $configurations.backendStorageEnabled) }}
```

## Additional Information

`$nodeScanEnabled` is assigned and never referenced — in `1.40.2` and at HEAD both (host
scanner removed in #773). It is re-gated only for consistency with the other two; it
renders nothing either way.

`capabilities.gates` (#852, `a94aabc7`, 2026-06-05) predates the decouple (#850,
2026-07-22) by seven weeks, and still emits `...Scan: backend` under backend-storage. Its
own comment says it exists so "the rendered value and the warning about that value can
never drift apart. See issue #851" — and #851 is the chart's `capabilities` block
disagreeing with the rendered config about whether a feature is on. Without this patch,
1.40.3 reintroduces that drift for `vulnerabilityScan` and `configurationScan`.

No value combination is a workaround: `enable` gives the right signal and the wrong
workloads; `disable` + `storage.enabled=false` gives the right workloads and the wrong
signal; and downstream wrappers can't express "off only when backend-storage is on"
in values at all.

## How to Test

```bash
helm template t charts/kubescape-operator \
  --set account=<guid> --set accessKey=<key> \
  --set server=api.armosec.io --set clusterName=c \
  --set capabilities.backend-storage=enable \
  | grep -E '^kind:|^  name:'
```

Verified against `6a0fb27`:

| case | result |
|---|---|
| no `backend-storage` (default install) | **identical render** (modulo per-render `genSelfSignedCert`/`genCA`) |
| Rapid7 value set (`backend-storage=enable`, scans `disable`, `storage.enabled=false`) | **identical render — strict no-op** |
| `backend-storage=enable`, minimal values | 75 → 48 documents |
| snapshot-test value set | 9 → 3 real workloads (`node-agent`, `operator`, `synchronizer`) |
| `kubescape-operator-1.40.2`, same values | same 3 workloads — behavior restored |
| `helm unittest` | 53/53 pass; 1 of 22 snapshot entries changes |

The snapshot case is renamed back to "backend-storage enabled **disables** scanning
capabilities", reverting the rename in #850.

Note: `helm unittest` v1.0.0 prunes the vanished snapshot documents and still reports
PASS, so the regenerated `snapshot_test.yaml.snap` is committed here deliberately rather
than left to drift.

## Release

No `Chart.yaml` bump here, to stay out of the way of the usual "prepare release" flow.
@matthyx — could this go out as `1.40.4`? `1.40.3` is the latest release and HEAD is still
versioned `1.40.3`, so there's currently no released version carrying the fix, and
downstream wrappers pin the dependency exactly.

## Related issues/PRs

* Regression introduced in #850
* Same drift class as #851
