### PR TITLE
prepare next release

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -1,6 +1,6 @@
 # Kubescape Operator
 
-![Version: 1.40.3](https://img.shields.io/badge/Version-1.40.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.40.3](https://img.shields.io/badge/AppVersion-v1.40.3-informational?style=flat-square)
+![Version: 1.40.4](https://img.shields.io/badge/Version-1.40.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.40.4](https://img.shields.io/badge/AppVersion-v1.40.4-informational?style=flat-square)
 
 [Kubescape operator documentation](https://kubescape.io/docs/install-operator/)
 

--- a/charts/kubescape-operator/templates/node-agent/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/node-agent/clusterrole.yaml
@@ -24,9 +24,6 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments", "daemonsets", "statefulsets", "replicasets"]
   verbs: ["get", "watch", "list"]
-- apiGroups: ["spdx.softwarecomposition.kubescape.io"]
-  resources: ["applicationprofiles", "networkneighborhoods"]
-  verbs: ["get", "watch", "list"]
 {{- if eq .Values.capabilities.seccompProfileBackend "crd" }}
 - apiGroups: ["kubescape.io"]
   resources: ["seccompprofiles"]

--- a/charts/kubescape-operator/templates/storage/configmap.yaml
+++ b/charts/kubescape-operator/templates/storage/configmap.yaml
@@ -25,6 +25,15 @@ data:
       "defaultMaxObjectSize": {{ .Values.storage.defaultMaxObjectSize }},
       "queueManagerEnabled": {{ .Values.storage.queueManagerEnabled }},
       "kindQueues": {{ .Values.storage.kindQueues | toJson }},
+      {{- if hasKey .Values.storage "singleWriterEnabled" }}
+      "singleWriterEnabled": {{ .Values.storage.singleWriterEnabled }},
+      {{- end }}
+      {{- if .Values.storage.poolTimeout }}
+      "poolTimeout": "{{ .Values.storage.poolTimeout }}",
+      {{- end }}
+      {{- if .Values.storage.sqliteBusyTimeout }}
+      "sqliteBusyTimeout": "{{ .Values.storage.sqliteBusyTimeout }}",
+      {{- end }}
       {{- if .Values.storage.mtls.enabled }}
       "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
       "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",

--- a/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
@@ -28,7 +28,7 @@ rules:
     resources: ["networkpolicies", "ingresses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
-    resources: ["applicationprofiles", "networkneighborhoods", "containerprofiles"]
+    resources: ["containerprofiles"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
     resources: ["knownservers"]

--- a/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- $components := fromYaml (include "components" .) }}
+{{- $configurations := fromYaml (include "configurations" .) }}
 {{- if $components.synchronizer.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -27,9 +28,11 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies", "ingresses"]
     verbs: ["get", "list", "watch"]
+{{- if not $configurations.backendStorageEnabled }}
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
     resources: ["containerprofiles"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+{{- end }}
   - apiGroups: ["spdx.softwarecomposition.kubescape.io"]
     resources: ["knownservers"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]

--- a/charts/kubescape-operator/templates/synchronizer/configmap.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/configmap.yaml
@@ -163,12 +163,6 @@ data:
           {
             "group": "spdx.softwarecomposition.kubescape.io",
             "version": "v1beta1",
-            "resource": "applicationprofiles",
-            "strategy": "copy"
-          },
-          {
-            "group": "spdx.softwarecomposition.kubescape.io",
-            "version": "v1beta1",
             "resource": "containerprofiles",
             "strategy": "copy"
           },
@@ -176,12 +170,6 @@ data:
             "group": "spdx.softwarecomposition.kubescape.io",
             "version": "v1beta1",
             "resource": "knownservers",
-            "strategy": "copy"
-          },
-          {
-            "group": "spdx.softwarecomposition.kubescape.io",
-            "version": "v1beta1",
-            "resource": "networkneighborhoods",
             "strategy": "copy"
           },
           {{- if eq .Values.capabilities.syncSBOM "enable" }}

--- a/charts/kubescape-operator/templates/synchronizer/configmap.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/configmap.yaml
@@ -160,12 +160,14 @@ data:
             "strategy": "patch"
           },
           {{- if $components.storage.enabled }}
+          {{- if not $configurations.backendStorageEnabled }}
           {
             "group": "spdx.softwarecomposition.kubescape.io",
             "version": "v1beta1",
             "resource": "containerprofiles",
             "strategy": "copy"
           },
+          {{- end }}
           {
             "group": "spdx.softwarecomposition.kubescape.io",
             "version": "v1beta1",

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -5643,7 +5643,7 @@ all capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -10241,7 +10241,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -14557,7 +14557,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19837,7 +19837,7 @@ backend-storage enabled allows scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21284,7 +21284,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21705,7 +21705,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22365,7 +22365,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23051,7 +23051,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23446,7 +23446,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23811,7 +23811,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24275,7 +24275,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24779,7 +24779,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -29405,7 +29405,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -34033,7 +34033,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -38532,7 +38532,7 @@ minimal capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -44921,7 +44921,7 @@ multiple node agents:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -49710,7 +49710,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -54065,7 +54065,7 @@ relevancy only:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -60202,7 +60202,7 @@ skipPersistence enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.329
+              image: quay.io/kubescape/storage:v0.0.330
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -20656,12 +20656,6 @@ backend-storage enabled allows scanning capabilities:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "containerprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "knownservers",
                 "strategy": "copy"
               },
@@ -20826,7 +20820,7 @@ backend-storage enabled allows scanning capabilities:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: c43947fbb741972e7be667da7aa9ab69b0e998bde2e48d33c7f9b53c00a384f0
+            checksum/synchronizer-configmap: fe0b34ca650d9c957b2a0e15238633f0b19c62d9370085306a85239363de61d2
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -759,7 +759,7 @@ all capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -1281,7 +1281,7 @@ all capabilities:
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v4.0.12
+              image: quay.io/kubescape/kubescape:v4.0.13
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -1708,7 +1708,7 @@ all capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -1971,7 +1971,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.159
+              image: quay.io/kubescape/kubevuln:v0.3.404
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -2959,14 +2959,14 @@ all capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.158
+                  value: v0.3.219
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.158
+              image: quay.io/kubescape/node-agent:v0.3.219
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -4469,7 +4469,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -4625,7 +4625,7 @@ all capabilities:
                   - name: bar
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -4713,7 +4713,7 @@ all capabilities:
                   - name: bar
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -4897,7 +4897,7 @@ all capabilities:
                   - name: bar
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -5204,7 +5204,7 @@ all capabilities:
                   value: zap
                 - name: ENABLE_WORKLOAD_METRICS
                   value: "true"
-              image: quay.io/kubescape/prometheus-exporter:v0.2.22
+              image: quay.io/kubescape/prometheus-exporter:v0.2.23
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 initialDelaySeconds: 3
@@ -5649,7 +5649,7 @@ all capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -6871,7 +6871,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.155
+              image: quay.io/kubescape/synchronizer:v0.0.160
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -7391,7 +7391,7 @@ autoscaler mode with sbom sidecar:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -7813,7 +7813,7 @@ autoscaler mode with sbom sidecar:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.12
+              image: quay.io/kubescape/kubescape:v4.0.13
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -8090,7 +8090,7 @@ autoscaler mode with sbom sidecar:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -8261,7 +8261,7 @@ autoscaler mode with sbom sidecar:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.159
+              image: quay.io/kubescape/kubevuln:v0.3.404
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -9064,7 +9064,7 @@ autoscaler mode with sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: ae23f990f84f71fdf3f7e943688dd98b1108a409df896497a7b1e1a0c7056ed5\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.158\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: ae23f990f84f71fdf3f7e943688dd98b1108a409df896497a7b1e1a0c7056ed5\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.219\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -9488,7 +9488,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -9632,7 +9632,7 @@ autoscaler mode with sbom sidecar:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -9717,7 +9717,7 @@ autoscaler mode with sbom sidecar:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -9802,7 +9802,7 @@ autoscaler mode with sbom sidecar:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -10267,7 +10267,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -11315,7 +11315,7 @@ autoscaler mode with sbom sidecar:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.155
+              image: quay.io/kubescape/synchronizer:v0.0.160
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -11727,7 +11727,7 @@ autoscaler mode without sbom sidecar:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -12149,7 +12149,7 @@ autoscaler mode without sbom sidecar:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.12
+              image: quay.io/kubescape/kubescape:v4.0.13
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12426,7 +12426,7 @@ autoscaler mode without sbom sidecar:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -12597,7 +12597,7 @@ autoscaler mode without sbom sidecar:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.159
+              image: quay.io/kubescape/kubevuln:v0.3.404
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -13400,7 +13400,7 @@ autoscaler mode without sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: ae23f990f84f71fdf3f7e943688dd98b1108a409df896497a7b1e1a0c7056ed5\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.158\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: ae23f990f84f71fdf3f7e943688dd98b1108a409df896497a7b1e1a0c7056ed5\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.219\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -13824,7 +13824,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -13968,7 +13968,7 @@ autoscaler mode without sbom sidecar:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -14053,7 +14053,7 @@ autoscaler mode without sbom sidecar:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -14138,7 +14138,7 @@ autoscaler mode without sbom sidecar:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -14603,7 +14603,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -15651,7 +15651,7 @@ autoscaler mode without sbom sidecar:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.155
+              image: quay.io/kubescape/synchronizer:v0.0.160
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16065,7 +16065,7 @@ backend-storage enabled allows scanning capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -16487,7 +16487,7 @@ backend-storage enabled allows scanning capabilities:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease
-              image: quay.io/kubescape/kubescape:v4.0.12
+              image: quay.io/kubescape/kubescape:v4.0.13
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16764,7 +16764,7 @@ backend-storage enabled allows scanning capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -16935,7 +16935,7 @@ backend-storage enabled allows scanning capabilities:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.159
+              image: quay.io/kubescape/kubevuln:v0.3.404
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -17769,14 +17769,14 @@ backend-storage enabled allows scanning capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.158
+                  value: v0.3.219
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.158
+              image: quay.io/kubescape/node-agent:v0.3.219
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19142,7 +19142,7 @@ backend-storage enabled allows scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19280,7 +19280,7 @@ backend-storage enabled allows scanning capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -19365,7 +19365,7 @@ backend-storage enabled allows scanning capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -19450,7 +19450,7 @@ backend-storage enabled allows scanning capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -19903,7 +19903,7 @@ backend-storage enabled allows scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -20951,7 +20951,7 @@ backend-storage enabled allows scanning capabilities:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.155
+              image: quay.io/kubescape/synchronizer:v0.0.160
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21199,7 +21199,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21382,7 +21382,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21518,7 +21518,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21803,7 +21803,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22201,7 +22201,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22463,7 +22463,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22785,7 +22785,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23149,7 +23149,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23361,7 +23361,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23544,7 +23544,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23680,7 +23680,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23909,7 +23909,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24181,7 +24181,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24373,7 +24373,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24639,7 +24639,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24877,7 +24877,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -25352,7 +25352,7 @@ default capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -25820,7 +25820,7 @@ default capabilities:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.12
+              image: quay.io/kubescape/kubescape:v4.0.13
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -26210,7 +26210,7 @@ default capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -26427,7 +26427,7 @@ default capabilities:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.159
+              image: quay.io/kubescape/kubevuln:v0.3.404
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -27328,14 +27328,14 @@ default capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.158
+                  value: v0.3.219
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.158
+              image: quay.io/kubescape/node-agent:v0.3.219
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -28636,7 +28636,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -28780,7 +28780,7 @@ default capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -28865,7 +28865,7 @@ default capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -29032,7 +29032,7 @@ default capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -29509,7 +29509,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -30609,7 +30609,7 @@ default capabilities:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.155
+              image: quay.io/kubescape/synchronizer:v0.0.160
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -31095,7 +31095,7 @@ disable otel:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -31517,7 +31517,7 @@ disable otel:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.12
+              image: quay.io/kubescape/kubescape:v4.0.13
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -31794,7 +31794,7 @@ disable otel:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -31965,7 +31965,7 @@ disable otel:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.159
+              image: quay.io/kubescape/kubevuln:v0.3.404
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -32799,14 +32799,14 @@ disable otel:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.158
+                  value: v0.3.219
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.158
+              image: quay.io/kubescape/node-agent:v0.3.219
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -33396,7 +33396,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -33534,7 +33534,7 @@ disable otel:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -33619,7 +33619,7 @@ disable otel:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -33704,7 +33704,7 @@ disable otel:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -34157,7 +34157,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -35205,7 +35205,7 @@ disable otel:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.155
+              image: quay.io/kubescape/synchronizer:v0.0.160
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -35623,7 +35623,7 @@ minimal capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -36041,7 +36041,7 @@ minimal capabilities:
                   value: /home/nonroot/.kubescape/host-scanner.yaml
                 - name: LARGE_CLUSTER_SIZE
                   value: "1500"
-              image: quay.io/kubescape/kubescape:v4.0.12
+              image: quay.io/kubescape/kubescape:v4.0.13
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -36318,7 +36318,7 @@ minimal capabilities:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -36487,7 +36487,7 @@ minimal capabilities:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.159
+              image: quay.io/kubescape/kubevuln:v0.3.404
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -37322,12 +37322,12 @@ minimal capabilities:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.158
+                  value: v0.3.219
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.158
+              image: quay.io/kubescape/node-agent:v0.3.219
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -37915,7 +37915,7 @@ minimal capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -38053,7 +38053,7 @@ minimal capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -38138,7 +38138,7 @@ minimal capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -38223,7 +38223,7 @@ minimal capabilities:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -38676,7 +38676,7 @@ minimal capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -39926,7 +39926,7 @@ multiple node agents:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -40448,7 +40448,7 @@ multiple node agents:
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v4.0.12
+              image: quay.io/kubescape/kubescape:v4.0.13
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -40875,7 +40875,7 @@ multiple node agents:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -41138,7 +41138,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.159
+              image: quay.io/kubescape/kubevuln:v0.3.404
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -42126,14 +42126,14 @@ multiple node agents:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.158
+                  value: v0.3.219
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.158
+              image: quay.io/kubescape/node-agent:v0.3.219
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -42380,14 +42380,14 @@ multiple node agents:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.158
+                  value: v0.3.219
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.158
+              image: quay.io/kubescape/node-agent:v0.3.219
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -43891,7 +43891,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -44047,7 +44047,7 @@ multiple node agents:
                   - name: bar
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -44135,7 +44135,7 @@ multiple node agents:
                   - name: bar
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -44319,7 +44319,7 @@ multiple node agents:
                   - name: bar
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -44626,7 +44626,7 @@ multiple node agents:
                   value: zap
                 - name: ENABLE_WORKLOAD_METRICS
                   value: "true"
-              image: quay.io/kubescape/prometheus-exporter:v0.2.22
+              image: quay.io/kubescape/prometheus-exporter:v0.2.23
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 initialDelaySeconds: 3
@@ -45071,7 +45071,7 @@ multiple node agents:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -46293,7 +46293,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.155
+              image: quay.io/kubescape/synchronizer:v0.0.160
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -46813,7 +46813,7 @@ priority class scheduling:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -47236,7 +47236,7 @@ priority class scheduling:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.12
+              image: quay.io/kubescape/kubescape:v4.0.13
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -47514,7 +47514,7 @@ priority class scheduling:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -47686,7 +47686,7 @@ priority class scheduling:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.159
+              image: quay.io/kubescape/kubevuln:v0.3.404
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -48521,14 +48521,14 @@ priority class scheduling:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.158
+                  value: v0.3.219
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.158
+              image: quay.io/kubescape/node-agent:v0.3.219
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -49118,7 +49118,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -49257,7 +49257,7 @@ priority class scheduling:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -49342,7 +49342,7 @@ priority class scheduling:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -49427,7 +49427,7 @@ priority class scheduling:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -49880,7 +49880,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -50929,7 +50929,7 @@ priority class scheduling:
                   value: zap
                 - name: API_URL
                   value: https://api.armosec.io
-              image: quay.io/kubescape/synchronizer:v0.0.155
+              image: quay.io/kubescape/synchronizer:v0.0.160
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -51341,7 +51341,7 @@ relevancy only:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -51759,7 +51759,7 @@ relevancy only:
                   value: /home/nonroot/.kubescape/host-scanner.yaml
                 - name: LARGE_CLUSTER_SIZE
                   value: "1500"
-              image: quay.io/kubescape/kubescape:v4.0.12
+              image: quay.io/kubescape/kubescape:v4.0.13
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -52036,7 +52036,7 @@ relevancy only:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -52205,7 +52205,7 @@ relevancy only:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.159
+              image: quay.io/kubescape/kubevuln:v0.3.404
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -53040,12 +53040,12 @@ relevancy only:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.158
+                  value: v0.3.219
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.158
+              image: quay.io/kubescape/node-agent:v0.3.219
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -53503,7 +53503,7 @@ relevancy only:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -53632,7 +53632,7 @@ relevancy only:
                       type: RuntimeDefault
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -53717,7 +53717,7 @@ relevancy only:
                       type: RuntimeDefault
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -53802,7 +53802,7 @@ relevancy only:
                       type: RuntimeDefault
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -54255,7 +54255,7 @@ relevancy only:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -55505,7 +55505,7 @@ skipPersistence enabled:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubescape-scheduler
                   resources:
@@ -56027,7 +56027,7 @@ skipPersistence enabled:
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v4.0.12
+              image: quay.io/kubescape/kubescape:v4.0.13
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -56457,7 +56457,7 @@ skipPersistence enabled:
                     - -path=v1/triggerAction
                     - -headers=Content-Type:application/json
                     - -path-body=/home/ks/request-body.json
-                  image: quay.io/kubescape/http-request:v0.2.20
+                  image: quay.io/kubescape/http-request:v0.2.23
                   imagePullPolicy: IfNotPresent
                   name: kubevuln-scheduler
                   resources:
@@ -56720,7 +56720,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.159
+              image: quay.io/kubescape/kubevuln:v0.3.404
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -57708,14 +57708,14 @@ skipPersistence enabled:
                 - name: KUBELET_ROOT
                   value: /var/lib/kubelet
                 - name: AGENT_VERSION
-                  value: v0.3.158
+                  value: v0.3.219
                 - name: API_URL
                   value: https://api.armosec.io
                 - name: NodeName
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: quay.io/kubescape/node-agent:v0.3.158
+              image: quay.io/kubescape/node-agent:v0.3.219
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -59218,7 +59218,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/operator:v0.2.162
+              image: quay.io/kubescape/operator:v0.2.169
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -59374,7 +59374,7 @@ skipPersistence enabled:
                   - name: bar
                   containers:
                   - name: kubescape-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -59462,7 +59462,7 @@ skipPersistence enabled:
                   - name: bar
                   containers:
                   - name: kubevuln-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -59646,7 +59646,7 @@ skipPersistence enabled:
                   - name: bar
                   containers:
                   - name: registry-scheduler
-                    image: "quay.io/kubescape/http-request:v0.2.20"
+                    image: "quay.io/kubescape/http-request:v0.2.23"
                     imagePullPolicy: IfNotPresent
                     securityContext:
                       allowPrivilegeEscalation: false
@@ -59953,7 +59953,7 @@ skipPersistence enabled:
                   value: zap
                 - name: ENABLE_WORKLOAD_METRICS
                   value: "true"
-              image: quay.io/kubescape/prometheus-exporter:v0.2.22
+              image: quay.io/kubescape/prometheus-exporter:v0.2.23
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 initialDelaySeconds: 3
@@ -60398,7 +60398,7 @@ skipPersistence enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.298
+              image: quay.io/kubescape/storage:v0.0.329
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -61620,7 +61620,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/synchronizer:v0.0.155
+              image: quay.io/kubescape/synchronizer:v0.0.160
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2670,15 +2670,6 @@ all capabilities:
           - watch
           - list
       - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
           - kubescape.io
         resources:
           - seccompprofiles
@@ -6303,8 +6294,6 @@ all capabilities:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -6633,12 +6622,6 @@ all capabilities:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -6646,12 +6629,6 @@ all capabilities:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -6834,7 +6811,7 @@ all capabilities:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: cb62da628f5afa9a6ea3abdcf39087e081964cb1f377a58b82bf2c90abbe81c7
+            checksum/synchronizer-configmap: f1c83380b4ab227f8219ffd32e23133bbf93d37a08f4f07e3c91063394ec0ad5
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -8812,15 +8789,6 @@ autoscaler mode with sbom sidecar:
           - daemonsets
           - statefulsets
           - replicasets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
         verbs:
           - get
           - watch
@@ -10839,8 +10807,6 @@ autoscaler mode with sbom sidecar:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -11100,12 +11066,6 @@ autoscaler mode with sbom sidecar:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -11113,12 +11073,6 @@ autoscaler mode with sbom sidecar:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -11282,7 +11236,7 @@ autoscaler mode with sbom sidecar:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
+            checksum/synchronizer-configmap: 77923ccf52f639e2212347cf07ac28648c138fca84b2d9e99a7a92121d01941c
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -13148,15 +13102,6 @@ autoscaler mode without sbom sidecar:
           - daemonsets
           - statefulsets
           - replicasets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
         verbs:
           - get
           - watch
@@ -15175,8 +15120,6 @@ autoscaler mode without sbom sidecar:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -15436,12 +15379,6 @@ autoscaler mode without sbom sidecar:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -15449,12 +15386,6 @@ autoscaler mode without sbom sidecar:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -15618,7 +15549,7 @@ autoscaler mode without sbom sidecar:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
+            checksum/synchronizer-configmap: 77923ccf52f639e2212347cf07ac28648c138fca84b2d9e99a7a92121d01941c
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -17486,15 +17417,6 @@ backend-storage enabled allows scanning capabilities:
           - daemonsets
           - statefulsets
           - replicasets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
         verbs:
           - get
           - watch
@@ -20475,8 +20397,6 @@ backend-storage enabled allows scanning capabilities:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -20736,12 +20656,6 @@ backend-storage enabled allows scanning capabilities:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -20749,12 +20663,6 @@ backend-storage enabled allows scanning capabilities:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -20918,7 +20826,7 @@ backend-storage enabled allows scanning capabilities:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: 89c4293fcd32cc7a3ee95ac49975a088c1eee7af72a1712948fa24960c0dcd6a
+            checksum/synchronizer-configmap: c43947fbb741972e7be667da7aa9ab69b0e998bde2e48d33c7f9b53c00a384f0
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -27049,15 +26957,6 @@ default capabilities:
           - watch
           - list
       - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
           - kubescape.io
         resources:
           - seccompprofiles
@@ -30132,8 +30031,6 @@ default capabilities:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -30393,12 +30290,6 @@ default capabilities:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -30406,12 +30297,6 @@ default capabilities:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -30576,7 +30461,7 @@ default capabilities:
             checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
+            checksum/synchronizer-configmap: 77923ccf52f639e2212347cf07ac28648c138fca84b2d9e99a7a92121d01941c
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -32516,15 +32401,6 @@ disable otel:
           - daemonsets
           - statefulsets
           - replicasets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
         verbs:
           - get
           - watch
@@ -34729,8 +34605,6 @@ disable otel:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -34990,12 +34864,6 @@ disable otel:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -35003,12 +34871,6 @@ disable otel:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -35172,7 +35034,7 @@ disable otel:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
+            checksum/synchronizer-configmap: 77923ccf52f639e2212347cf07ac28648c138fca84b2d9e99a7a92121d01941c
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -37038,15 +36900,6 @@ minimal capabilities:
           - daemonsets
           - statefulsets
           - replicasets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
         verbs:
           - get
           - watch
@@ -41837,15 +41690,6 @@ multiple node agents:
           - watch
           - list
       - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
           - kubescape.io
         resources:
           - seccompprofiles
@@ -45725,8 +45569,6 @@ multiple node agents:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -46055,12 +45897,6 @@ multiple node agents:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -46068,12 +45904,6 @@ multiple node agents:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -46256,7 +46086,7 @@ multiple node agents:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: cb62da628f5afa9a6ea3abdcf39087e081964cb1f377a58b82bf2c90abbe81c7
+            checksum/synchronizer-configmap: f1c83380b4ab227f8219ffd32e23133bbf93d37a08f4f07e3c91063394ec0ad5
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -48238,15 +48068,6 @@ priority class scheduling:
           - daemonsets
           - statefulsets
           - replicasets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
         verbs:
           - get
           - watch
@@ -50453,8 +50274,6 @@ priority class scheduling:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -50714,12 +50533,6 @@ priority class scheduling:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -50727,12 +50540,6 @@ priority class scheduling:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -50896,7 +50703,7 @@ priority class scheduling:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/synchronizer-configmap: bb19e36fdc84eee20a6ceb6992e464f205f9346b12e7f8cbfe5ebe088f949b69
+            checksum/synchronizer-configmap: 77923ccf52f639e2212347cf07ac28648c138fca84b2d9e99a7a92121d01941c
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer
@@ -52756,15 +52563,6 @@ relevancy only:
           - daemonsets
           - statefulsets
           - replicasets
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
         verbs:
           - get
           - watch
@@ -57419,15 +57217,6 @@ skipPersistence enabled:
           - watch
           - list
       - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
-          - applicationprofiles
-          - networkneighborhoods
-        verbs:
-          - get
-          - watch
-          - list
-      - apiGroups:
           - kubescape.io
         resources:
           - seccompprofiles
@@ -61052,8 +60841,6 @@ skipPersistence enabled:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - applicationprofiles
-          - networkneighborhoods
           - containerprofiles
         verbs:
           - get
@@ -61382,12 +61169,6 @@ skipPersistence enabled:
               {
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
-                "resource": "applicationprofiles",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
                 "resource": "containerprofiles",
                 "strategy": "copy"
               },
@@ -61395,12 +61176,6 @@ skipPersistence enabled:
                 "group": "spdx.softwarecomposition.kubescape.io",
                 "version": "v1beta1",
                 "resource": "knownservers",
-                "strategy": "copy"
-              },
-              {
-                "group": "spdx.softwarecomposition.kubescape.io",
-                "version": "v1beta1",
-                "resource": "networkneighborhoods",
                 "strategy": "copy"
               },
               {
@@ -61583,7 +61358,7 @@ skipPersistence enabled:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
-            checksum/synchronizer-configmap: cb62da628f5afa9a6ea3abdcf39087e081964cb1f377a58b82bf2c90abbe81c7
+            checksum/synchronizer-configmap: f1c83380b4ab227f8219ffd32e23133bbf93d37a08f4f07e3c91063394ec0ad5
           labels:
             app: synchronizer
             app.kubernetes.io/component: synchronizer

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1971,7 +1971,7 @@ all capabilities:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.404
+              image: quay.io/kubescape/kubevuln:v0.3.430
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -8238,7 +8238,7 @@ autoscaler mode with sbom sidecar:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.404
+              image: quay.io/kubescape/kubevuln:v0.3.430
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12551,7 +12551,7 @@ autoscaler mode without sbom sidecar:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.404
+              image: quay.io/kubescape/kubevuln:v0.3.430
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16866,7 +16866,7 @@ backend-storage enabled allows scanning capabilities:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.404
+              image: quay.io/kubescape/kubevuln:v0.3.430
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -26335,7 +26335,7 @@ default capabilities:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.404
+              image: quay.io/kubescape/kubevuln:v0.3.430
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -31850,7 +31850,7 @@ disable otel:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.404
+              image: quay.io/kubescape/kubevuln:v0.3.430
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -36349,7 +36349,7 @@ minimal capabilities:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.404
+              image: quay.io/kubescape/kubevuln:v0.3.430
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -40991,7 +40991,7 @@ multiple node agents:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.404
+              image: quay.io/kubescape/kubevuln:v0.3.430
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -47516,7 +47516,7 @@ priority class scheduling:
                   value: https://api.armosec.io
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.404
+              image: quay.io/kubescape/kubevuln:v0.3.430
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -52012,7 +52012,7 @@ relevancy only:
                   value: ""
                 - name: CA_MAX_VULN_SCAN_ROUTINES
                   value: "1"
-              image: quay.io/kubescape/kubevuln:v0.3.404
+              image: quay.io/kubescape/kubevuln:v0.3.430
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -56518,7 +56518,7 @@ skipPersistence enabled:
                   value: https://foo:bar@baz:1234
                 - name: no_proxy
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
-              image: quay.io/kubescape/kubevuln:v0.3.404
+              image: quay.io/kubescape/kubevuln:v0.3.430
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -5563,6 +5563,9 @@ all capabilities:
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "singleWriterEnabled": true,
+          "poolTimeout": "15s",
+          "sqliteBusyTimeout": "60s",
           "serverBindPort": "8443"
         }
     kind: ConfigMap
@@ -5614,7 +5617,7 @@ all capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
-            checksum/storage-config: 2bfab29c4f2202642843536de82e3599252f3db66aa3b8429db6fc662544401c
+            checksum/storage-config: 98647d83976afeb253cb21e3e9e198a7ea2cccd0aa2bf08621da3aae776fcbd0
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -10155,6 +10158,9 @@ autoscaler mode with sbom sidecar:
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "singleWriterEnabled": true,
+          "poolTimeout": "15s",
+          "sqliteBusyTimeout": "60s",
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -10209,7 +10215,7 @@ autoscaler mode with sbom sidecar:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+            checksum/storage-config: 590c6ecbb0da091594f8b56720497bbe048f88fc50e2896f953f06faafefe0a3
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -14468,6 +14474,9 @@ autoscaler mode without sbom sidecar:
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "singleWriterEnabled": true,
+          "poolTimeout": "15s",
+          "sqliteBusyTimeout": "60s",
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -14522,7 +14531,7 @@ autoscaler mode without sbom sidecar:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+            checksum/storage-config: 590c6ecbb0da091594f8b56720497bbe048f88fc50e2896f953f06faafefe0a3
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -19745,6 +19754,9 @@ backend-storage enabled allows scanning capabilities:
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "singleWriterEnabled": true,
+          "poolTimeout": "15s",
+          "sqliteBusyTimeout": "60s",
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -19799,7 +19811,7 @@ backend-storage enabled allows scanning capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+            checksum/storage-config: 590c6ecbb0da091594f8b56720497bbe048f88fc50e2896f953f06faafefe0a3
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -21258,7 +21270,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: bacd8615629fc0d8d77c7fa095084e77313ab6666170a7985820f92dfc40670a
+            checksum/storage-config: 5e8458623c44b5fae66b5d816abab8fd02a7996758b510dbb4afb5a221918b0d
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -21679,7 +21691,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/storage-certgen-scripts: 0437bf4a87439f0a5e709a25751946c2ea0940389b61c553aeac7c899fc362a4
-            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
+            checksum/storage-config: 3bb611086ab7fc5b5acbd122deb6ed76612809110a19007d5e686e45310a0979
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -22339,7 +22351,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: bacd8615629fc0d8d77c7fa095084e77313ab6666170a7985820f92dfc40670a
+            checksum/storage-config: 5e8458623c44b5fae66b5d816abab8fd02a7996758b510dbb4afb5a221918b0d
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -23025,7 +23037,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/storage-certgen-scripts: 0437bf4a87439f0a5e709a25751946c2ea0940389b61c553aeac7c899fc362a4
-            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
+            checksum/storage-config: 3bb611086ab7fc5b5acbd122deb6ed76612809110a19007d5e686e45310a0979
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -23420,7 +23432,7 @@ cert strategy template, admission disabled, mtls disabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: bacd8615629fc0d8d77c7fa095084e77313ab6666170a7985820f92dfc40670a
+            checksum/storage-config: 5e8458623c44b5fae66b5d816abab8fd02a7996758b510dbb4afb5a221918b0d
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -23785,7 +23797,7 @@ cert strategy template, admission disabled, mtls enabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
+            checksum/storage-config: 3bb611086ab7fc5b5acbd122deb6ed76612809110a19007d5e686e45310a0979
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -24249,7 +24261,7 @@ cert strategy template, admission enabled, mtls disabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: bacd8615629fc0d8d77c7fa095084e77313ab6666170a7985820f92dfc40670a
+            checksum/storage-config: 5e8458623c44b5fae66b5d816abab8fd02a7996758b510dbb4afb5a221918b0d
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -24753,7 +24765,7 @@ cert strategy template, admission enabled, mtls enabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
+            checksum/storage-config: 3bb611086ab7fc5b5acbd122deb6ed76612809110a19007d5e686e45310a0979
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -29322,6 +29334,9 @@ default capabilities:
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "singleWriterEnabled": true,
+          "poolTimeout": "15s",
+          "sqliteBusyTimeout": "60s",
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -29376,7 +29391,7 @@ default capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+            checksum/storage-config: 590c6ecbb0da091594f8b56720497bbe048f88fc50e2896f953f06faafefe0a3
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -33947,6 +33962,9 @@ disable otel:
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "singleWriterEnabled": true,
+          "poolTimeout": "15s",
+          "sqliteBusyTimeout": "60s",
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -34001,7 +34019,7 @@ disable otel:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+            checksum/storage-config: 590c6ecbb0da091594f8b56720497bbe048f88fc50e2896f953f06faafefe0a3
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -38443,6 +38461,9 @@ minimal capabilities:
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "singleWriterEnabled": true,
+          "poolTimeout": "15s",
+          "sqliteBusyTimeout": "60s",
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -38497,7 +38518,7 @@ minimal capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
-            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
+            checksum/storage-config: 3bb611086ab7fc5b5acbd122deb6ed76612809110a19007d5e686e45310a0979
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -44832,6 +44853,9 @@ multiple node agents:
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "singleWriterEnabled": true,
+          "poolTimeout": "15s",
+          "sqliteBusyTimeout": "60s",
           "serverBindPort": "8443"
         }
     kind: ConfigMap
@@ -44883,7 +44907,7 @@ multiple node agents:
         metadata:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
-            checksum/storage-config: 2bfab29c4f2202642843536de82e3599252f3db66aa3b8429db6fc662544401c
+            checksum/storage-config: 98647d83976afeb253cb21e3e9e198a7ea2cccd0aa2bf08621da3aae776fcbd0
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -49615,6 +49639,9 @@ priority class scheduling:
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "singleWriterEnabled": true,
+          "poolTimeout": "15s",
+          "sqliteBusyTimeout": "60s",
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -49669,7 +49696,7 @@ priority class scheduling:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 93d3421370840ceb49f54b45948bc46db534250f88be6ef6df7d4b10b9d09228
+            checksum/storage-config: 590c6ecbb0da091594f8b56720497bbe048f88fc50e2896f953f06faafefe0a3
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -53967,6 +53994,9 @@ relevancy only:
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "singleWriterEnabled": true,
+          "poolTimeout": "15s",
+          "sqliteBusyTimeout": "60s",
           "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
           "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
           "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
@@ -54021,7 +54051,7 @@ relevancy only:
         metadata:
           annotations:
             checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
-            checksum/storage-config: 5ef9efd40532900e9053245bd7d11836f4c2212e734885e4ae28983d9e2c84a4
+            checksum/storage-config: 3bb611086ab7fc5b5acbd122deb6ed76612809110a19007d5e686e45310a0979
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -60104,6 +60134,9 @@ skipPersistence enabled:
           "defaultMaxObjectSize": 400000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "singleWriterEnabled": true,
+          "poolTimeout": "15s",
+          "sqliteBusyTimeout": "60s",
           "serverBindPort": "8443"
         }
     kind: ConfigMap
@@ -60155,7 +60188,7 @@ skipPersistence enabled:
         metadata:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
-            checksum/storage-config: 2bfab29c4f2202642843536de82e3599252f3db66aa3b8429db6fc662544401c
+            checksum/storage-config: 98647d83976afeb253cb21e3e9e198a7ea2cccd0aa2bf08621da3aae776fcbd0
           labels:
             app: storage
             app.kubernetes.io/component: storage

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -20409,18 +20409,6 @@ backend-storage enabled allows scanning capabilities:
       - apiGroups:
           - spdx.softwarecomposition.kubescape.io
         resources:
-          - containerprofiles
-        verbs:
-          - get
-          - watch
-          - list
-          - create
-          - update
-          - patch
-          - delete
-      - apiGroups:
-          - spdx.softwarecomposition.kubescape.io
-        resources:
           - knownservers
         verbs:
           - get

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -5643,7 +5643,7 @@ all capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -10241,7 +10241,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -14557,7 +14557,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19837,7 +19837,7 @@ backend-storage enabled allows scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21284,7 +21284,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -21705,7 +21705,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -22365,7 +22365,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23051,7 +23051,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23446,7 +23446,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -23811,7 +23811,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24275,7 +24275,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24779,7 +24779,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -29405,7 +29405,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -34033,7 +34033,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -38532,7 +38532,7 @@ minimal capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -44921,7 +44921,7 @@ multiple node agents:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -49710,7 +49710,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -54065,7 +54065,7 @@ relevancy only:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -60202,7 +60202,7 @@ skipPersistence enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.330
+              image: quay.io/kubescape/storage:v0.0.331
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -321,7 +321,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v4.0.12
+    tag: v4.0.13
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -383,7 +383,7 @@ operator:
   image:
     # -- source code: https://github.com/kubescape/operator
     repository: quay.io/kubescape/operator
-    tag: v0.2.162
+    tag: v0.2.169
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -458,7 +458,7 @@ kubevuln:
   image:
     # -- source code: https://github.com/kubescape/kubevuln
     repository: quay.io/kubescape/kubevuln
-    tag: v0.3.159
+    tag: v0.3.404
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -557,7 +557,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: quay.io/kubescape/storage
-    tag: v0.0.298
+    tag: v0.0.329
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -626,7 +626,7 @@ nodeAgent:
   image:
     # -- source code: https://github.com/kubescape/node-agent
     repository: quay.io/kubescape/node-agent
-    tag: v0.3.158
+    tag: v0.3.219
     pullPolicy: IfNotPresent
 
   config:
@@ -917,7 +917,7 @@ synchronizer:
   image:
     # -- source code: https://github.com/kubescape/synchronizer
     repository: quay.io/kubescape/synchronizer
-    tag: v0.0.155
+    tag: v0.0.160
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux
@@ -998,7 +998,7 @@ prometheusExporter:
   name: "prometheus-exporter"
   image:
     repository: quay.io/kubescape/prometheus-exporter
-    tag: v0.2.22
+    tag: v0.2.23
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -1109,7 +1109,7 @@ kubescapeScheduler:
   image:
     # -- source code: https://github.com/kubescape/http-request (public repo)
     repository: quay.io/kubescape/http-request
-    tag: v0.2.20
+    tag: v0.2.23
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -1157,7 +1157,7 @@ kubevulnScheduler:
   image:
     # source code - https://github.com/kubescape/http-request
     repository: quay.io/kubescape/http-request
-    tag: v0.2.20
+    tag: v0.2.23
     pullPolicy: IfNotPresent
 
   nodeSelector:
@@ -1207,7 +1207,7 @@ registryScanScheduler:
   image:
     # -- source code: https://github.com/kubescape/http-request (public repo)
     repository: quay.io/kubescape/http-request
-    tag: v0.2.20
+    tag: v0.2.23
     pullPolicy: IfNotPresent
 
   nodeSelector:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -557,7 +557,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: quay.io/kubescape/storage
-    tag: v0.0.330
+    tag: v0.0.331
     pullPolicy: IfNotPresent
 
   nodeSelector:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -579,6 +579,11 @@ storage:
 
   disableVirtualCRDs: false # set to true or false to override auto-detection
 
+  # -- single-dedicated-writer and SQLite pool tuning
+  singleWriterEnabled: true
+  poolTimeout: "15s"
+  sqliteBusyTimeout: "60s"
+
   # -- queue manager configuration
   queueManagerEnabled: true # set to false to disable the queue manager, this will disable the queue manager for all kinds
   defaultQueueLength: 100

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -557,7 +557,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: quay.io/kubescape/storage
-    tag: v0.0.329
+    tag: v0.0.330
     pullPolicy: IfNotPresent
 
   nodeSelector:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -458,7 +458,7 @@ kubevuln:
   image:
     # -- source code: https://github.com/kubescape/kubevuln
     repository: quay.io/kubescape/kubevuln
-    tag: v0.3.404
+    tag: v0.3.430
     pullPolicy: IfNotPresent
 
   nodeSelector:


### PR DESCRIPTION
Bumps components to their latest releases and updates snapshot tests:

- **kubescape**: `v4.0.12` → `v4.0.13`
- **operator**: `v0.2.162` → `v0.2.169`
- **kubevuln**: `v0.3.159` → `v0.3.430`
- **storage**: `v0.0.298` → `v0.0.331`
- **node-agent**: `v0.3.158` → `v0.3.219`
- **synchronizer**: `v0.0.155` → `v0.0.160`
- **prometheus-exporter**: `v0.2.22` → `v0.2.23`
- **http-request** (schedulers): `v0.2.20` → `v0.2.23`
- **README.md**: update version badges to `1.40.4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Updated Kubescape Operator components, scheduled task images, and the Helm chart/application version to 1.40.4.

- **Configuration**
  - Added SQLite connection pool and timeout settings.
  - Added configurable node-agent tracing options.
  - Reduced synchronization and access for application profile and network neighborhood resources while retaining conditional container profile support.

- **Documentation**
  - Documented the available node-agent tracer settings and storage configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->