### PR TITLE
fix(storage): omit the empty annotations key on the seccompprofiles CRD

### DIFF
--- a/charts/kubescape-operator/templates/storage/seccompprofile-crd.yaml
+++ b/charts/kubescape-operator/templates/storage/seccompprofile-crd.yaml
@@ -3,8 +3,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: seccompprofiles.kubescape.io
+  {{- with include "kubescape-operator.annotations" (dict "Values" .Values) }}
   annotations:
-    {{- include "kubescape-operator.annotations" (dict "Values" .Values) | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "kubescape-operator.labels" (dict "Chart" .Chart "Release" .Release "Values" .Values "app" "seccompprofile" "tier" .Values.global.namespaceTier) | nindent 4 }}
 spec:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -5903,7 +5903,6 @@ all capabilities:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      annotations: null
       labels:
         app: seccompprofile
         app.kubernetes.io/component: seccompprofile
@@ -10414,7 +10413,6 @@ autoscaler mode with sbom sidecar:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      annotations: null
       labels:
         app: seccompprofile
         app.kubernetes.io/component: seccompprofile
@@ -14725,7 +14723,6 @@ autoscaler mode without sbom sidecar:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      annotations: null
       labels:
         app: seccompprofile
         app.kubernetes.io/component: seccompprofile
@@ -20014,7 +20011,6 @@ backend-storage enabled allows scanning capabilities:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      annotations: null
       labels:
         app: seccompprofile
         app.kubernetes.io/component: seccompprofile
@@ -29636,7 +29632,6 @@ default capabilities:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      annotations: null
       labels:
         app: seccompprofile
         app.kubernetes.io/component: seccompprofile
@@ -34222,7 +34217,6 @@ disable otel:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      annotations: null
       labels:
         app: seccompprofile
         app.kubernetes.io/component: seccompprofile
@@ -38730,7 +38724,6 @@ minimal capabilities:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      annotations: null
       labels:
         app: seccompprofile
         app.kubernetes.io/component: seccompprofile
@@ -45296,7 +45289,6 @@ multiple node agents:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      annotations: null
       labels:
         app: seccompprofile
         app.kubernetes.io/component: seccompprofile
@@ -50013,7 +50005,6 @@ priority class scheduling:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      annotations: null
       labels:
         app: seccompprofile
         app.kubernetes.io/component: seccompprofile
@@ -54376,7 +54367,6 @@ relevancy only:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      annotations: null
       labels:
         app: seccompprofile
         app.kubernetes.io/component: seccompprofile
@@ -60651,7 +60641,6 @@ skipPersistence enabled:
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
-      annotations: null
       labels:
         app: seccompprofile
         app.kubernetes.io/component: seccompprofile

--- a/charts/kubescape-operator/tests/seccompprofile_crd_test.yaml
+++ b/charts/kubescape-operator/tests/seccompprofile_crd_test.yaml
@@ -1,0 +1,28 @@
+suite: SeccompProfile CRD tests
+tests:
+  - it: omits the annotations key when no additional annotations are set
+    template: storage/seccompprofile-crd.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: carries additional annotations when they are set
+    template: storage/seccompprofile-crd.yaml
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      clusterName: kind-kind
+      additionalAnnotations:
+        example.com/team: platform
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/team"]
+          value: platform


### PR DESCRIPTION
## Overview

The seccompprofiles CRD template always writes an `annotations:` key. The helper that fills it only produces anything when `additionalAnnotations` is set, so by default the key stays empty:
https://github.com/kubescape/helm-charts/blob/main/charts/kubescape-operator/templates/storage/seccompprofile-crd.yaml#L6-L7

YAML reads the bare key as `annotations: null`, and the API server strips a null metadata map on write. The rendered manifest never matches the stored object, so anything that compares the two (`kubectl diff`, GitOps reconcilers, drift detection) reports this one field of this one object as different, indefinitely:

```
  metadata:
-   annotations: null
    name: seccompprofiles.kubescape.io
```

This wraps the block in `with`, so the key is rendered only when there is something to put in it. Annotations set via `additionalAnnotations` render exactly as before.

## How to Test

New tests in `tests/seccompprofile_crd_test.yaml` assert both directions — key omitted when `additionalAnnotations` is unset, annotations carried when it is set. The 11 snapshot changes are exactly the removed null key.

## Related issues/PRs:

* Related: #531 was the same class from a different field — a rendered value (`divisor: '0'`) the API server normalizes, so comparators never converge.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of annotations in the SeccompProfile resource, ensuring configured annotations are rendered correctly and omitted when not set.

* **Tests**
  * Added coverage for annotation rendering and omission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->