### PR TITLE
fix: mount CA certificates into the sbom-scanner sidecar

### DIFF
--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -183,6 +183,23 @@ spec:
               mountPath: /sbom-comm
             - name: tmp-dir
               mountPath: /tmp
+{{- if ne .Values.global.proxySecretFile "" }}
+            - name: proxy-secret
+              mountPath: /etc/ssl/certs/proxy.crt
+              subPath: proxy.crt
+{{- end }}
+{{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+            - name: custom-ca-certificates
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              subPath: ca-certificates.crt
+{{- end }}
+{{- if .Values.global.extraCaCertificates.enabled }}
+        {{- range $key, $value := (lookup "v1" "Secret" .Values.ksNamespace .Values.global.extraCaCertificates.secretName).data }}
+            - name: extra-ca-certificates
+              mountPath: /etc/ssl/certs/{{ $key }}
+              subPath: {{ $key }}
+        {{- end }}
+{{- end }}
 {{- end }}
       volumes:
         - name: {{ $components.cloudSecret.name }}

--- a/charts/kubescape-operator/templates/node-agent/_node-agent.tpl
+++ b/charts/kubescape-operator/templates/node-agent/_node-agent.tpl
@@ -309,9 +309,29 @@ Parameters:
           fieldPath: metadata.namespace
     - name: CLUSTER_NAME
       value: "{{ .Values.clusterName }}"
-  {{- if .Values.nodeAgent.sbomScanner.volumeMounts }}
   volumeMounts:
+  {{- if .Values.nodeAgent.sbomScanner.volumeMounts }}
     {{- toYaml .Values.nodeAgent.sbomScanner.volumeMounts | nindent 4 }}
+  {{- end }}
+  {{- if ne .Values.global.proxySecretFile "" }}
+    - name: proxy-secret
+      mountPath: /etc/ssl/certs/proxy.crt
+      subPath: proxy.crt
+      readOnly: true
+  {{- end }}
+  {{- if .Values.global.overrideDefaultCaCertificates.enabled }}
+    - name: custom-ca-certificates
+      mountPath: /etc/ssl/certs/ca-certificates.crt
+      subPath: ca-certificates.crt
+      readOnly: true
+  {{- end }}
+  {{- if .Values.global.extraCaCertificates.enabled }}
+  {{- range $key, $value := (lookup "v1" "Secret" .Values.ksNamespace .Values.global.extraCaCertificates.secretName).data }}
+    - name: extra-ca-certificates
+      mountPath: /etc/ssl/certs/{{ $key }}
+      subPath: {{ $key }}
+      readOnly: true
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -284,6 +284,101 @@ tests:
           content:
             name: CLUSTER_NAME
             value: kind-kind
+  - it: node-agent sbom scanner sidecar mounts custom, extra and proxy CA certificates
+    template: node-agent/daemonset.yaml
+    documentSelector:
+      path: metadata.name
+      value: node-agent
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+      nodeAgent.sbomScanner.enabled: true
+      capabilities.nodeSbomGeneration: enable
+      global:
+        proxySecretFile: foo
+        overrideDefaultCaCertificates:
+          enabled: true
+        extraCaCertificates:
+          enabled: true
+          secretName: "extra-certificates"
+    asserts:
+      # containers[0] is the sbom-scanner sidecar
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: proxy-secret
+            mountPath: /etc/ssl/certs/proxy.crt
+            subPath: proxy.crt
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: custom-ca-certificates
+            mountPath: /etc/ssl/certs/ca-certificates.crt
+            subPath: ca-certificates.crt
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-ca-certificates
+            mountPath: /etc/ssl/certs/cert1.pem
+            subPath: cert1.pem
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-ca-certificates
+            mountPath: /etc/ssl/certs/cert2.pem
+            subPath: cert2.pem
+            readOnly: true
+  - it: kubevuln sbom scanner sidecar mounts custom, extra and proxy CA certificates
+    template: kubevuln/deployment.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+      kubevuln.sbomScanner.enabled: true
+      global:
+        proxySecretFile: foo
+        overrideDefaultCaCertificates:
+          enabled: true
+        extraCaCertificates:
+          enabled: true
+          secretName: "extra-certificates"
+    asserts:
+      # containers[0] is the main kubevuln container, containers[1] is the sbom-scanner sidecar
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: sbom-scanner
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: proxy-secret
+            mountPath: /etc/ssl/certs/proxy.crt
+            subPath: proxy.crt
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: custom-ca-certificates
+            mountPath: /etc/ssl/certs/ca-certificates.crt
+            subPath: ca-certificates.crt
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: extra-ca-certificates
+            mountPath: /etc/ssl/certs/cert1.pem
+            subPath: cert1.pem
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: extra-ca-certificates
+            mountPath: /etc/ssl/certs/cert2.pem
+            subPath: cert2.pem
   - it: node-agent egress allows OTLP ports when otelUrl is set
     template: node-agent/networkpolicy.yaml
     capabilities:


### PR DESCRIPTION
## Overview
The optional `sbom-scanner` sidecar (added to `node-agent` and `kubevuln` for OOM isolation) never received the `proxy-secret`, `custom-ca-certificates`, or `extra-ca-certificates` volume mounts that the main container gets. When those pod-level CA/proxy settings are enabled, the sidecar still trusts only the image's default trust store, so scans that need to reach the registry/API through a custom CA or proxy fail with TLS/CA verification errors.

This adds the same conditional mounts (`global.overrideDefaultCaCertificates`, `global.extraCaCertificates`, `global.proxySecretFile`) to the `sbom-scanner` container in:
- `charts/kubescape-operator/templates/kubevuln/deployment.yaml`
- `charts/kubescape-operator/templates/node-agent/_node-agent.tpl`

The corresponding secret volumes were already declared at the pod level (used by the main container), so this is purely additive — no new volumes needed.

## How to Test
```
helm unittest charts/kubescape-operator
```
Added two new test cases in `tests/snapshot_test.yaml` asserting the sidecar picks up `proxy-secret`, `custom-ca-certificates`, and `extra-ca-certificates` mounts when those globals are enabled. Full suite (58 tests / 996 snapshots) passes unchanged plus the 2 new tests.

## Checklist before requesting a review
- [x] New and existing unit tests pass locally with my changes

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * SBOM scanning now supports configured proxy, custom CA, and additional CA certificates.
  * Scanner components automatically mount the required certificate files when enabled, improving connectivity to secured registries and services.
  * Certificate handling is now consistent across node-agent and vulnerability-scanning components.

* **Tests**
  * Added coverage for proxy and custom certificate volume mounts, including dynamically configured extra certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->