### PR TITLE
feat: add options to disable exec and open tracing

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -191,6 +191,25 @@ However, we recommend that you give Kubescape no less than 500m CPU no matter th
 | operator.volumeMounts | object | `[]` | Additional volumeMounts for the web socket |
 | storage.hostNetwork | bool | `false` | Bind the storage APIServer to the host network. Required when using a custom CNI where the control plane cannot reach pod IPs |
 | nodeAgent.autoscaler.bottlerocketAutoDetect | bool | `true` | When the autoscaler is enabled, auto-detect AWS Bottlerocket nodes and set `seLinuxType: super_t` on the node-agent DaemonSet rendered for that node group, so you don't need to `--set nodeAgent.seLinuxType=super_t` manually |
+| nodeAgent.config.tracers.capSys | string | `enable` | Allow capSys tracing when required by enabled node-agent features. Set to disable to force-disable the capSys tracer |
+| nodeAgent.config.tracers.dns | string | `enable` | Allow dns tracing when required by enabled node-agent features. Set to disable to force-disable the dns tracer |
+| nodeAgent.config.tracers.exec | string | `enable` | Allow exec tracing when required by enabled node-agent features. Set to disable to force-disable the exec tracer |
+| nodeAgent.config.tracers.exit | string | `enable` | Allow exit tracing when required by enabled node-agent features. Set to disable to force-disable the exit tracer |
+| nodeAgent.config.tracers.fork | string | `enable` | Allow fork tracing when required by enabled node-agent features. Set to disable to force-disable the fork tracer |
+| nodeAgent.config.tracers.hardlink | string | `enable` | Allow hardlink tracing when required by enabled node-agent features. Set to disable to force-disable the hardlink tracer |
+| nodeAgent.config.tracers.http | string | `enable` | Allow HTTP tracing when required by enabled node-agent features. Set to disable to force-disable the HTTP tracer |
+| nodeAgent.config.tracers.iouring | string | `enable` | Allow io_uring tracing when required by enabled node-agent features. Set to disable to force-disable the io_uring tracer |
+| nodeAgent.config.tracers.network | string | `enable` | Allow network tracing when required by enabled node-agent features. Set to disable to force-disable the network tracer |
+| nodeAgent.config.tracers.open | string | `enable` | Allow file-open tracing when required by enabled node-agent features. Set to disable to force-disable the file-open tracer |
+| nodeAgent.config.tracers.ptrace | string | `enable` | Allow ptrace tracing when required by enabled node-agent features. Set to disable to force-disable the ptrace tracer |
+| nodeAgent.config.tracers.randomx | string | `enable` | Allow RandomX tracing when required by enabled node-agent features. Set to disable to force-disable the RandomX tracer |
+| nodeAgent.config.tracers.seccomp | string | `enable` | Allow seccomp tracing when required by enabled node-agent features. Set to disable to force-disable the seccomp tracer |
+| nodeAgent.config.tracers.ssh | string | `enable` | Allow SSH tracing when required by enabled node-agent features. Set to disable to force-disable the SSH tracer |
+| nodeAgent.config.tracers.symlink | string | `enable` | Allow symlink tracing when required by enabled node-agent features. Set to disable to force-disable the symlink tracer |
+| nodeAgent.config.tracers.kmod | string | `enable` | Allow kernel module tracing when required by enabled node-agent features. Set to disable to force-disable the kernel module tracer |
+| nodeAgent.config.tracers.unshare | string | `enable` | Allow unshare tracing when required by enabled node-agent features. Set to disable to force-disable the unshare tracer |
+| nodeAgent.config.tracers.bpf | string | `enable` | Allow BPF tracing when required by enabled node-agent features. Set to disable to force-disable the BPF tracer |
+| nodeAgent.config.tracers.top | string | `enable` | Allow top tracing when required by enabled node-agent features. Set to disable to force-disable the top tracer |
 | prometheusExporter.serviceMonitor.enabled | bool | `false` | enable/disable service monitor for prometheus-exporter integration |
 | awsIamRoleArn | string | `nil` | AWS IAM arn role |
 | cloudProviderMetadata.secretRef.name | string | `nil` | secret name to define values for the provider's metadata |

--- a/charts/kubescape-operator/templates/node-agent/configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/configmap.yaml
@@ -69,6 +69,25 @@ data:
         },
         "alertDeduplication": {
             "bypass": {{ .Values.nodeAgent.config.alertDeduplication.bypass }}
-        }
+        },
+        "dCapSys": {{ eq .Values.nodeAgent.config.tracers.capSys "disable" }},
+        "dDns": {{ eq .Values.nodeAgent.config.tracers.dns "disable" }},
+        "dExec": {{ eq .Values.nodeAgent.config.tracers.exec "disable" }},
+        "dExit": {{ eq .Values.nodeAgent.config.tracers.exit "disable" }},
+        "dFork": {{ eq .Values.nodeAgent.config.tracers.fork "disable" }},
+        "dHardlink": {{ eq .Values.nodeAgent.config.tracers.hardlink "disable" }},
+        "dHttp": {{ eq .Values.nodeAgent.config.tracers.http "disable" }},
+        "dIouring": {{ eq .Values.nodeAgent.config.tracers.iouring "disable" }},
+        "dNetwork": {{ eq .Values.nodeAgent.config.tracers.network "disable" }},
+        "dOpen": {{ eq .Values.nodeAgent.config.tracers.open "disable" }},
+        "dPtrace": {{ eq .Values.nodeAgent.config.tracers.ptrace "disable" }},
+        "dRandomx": {{ eq .Values.nodeAgent.config.tracers.randomx "disable" }},
+        "dSeccomp": {{ eq .Values.nodeAgent.config.tracers.seccomp "disable" }},
+        "dSsh": {{ eq .Values.nodeAgent.config.tracers.ssh "disable" }},
+        "dSymlink": {{ eq .Values.nodeAgent.config.tracers.symlink "disable" }},
+        "dKmod": {{ eq .Values.nodeAgent.config.tracers.kmod "disable" }},
+        "dUnshare": {{ eq .Values.nodeAgent.config.tracers.unshare "disable" }},
+        "dBpf": {{ eq .Values.nodeAgent.config.tracers.bpf "disable" }},
+        "dTop": {{ eq .Values.nodeAgent.config.tracers.top "disable" }}
     }
 {{- end }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2830,7 +2830,26 @@ all capabilities:
             },
             "alertDeduplication": {
                 "bypass": false
-            }
+            },
+            "dCapSys": false,
+            "dDns": false,
+            "dExec": false,
+            "dExit": false,
+            "dFork": false,
+            "dHardlink": false,
+            "dHttp": false,
+            "dIouring": false,
+            "dNetwork": false,
+            "dOpen": false,
+            "dPtrace": false,
+            "dRandomx": false,
+            "dSeccomp": false,
+            "dSsh": false,
+            "dSymlink": false,
+            "dKmod": false,
+            "dUnshare": false,
+            "dBpf": false,
+            "dTop": false
         }
     kind: ConfigMap
     metadata:
@@ -2879,7 +2898,7 @@ all capabilities:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 42fec66291e55765ef0dfc023dda6243b349aeedd7bd0cc9fdf2dccee3390125
+            checksum/node-agent-config: 3e0ae483bbe487ebbe9da5f630a486b4014d6ff70c4705477a54a82a810765d7
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -8958,7 +8977,26 @@ autoscaler mode with sbom sidecar:
             },
             "alertDeduplication": {
                 "bypass": false
-            }
+            },
+            "dCapSys": false,
+            "dDns": false,
+            "dExec": false,
+            "dExit": false,
+            "dFork": false,
+            "dHardlink": false,
+            "dHttp": false,
+            "dIouring": false,
+            "dNetwork": false,
+            "dOpen": false,
+            "dPtrace": false,
+            "dRandomx": false,
+            "dSeccomp": false,
+            "dSsh": false,
+            "dSymlink": false,
+            "dKmod": false,
+            "dUnshare": false,
+            "dBpf": false,
+            "dTop": false
         }
     kind: ConfigMap
     metadata:
@@ -9026,7 +9064,7 @@ autoscaler mode with sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: dea3d85c79809741877283d857ea833676eddf1c09c5e1e05d17ac1280f49b86\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.158\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: ae23f990f84f71fdf3f7e943688dd98b1108a409df896497a7b1e1a0c7056ed5\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.158\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -13275,7 +13313,26 @@ autoscaler mode without sbom sidecar:
             },
             "alertDeduplication": {
                 "bypass": false
-            }
+            },
+            "dCapSys": false,
+            "dDns": false,
+            "dExec": false,
+            "dExit": false,
+            "dFork": false,
+            "dHardlink": false,
+            "dHttp": false,
+            "dIouring": false,
+            "dNetwork": false,
+            "dOpen": false,
+            "dPtrace": false,
+            "dRandomx": false,
+            "dSeccomp": false,
+            "dSsh": false,
+            "dSymlink": false,
+            "dKmod": false,
+            "dUnshare": false,
+            "dBpf": false,
+            "dTop": false
         }
     kind: ConfigMap
     metadata:
@@ -13343,7 +13400,7 @@ autoscaler mode without sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: dea3d85c79809741877283d857ea833676eddf1c09c5e1e05d17ac1280f49b86\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.158\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: ae23f990f84f71fdf3f7e943688dd98b1108a409df896497a7b1e1a0c7056ed5\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.158\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -17594,7 +17651,26 @@ backend-storage enabled allows scanning capabilities:
             },
             "alertDeduplication": {
                 "bypass": false
-            }
+            },
+            "dCapSys": false,
+            "dDns": false,
+            "dExec": false,
+            "dExit": false,
+            "dFork": false,
+            "dHardlink": false,
+            "dHttp": false,
+            "dIouring": false,
+            "dNetwork": false,
+            "dOpen": false,
+            "dPtrace": false,
+            "dRandomx": false,
+            "dSeccomp": false,
+            "dSsh": false,
+            "dSymlink": false,
+            "dKmod": false,
+            "dUnshare": false,
+            "dBpf": false,
+            "dTop": false
         }
     kind: ConfigMap
     metadata:
@@ -17643,7 +17719,7 @@ backend-storage enabled allows scanning capabilities:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 1c90c08695cbe2d0b65b6c19efa631d2641c189c2383e503567dc1e59d3c631c
+            checksum/node-agent-config: 70e5e98cb894ed2343f32898b130aa3e7a2b1b2992c31a65203cf08d331b65b5
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -27133,7 +27209,26 @@ default capabilities:
             },
             "alertDeduplication": {
                 "bypass": false
-            }
+            },
+            "dCapSys": false,
+            "dDns": false,
+            "dExec": false,
+            "dExit": false,
+            "dFork": false,
+            "dHardlink": false,
+            "dHttp": false,
+            "dIouring": false,
+            "dNetwork": false,
+            "dOpen": false,
+            "dPtrace": false,
+            "dRandomx": false,
+            "dSeccomp": false,
+            "dSsh": false,
+            "dSymlink": false,
+            "dKmod": false,
+            "dUnshare": false,
+            "dBpf": false,
+            "dTop": false
         }
     kind: ConfigMap
     metadata:
@@ -27182,7 +27277,7 @@ default capabilities:
           annotations:
             checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 265ab40e94abc183e59687850a4f48bd77013a8b5d9d33ce6aec5dad28ef78f4
+            checksum/node-agent-config: ae0e90357c1b7766f61d8be4c026957b6725cf29861278d5c5f7af29f124c3fd
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -32586,7 +32681,26 @@ disable otel:
             },
             "alertDeduplication": {
                 "bypass": false
-            }
+            },
+            "dCapSys": false,
+            "dDns": false,
+            "dExec": false,
+            "dExit": false,
+            "dFork": false,
+            "dHardlink": false,
+            "dHttp": false,
+            "dIouring": false,
+            "dNetwork": false,
+            "dOpen": false,
+            "dPtrace": false,
+            "dRandomx": false,
+            "dSeccomp": false,
+            "dSsh": false,
+            "dSymlink": false,
+            "dKmod": false,
+            "dUnshare": false,
+            "dBpf": false,
+            "dTop": false
         }
     kind: ConfigMap
     metadata:
@@ -32635,7 +32749,7 @@ disable otel:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: dc71209894b8da482d8e2e7a92e3b69ff7b89d16d41b60c14f9b5a91e3293661
+            checksum/node-agent-config: b7f58e6efb31eb42fe31431e66fe9077b5508af9f4ab216f0373a2252b5cfb75
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -37087,7 +37201,26 @@ minimal capabilities:
             },
             "alertDeduplication": {
                 "bypass": false
-            }
+            },
+            "dCapSys": false,
+            "dDns": false,
+            "dExec": false,
+            "dExit": false,
+            "dFork": false,
+            "dHardlink": false,
+            "dHttp": false,
+            "dIouring": false,
+            "dNetwork": false,
+            "dOpen": false,
+            "dPtrace": false,
+            "dRandomx": false,
+            "dSeccomp": false,
+            "dSsh": false,
+            "dSymlink": false,
+            "dKmod": false,
+            "dUnshare": false,
+            "dBpf": false,
+            "dTop": false
         }
     kind: ConfigMap
     metadata:
@@ -37136,7 +37269,7 @@ minimal capabilities:
           annotations:
             checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
-            checksum/node-agent-config: 11a681ecf13bd0da14f256542f0aca88263bef5cadbaf148bfea408619483f08
+            checksum/node-agent-config: 33a253678380bd3929c0a7203f6b0853dbd1e4f9a5fe0e5a277ed0c0df0c8b70
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -41864,7 +41997,26 @@ multiple node agents:
             },
             "alertDeduplication": {
                 "bypass": false
-            }
+            },
+            "dCapSys": false,
+            "dDns": false,
+            "dExec": false,
+            "dExit": false,
+            "dFork": false,
+            "dHardlink": false,
+            "dHttp": false,
+            "dIouring": false,
+            "dNetwork": false,
+            "dOpen": false,
+            "dPtrace": false,
+            "dRandomx": false,
+            "dSeccomp": false,
+            "dSsh": false,
+            "dSymlink": false,
+            "dKmod": false,
+            "dUnshare": false,
+            "dBpf": false,
+            "dTop": false
         }
     kind: ConfigMap
     metadata:
@@ -41913,7 +42065,7 @@ multiple node agents:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 42fec66291e55765ef0dfc023dda6243b349aeedd7bd0cc9fdf2dccee3390125
+            checksum/node-agent-config: 3e0ae483bbe487ebbe9da5f630a486b4014d6ff70c4705477a54a82a810765d7
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -42167,7 +42319,7 @@ multiple node agents:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 42fec66291e55765ef0dfc023dda6243b349aeedd7bd0cc9fdf2dccee3390125
+            checksum/node-agent-config: 3e0ae483bbe487ebbe9da5f630a486b4014d6ff70c4705477a54a82a810765d7
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -48251,7 +48403,26 @@ priority class scheduling:
             },
             "alertDeduplication": {
                 "bypass": false
-            }
+            },
+            "dCapSys": false,
+            "dDns": false,
+            "dExec": false,
+            "dExit": false,
+            "dFork": false,
+            "dHardlink": false,
+            "dHttp": false,
+            "dIouring": false,
+            "dNetwork": false,
+            "dOpen": false,
+            "dPtrace": false,
+            "dRandomx": false,
+            "dSeccomp": false,
+            "dSsh": false,
+            "dSymlink": false,
+            "dKmod": false,
+            "dUnshare": false,
+            "dBpf": false,
+            "dTop": false
         }
     kind: ConfigMap
     metadata:
@@ -48300,7 +48471,7 @@ priority class scheduling:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: dea3d85c79809741877283d857ea833676eddf1c09c5e1e05d17ac1280f49b86
+            checksum/node-agent-config: ae23f990f84f71fdf3f7e943688dd98b1108a409df896497a7b1e1a0c7056ed5
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -52748,7 +52919,26 @@ relevancy only:
             },
             "alertDeduplication": {
                 "bypass": false
-            }
+            },
+            "dCapSys": false,
+            "dDns": false,
+            "dExec": false,
+            "dExit": false,
+            "dFork": false,
+            "dHardlink": false,
+            "dHttp": false,
+            "dIouring": false,
+            "dNetwork": false,
+            "dOpen": false,
+            "dPtrace": false,
+            "dRandomx": false,
+            "dSeccomp": false,
+            "dSsh": false,
+            "dSymlink": false,
+            "dKmod": false,
+            "dUnshare": false,
+            "dBpf": false,
+            "dTop": false
         }
     kind: ConfigMap
     metadata:
@@ -52797,7 +52987,7 @@ relevancy only:
           annotations:
             checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
-            checksum/node-agent-config: d21a289513e8d0ed12d2406997a555e2f3d2397b67f5a80ed478cd510b2560df
+            checksum/node-agent-config: ab9691f440e031c4c9e60adc976744bec228835fe9b91d07ced4c7829918c57e
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -57389,7 +57579,26 @@ skipPersistence enabled:
             },
             "alertDeduplication": {
                 "bypass": false
-            }
+            },
+            "dCapSys": false,
+            "dDns": false,
+            "dExec": false,
+            "dExit": false,
+            "dFork": false,
+            "dHardlink": false,
+            "dHttp": false,
+            "dIouring": false,
+            "dNetwork": false,
+            "dOpen": false,
+            "dPtrace": false,
+            "dRandomx": false,
+            "dSeccomp": false,
+            "dSsh": false,
+            "dSymlink": false,
+            "dKmod": false,
+            "dUnshare": false,
+            "dBpf": false,
+            "dTop": false
         }
     kind: ConfigMap
     metadata:
@@ -57438,7 +57647,7 @@ skipPersistence enabled:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 42fec66291e55765ef0dfc023dda6243b349aeedd7bd0cc9fdf2dccee3390125
+            checksum/node-agent-config: 3e0ae483bbe487ebbe9da5f630a486b4014d6ff70c4705477a54a82a810765d7
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -675,6 +675,27 @@ nodeAgent:
     hostSensor:
       enabled: true
       interval: 5m # duration string
+    # Advanced/debug options for force-disabling individual node-agent tracers.
+    tracers:
+      capSys: enable
+      dns: enable
+      exec: enable
+      exit: enable
+      fork: enable
+      hardlink: enable
+      http: enable
+      iouring: enable
+      network: enable
+      open: enable
+      ptrace: enable
+      randomx: enable
+      seccomp: enable
+      ssh: enable
+      symlink: enable
+      kmod: enable
+      unshare: enable
+      bpf: enable
+      top: enable
 
   # GKE Autopilot allowlist
   gke:


### PR DESCRIPTION
## Overview

This PR adds `execTracer` and `openTracer` configuration options for the node-agent.

Both options are enabled by default to preserve the current behavior. 
They can be disabled to prevent exec and open events from being included in SBOMSyft resources.

The README and Helm unit test snapshots have also been updated.

## Note

There seem to be other options that could be added, but it was unclear which ones should be included. 
Therefore, this PR only adds the options I need.

If you have any suggestions, I can add the other options in a separate PR.

https://github.com/kubescape/node-agent/blob/v0.3.197/docs/CONFIGURATION.md?plain=1#L399-L418


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options to enable or force-disable individual node-agent tracers, including exec and file-open event tracing.
  * Node-agent configuration now records disabled tracer settings.
  * All supported tracers remain enabled by default.
* **Documentation**
  * Added Helm upgrade guidance covering CRD schema changes and manual application steps.
  * Documented new risk-acceptance schema fields and per-tracer configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->