### PR TITLE
fix: drop all Linux capabilities in workload container securityContexts

### DIFF
--- a/charts/kubescape-operator/templates/autoupdater/cronjob.yaml
+++ b/charts/kubescape-operator/templates/autoupdater/cronjob.yaml
@@ -30,6 +30,8 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
           volumes:
             - name: "helm-scratch-data"
               emptyDir:

--- a/charts/kubescape-operator/templates/autoupdater/cronjob.yaml
+++ b/charts/kubescape-operator/templates/autoupdater/cronjob.yaml
@@ -41,6 +41,9 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
             volumeMounts:
               - name: "helm-scratch-data"
                 mountPath: /data/helm-scratch-data

--- a/charts/kubescape-operator/templates/grype-offline-db/cronjob.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/cronjob.yaml
@@ -54,6 +54,9 @@ spec:
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               runAsUser: 100
+              capabilities:
+                drop:
+                  - ALL
             command: ["/bin/sh", "-c"]
             args:
               - |

--- a/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/deployment.yaml
@@ -51,6 +51,9 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
           ports:
           - containerPort: 8080
             protocol: TCP

--- a/charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml
+++ b/charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml
@@ -56,6 +56,9 @@ spec:
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               runAsUser: 100
+              capabilities:
+                drop:
+                  - ALL
             args:
               - -method=post
               - -scheme=http

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -67,6 +67,9 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
         ports:
           - name: http
             containerPort: 8080

--- a/charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml
+++ b/charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml
@@ -56,6 +56,9 @@ spec:
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               runAsUser: 100
+              capabilities:
+                drop:
+                  - ALL
             args:
               - -method=post
               - -scheme=http

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -58,6 +58,9 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
           ports:
           - containerPort: {{ .Values.kubevuln.service.port }}
             protocol: TCP
@@ -159,6 +162,9 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
           resources:
 {{ toYaml .Values.kubevuln.sbomScanner.resources | indent 12 }}
           env:

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -136,6 +136,9 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - name: "trigger-port"
               containerPort: 4002

--- a/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
@@ -50,6 +50,9 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
           ports:
           - name: metrics
             containerPort: {{ .Values.prometheusExporter.service.port }}

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -132,6 +132,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
         livenessProbe:
           httpGet:
             path: /livez

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -59,6 +59,9 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -96,6 +96,8 @@ all capabilities:
                 runAsGroup: 1000
                 runAsNonRoot: true
                 runAsUser: 1000
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: helm-release-upgrader
               tolerations: null
               volumes:
@@ -39193,6 +39195,8 @@ multiple node agents:
                 runAsGroup: 1000
                 runAsNonRoot: true
                 runAsUser: 1000
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: helm-release-upgrader
               tolerations: null
               volumes:
@@ -54837,6 +54841,8 @@ skipPersistence enabled:
                 runAsGroup: 1000
                 runAsNonRoot: true
                 runAsUser: 1000
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: helm-release-upgrader
               tolerations: null
               volumes:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -81,6 +81,9 @@ all capabilities:
                       memory: 256Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                   volumeMounts:
                     - mountPath: /data/helm-scratch-data
@@ -439,6 +442,9 @@ all capabilities:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -534,6 +540,9 @@ all capabilities:
                   memory: 200Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
           imagePullSecrets:
             - name: foo
@@ -759,6 +768,9 @@ all capabilities:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -1293,6 +1305,9 @@ all capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -1700,6 +1715,9 @@ all capabilities:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -1974,6 +1992,9 @@ all capabilities:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -4532,6 +4553,9 @@ all capabilities:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -5253,6 +5277,9 @@ all capabilities:
                   memory: 10Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -5692,6 +5719,9 @@ all capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -6908,6 +6938,9 @@ all capabilities:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -7417,6 +7450,9 @@ autoscaler mode with sbom sidecar:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -7851,6 +7887,9 @@ autoscaler mode with sbom sidecar:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -8108,6 +8147,9 @@ autoscaler mode with sbom sidecar:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -8290,6 +8332,9 @@ autoscaler mode with sbom sidecar:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -9501,6 +9546,9 @@ autoscaler mode with sbom sidecar:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -10264,6 +10312,9 @@ autoscaler mode with sbom sidecar:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -11306,6 +11357,9 @@ autoscaler mode with sbom sidecar:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -11707,6 +11761,9 @@ autoscaler mode without sbom sidecar:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -12141,6 +12198,9 @@ autoscaler mode without sbom sidecar:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -12398,6 +12458,9 @@ autoscaler mode without sbom sidecar:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -12580,6 +12643,9 @@ autoscaler mode without sbom sidecar:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -13791,6 +13857,9 @@ autoscaler mode without sbom sidecar:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -14554,6 +14623,9 @@ autoscaler mode without sbom sidecar:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -15596,6 +15668,9 @@ autoscaler mode without sbom sidecar:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -15999,6 +16074,9 @@ backend-storage enabled allows scanning capabilities:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -16433,6 +16511,9 @@ backend-storage enabled allows scanning capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -16690,6 +16771,9 @@ backend-storage enabled allows scanning capabilities:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -16872,6 +16956,9 @@ backend-storage enabled allows scanning capabilities:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -19077,6 +19164,9 @@ backend-storage enabled allows scanning capabilities:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -19822,6 +19912,9 @@ backend-storage enabled allows scanning capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -20864,6 +20957,9 @@ backend-storage enabled allows scanning capabilities:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -21120,6 +21216,9 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -21290,6 +21389,9 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -21431,6 +21533,9 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -21703,6 +21808,9 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -22107,6 +22215,9 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -22351,6 +22462,9 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -22681,6 +22795,9 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -23027,6 +23144,9 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -23242,6 +23362,9 @@ cert strategy template, admission disabled, mtls disabled:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -23412,6 +23535,9 @@ cert strategy template, admission disabled, mtls disabled:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -23553,6 +23679,9 @@ cert strategy template, admission disabled, mtls enabled:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -23769,6 +23898,9 @@ cert strategy template, admission disabled, mtls enabled:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -24049,6 +24181,9 @@ cert strategy template, admission enabled, mtls disabled:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -24225,6 +24360,9 @@ cert strategy template, admission enabled, mtls disabled:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -24499,6 +24637,9 @@ cert strategy template, admission enabled, mtls enabled:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -24721,6 +24862,9 @@ cert strategy template, admission enabled, mtls enabled:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -25007,6 +25151,9 @@ default capabilities:
                   memory: 200Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
           nodeSelector:
             kubernetes.io/os: linux
@@ -25179,6 +25326,9 @@ default capabilities:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -25659,6 +25809,9 @@ default capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -26029,6 +26182,9 @@ default capabilities:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -26257,6 +26413,9 @@ default capabilities:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -28461,6 +28620,9 @@ default capabilities:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -29321,6 +29483,9 @@ default capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -30415,6 +30580,9 @@ default capabilities:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -30890,6 +31058,9 @@ disable otel:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -31324,6 +31495,9 @@ disable otel:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -31581,6 +31755,9 @@ disable otel:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -31763,6 +31940,9 @@ disable otel:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -33192,6 +33372,9 @@ disable otel:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -33937,6 +34120,9 @@ disable otel:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -34979,6 +35165,9 @@ disable otel:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -35386,6 +35575,9 @@ minimal capabilities:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -35816,6 +36008,9 @@ minimal capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -36073,6 +36268,9 @@ minimal capabilities:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -36253,6 +36451,9 @@ minimal capabilities:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -37679,6 +37880,9 @@ minimal capabilities:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -38424,6 +38628,9 @@ minimal capabilities:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -38971,6 +39178,9 @@ multiple node agents:
                       memory: 256Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                   volumeMounts:
                     - mountPath: /data/helm-scratch-data
@@ -39329,6 +39539,9 @@ multiple node agents:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -39424,6 +39637,9 @@ multiple node agents:
                   memory: 200Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
           imagePullSecrets:
             - name: foo
@@ -39649,6 +39865,9 @@ multiple node agents:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -40183,6 +40402,9 @@ multiple node agents:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -40590,6 +40812,9 @@ multiple node agents:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -40864,6 +41089,9 @@ multiple node agents:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -43716,6 +43944,9 @@ multiple node agents:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -44437,6 +44668,9 @@ multiple node agents:
                   memory: 10Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -44876,6 +45110,9 @@ multiple node agents:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -46092,6 +46329,9 @@ multiple node agents:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -46601,6 +46841,9 @@ priority class scheduling:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -47036,6 +47279,9 @@ priority class scheduling:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -47294,6 +47540,9 @@ priority class scheduling:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -47477,6 +47726,9 @@ priority class scheduling:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -48907,6 +49159,9 @@ priority class scheduling:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -49653,6 +49908,9 @@ priority class scheduling:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -50696,6 +50954,9 @@ priority class scheduling:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -51097,6 +51358,9 @@ relevancy only:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -51527,6 +51791,9 @@ relevancy only:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -51784,6 +52051,9 @@ relevancy only:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -51964,6 +52234,9 @@ relevancy only:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -53257,6 +53530,9 @@ relevancy only:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -53996,6 +54272,9 @@ relevancy only:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -54543,6 +54822,9 @@ skipPersistence enabled:
                       memory: 256Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                   volumeMounts:
                     - mountPath: /data/helm-scratch-data
@@ -54901,6 +55183,9 @@ skipPersistence enabled:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -54996,6 +55281,9 @@ skipPersistence enabled:
                   memory: 200Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
           imagePullSecrets:
             - name: foo
@@ -55221,6 +55509,9 @@ skipPersistence enabled:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -55755,6 +56046,9 @@ skipPersistence enabled:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -56165,6 +56459,9 @@ skipPersistence enabled:
                       memory: 10Mi
                   securityContext:
                     allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
                     readOnlyRootFilesystem: true
                     runAsNonRoot: true
                     runAsUser: 100
@@ -56439,6 +56736,9 @@ skipPersistence enabled:
                   memory: 1000Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -58997,6 +59297,9 @@ skipPersistence enabled:
                   memory: 100Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -59718,6 +60021,9 @@ skipPersistence enabled:
                   memory: 10Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:
@@ -60157,6 +60463,9 @@ skipPersistence enabled:
                   memory: 400Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 runAsNonRoot: true
               volumeMounts:
                 - mountPath: /data
@@ -61373,6 +61682,9 @@ skipPersistence enabled:
                   memory: 250Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
               volumeMounts:

--- a/charts/kubescape-operator/tests/container_capabilities_test.yaml
+++ b/charts/kubescape-operator/tests/container_capabilities_test.yaml
@@ -1,0 +1,73 @@
+suite: Container capability tests
+tests:
+  - it: drops all capabilities on the kubescape container
+    template: kubescape/deployment.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+
+  - it: drops all capabilities on the operator container
+    template: operator/deployment.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+
+  - it: drops all capabilities on the storage apiserver container
+    template: storage/deployment.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+
+  - it: drops all capabilities on the prometheus exporter container
+    template: prometheus-exporter/deployment.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+      capabilities.prometheusExporter: enable
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+
+  - it: drops all capabilities on the kubescape scheduler container
+    template: kubescape-scheduler/cronjob.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+      capabilities.continuousScan: disable
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL


### PR DESCRIPTION
## Overview

Adds `capabilities: drop [ALL]` to the 12 workload container securityContexts.
Every container already sets `allowPrivilegeEscalation: false`, `runAsNonRoot: true` with a `RuntimeDefault` seccomp profile and none of the components uses a capability.

The missing drop is the one field that keeps the chart out of namespaces with `pod-security.kubernetes.io/enforce: restricted`.
Admission rejects every pod with:

```
violates PodSecurity "restricted:latest": unrestricted capabilities
(container "kubescape" must set securityContext.capabilities.drop=["ALL"])
```

It is also the finding Kubescape raises against its own namespace when it scans the cluster it runs in.

The certgen init containers already declare the drop https://github.com/kubescape/helm-charts/blob/main/charts/kubescape-operator/templates/storage/deployment.yaml#L72 and is untouched.

## How to Test

New tests in `tests/container_capabilities_test.yaml` assert the drop on 5 out of 12 deployed components (if needed I can add all 12). The 104 snapshot changes are exactly the capability additions.

Confirmed in a cluster: all five deployed components run with the drop, scans complete and persist their results.

## Related issues/PRs:

* Related: #740 asked for configurable securityContexts. The hardcoded contexts were already nearly restricted-complete, so finishing them fixes the restricted-namespace case without adding a knob.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Containers across Kubescape Operator components now drop all Linux capabilities by default.
  * Applies to scheduled jobs, services, database components, scanners, exporters, and supporting workloads.
  * The autoupdater uses the `RuntimeDefault` seccomp profile.
  * Reduces the potential impact of container compromise through stricter runtime permissions.

* **Tests**
  * Added coverage to verify that required containers run without Linux capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->