### PR TITLE
fix: forward HTTPS_PROXY/no_proxy to the sbom-scanner sidecar

### DIFF
--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -178,6 +178,12 @@ spec:
               value: "{{ .Values.logger.level }}"
             - name: KS_LOGGER_NAME
               value: "sbom-scanner"
+            {{- if ne .Values.global.httpsProxy "" }}
+            - name: HTTPS_PROXY
+              value: "{{ .Values.global.httpsProxy }}"
+            - name : no_proxy
+              value: "{{ $no_proxy_envar_list }}"
+            {{- end }}
           volumeMounts:
             - name: sbom-comm
               mountPath: /sbom-comm

--- a/charts/kubescape-operator/templates/node-agent/_node-agent.tpl
+++ b/charts/kubescape-operator/templates/node-agent/_node-agent.tpl
@@ -266,6 +266,7 @@ SBOM Scanner Sidecar Container (optional)
 Parameters:
   - Values: .Values
   - components: $components
+  - no_proxy_envar_list: the no_proxy list
 */}}
 {{- define "node-agent.sbomScannerContainer" -}}
 {{- if .components.sbomScanner.enabled }}
@@ -309,6 +310,12 @@ Parameters:
           fieldPath: metadata.namespace
     - name: CLUSTER_NAME
       value: "{{ .Values.clusterName }}"
+    {{- if ne .Values.global.httpsProxy "" }}
+    - name: HTTPS_PROXY
+      value: "{{ .Values.global.httpsProxy }}"
+    - name: no_proxy
+      value: "{{ .no_proxy_envar_list }}"
+    {{- end }}
   volumeMounts:
   {{- if .Values.nodeAgent.sbomScanner.volumeMounts }}
     {{- toYaml .Values.nodeAgent.sbomScanner.volumeMounts | nindent 4 }}
@@ -523,7 +530,7 @@ containers:
 {{ include "node-agent.clamavContainer" (dict "Values" .Values "components" .components) | trim | nindent 0 }}
 {{- end }}
 {{- if .includeSbomScanner }}
-{{ include "node-agent.sbomScannerContainer" (dict "Values" .Values "components" .components) | trim | nindent 0 }}
+{{ include "node-agent.sbomScannerContainer" (dict "Values" .Values "components" .components "no_proxy_envar_list" .no_proxy_envar_list) | trim | nindent 0 }}
 {{- end }}
 {{ include "node-agent.container" (dict "Values" .Values "components" .components "no_proxy_envar_list" .no_proxy_envar_list "autoscalerMode" .autoscalerMode "testingMode" .testingMode "resources" .resources) | trim | nindent 0 }}
 nodeSelector:

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -379,6 +379,61 @@ tests:
             name: extra-ca-certificates
             mountPath: /etc/ssl/certs/cert2.pem
             subPath: cert2.pem
+  - it: node-agent sbom scanner sidecar forwards the HTTPS proxy
+    template: node-agent/daemonset.yaml
+    documentSelector:
+      path: metadata.name
+      value: node-agent
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+      nodeAgent.sbomScanner.enabled: true
+      capabilities.nodeSbomGeneration: enable
+      global:
+        httpsProxy: "https://foo:bar@baz:1234"
+        noProxy: "*.foo,bar.baz"
+    asserts:
+      # containers[0] is the sbom-scanner sidecar
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_PROXY
+            value: "https://foo:bar@baz:1234"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: no_proxy
+            value: "kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz"
+  - it: kubevuln sbom scanner sidecar forwards the HTTPS proxy
+    template: kubevuln/deployment.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+      kubevuln.sbomScanner.enabled: true
+      global:
+        httpsProxy: "https://foo:bar@baz:1234"
+        noProxy: "*.foo,bar.baz"
+    asserts:
+      # containers[0] is the main kubevuln container, containers[1] is the sbom-scanner sidecar
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: sbom-scanner
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: HTTPS_PROXY
+            value: "https://foo:bar@baz:1234"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name : no_proxy
+            value: "kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz"
   - it: node-agent egress allows OTLP ports when otelUrl is set
     template: node-agent/networkpolicy.yaml
     capabilities:


### PR DESCRIPTION
## Overview
Follow-up to #898. The `sbom-scanner` sidecar (added to `node-agent` and `kubevuln` for OOM isolation) pulls image data over HTTPS itself but never received `global.httpsProxy`/`no_proxy` the way the main container does. In clusters that route egress through a proxy — especially with `global.networkPolicy.createEgressRules` enabled, which only opens egress to DNS, the API server, and the proxy IP/port — the sidecar had no route to the registry at all.

Adds the same `HTTPS_PROXY`/`no_proxy` env vars to the `sbom-scanner` container in:
- `charts/kubescape-operator/templates/kubevuln/deployment.yaml`
- `charts/kubescape-operator/templates/node-agent/_node-agent.tpl`

## How to Test
```
helm unittest charts/kubescape-operator
```
Added two new test cases in `tests/snapshot_test.yaml` asserting the sidecar picks up `HTTPS_PROXY`/`no_proxy` when `global.httpsProxy` is set. Full suite (60 tests / 996 snapshots) passes unchanged plus the 2 new tests.

## Checklist before requesting a review
- [x] New and existing unit tests pass locally with my changes

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SBOM scanner components now support configured HTTPS proxy settings.
  * Added support for combined proxy bypass rules through the `no_proxy` environment variable.
  * Proxy settings are applied conditionally when an HTTPS proxy is configured.

* **Tests**
  * Added coverage verifying proxy environment variables for SBOM scanner components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->