### PR TITLE
fix(node-agent): enable Prometheus OTEL exporter

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/_node-agent.tpl
+++ b/charts/kubescape-operator/templates/node-agent/_node-agent.tpl
@@ -60,6 +60,10 @@ Parameters:
 - name: OTEL_COLLECTOR_SVC
   value: {{ .Values.configurations.otelUrl }}
 {{- end }}
+{{- if eq .Values.nodeAgent.config.prometheusExporter "enable" }}
+- name: OTEL_METRICS_EXPORTER
+  value: "prometheus"
+{{- end }}
 {{- if and .components.clamAV.enabled (not .autoscalerMode) }}
 - name: CLAMAV_SOCKET
   value: "/clamav/clamd.sock"

--- a/charts/kubescape-operator/tests/node_agent_prometheus_exporter_test.yaml
+++ b/charts/kubescape-operator/tests/node_agent_prometheus_exporter_test.yaml
@@ -1,0 +1,79 @@
+suite: node-agent Prometheus exporter OTEL env var
+templates:
+  - configs/components-configmap.yaml
+  - configs/cloudapi-configmap.yaml
+  - configs/cloud-secret.yaml
+  - configs/matchingRules-configmap.yaml
+  - node-agent/configmap.yaml
+  - node-agent/daemonset.yaml
+  - node-agent/template-configmap.yaml
+  - operator/admission-webhook/configmap.yaml
+  - operator/configmap.yaml
+  - proxy-support/proxy-secret.yaml
+  - storage/certgen/configmap.yaml
+  - storage/configmap.yaml
+  - synchronizer/configmap.yaml
+tests:
+  - it: adds OTEL_METRICS_EXPORTER env var to node-agent daemonset when prometheusExporter is enabled
+    template: node-agent/daemonset.yaml
+    set:
+      unittest: true
+      clusterName: kind-kind
+      capabilities.runtimeObservability: enable
+      nodeAgent.config.prometheusExporter: enable
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_METRICS_EXPORTER
+            value: "prometheus"
+
+  - it: does not add OTEL_METRICS_EXPORTER env var by default
+    template: node-agent/daemonset.yaml
+    set:
+      unittest: true
+      clusterName: kind-kind
+      capabilities.runtimeObservability: enable
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_METRICS_EXPORTER
+
+  - it: does not add OTEL_METRICS_EXPORTER env var when explicitly disabled
+    template: node-agent/daemonset.yaml
+    set:
+      unittest: true
+      clusterName: kind-kind
+      capabilities.runtimeObservability: enable
+      nodeAgent.config.prometheusExporter: disable
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_METRICS_EXPORTER
+
+  - it: adds OTEL_METRICS_EXPORTER env var to autoscaler template-configmap when prometheusExporter is enabled
+    template: node-agent/template-configmap.yaml
+    set:
+      unittest: true
+      clusterName: kind-kind
+      capabilities.runtimeObservability: enable
+      nodeAgent.autoscaler.enabled: true
+      nodeAgent.config.prometheusExporter: enable
+    asserts:
+      - matchRegex:
+          path: data["daemonset-template.yaml"]
+          pattern: "- name: OTEL_METRICS_EXPORTER\\s+value: \"prometheus\""
+
+  - it: does not add OTEL_METRICS_EXPORTER env var to autoscaler template-configmap by default
+    template: node-agent/template-configmap.yaml
+    set:
+      unittest: true
+      clusterName: kind-kind
+      capabilities.runtimeObservability: enable
+      nodeAgent.autoscaler.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["daemonset-template.yaml"]
+          pattern: "OTEL_METRICS_EXPORTER"

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -635,6 +635,11 @@ nodeAgent:
     updatePeriod: 10m # duration string
     nodeProfileInterval: 10m # duration string
     networkStreamingInterval: 2m # duration string
+    # -- Enable the in-process OpenTelemetry Prometheus metrics exporter on node-agent port 8080 (/metrics).
+    # NOTE: Enabling this replaces any OTLP metric push configured by configurations.otelUrl with the
+    # Prometheus reader (OTLP traces and logs are unaffected).
+    # To scrape these metrics, also enable nodeAgent.serviceMonitor.enabled or configure Prometheus scraping.
+    # Note: This is distinct from capabilities.prometheusExporter, which deploys a separate Prometheus exporter.
     prometheusExporter: disable
     httpExporterConfig:
       url: http://synchronizer:8089/apis/v1/kubescape.io

--- a/gke-allowlist/armo-kubescape-node-agent-1.40-v2.yaml
+++ b/gke-allowlist/armo-kubescape-node-agent-1.40-v2.yaml
@@ -65,6 +65,7 @@ matchingCriteria:
         - name: KS_LOGGER_LEVEL
         - name: KS_LOGGER_NAME
         - name: OTEL_COLLECTOR_SVC
+        - name: OTEL_METRICS_EXPORTER
         - name: CLAMAV_SOCKET
         - name: SBOM_SCANNER_SOCKET
         - name: SCANNER_MEMORY_LIMIT

--- a/scripts/gke-allowlist/check-drift.sh
+++ b/scripts/gke-allowlist/check-drift.sh
@@ -35,4 +35,5 @@ exec python3 "$HERE/allowlist-drift.py" \
   --set "${prefix}global.httpsProxy=http://proxy:3128" \
   --set "${prefix}global.overrideRuntimePath=/run/containerd/containerd.sock" \
   --set "${prefix}nodeAgent.config.skipKernelVersionCheck=true" \
-  --set "${prefix}nodeAgent.config.malwareScanAllFiles=true"
+  --set "${prefix}nodeAgent.config.malwareScanAllFiles=true" \
+  --set "${prefix}nodeAgent.config.prometheusExporter=enable"


### PR DESCRIPTION
## Overview

Follow-up to #891 / fixes #889.

PR #891 addressed the missing `OTEL_METRICS_EXPORTER=prometheus` environment variable required for the node-agent's in-process Prometheus metrics exporter. The PR was left waiting on the author after review identified an additional GKE Autopilot allowlist blocker.

This PR picks up that work and addresses the original issue together with the maintainer's review feedback.

## Changes

* Add `OTEL_METRICS_EXPORTER=prometheus` to the node-agent environment when `nodeAgent.config.prometheusExporter` is enabled.
* Add `OTEL_METRICS_EXPORTER` to the GKE Autopilot node-agent WorkloadAllowlist.
* Update `check-drift.sh` to enable `nodeAgent.config.prometheusExporter` so the allowlist drift check covers this path.
* Document the Prometheus exporter behavior and its interaction with OTLP metrics and `ServiceMonitor`.
* Add Helm unit tests covering enabled, default, explicitly disabled, and autoscaler configurations.

## Validation

* `helm unittest charts/kubescape-operator` — 92/92 tests passed
* `scripts/gke-allowlist/check-drift.sh charts/kubescape-operator gke-allowlist/armo-kubescape-node-agent-1.40-v2.yaml` — `CLASS: no-op`

Related:

* Original issue: #889
* Previous PR: #891


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional in-process Prometheus metrics exporter for the node agent.
  * When enabled, node-agent metrics are exported to Prometheus instead of using OTLP metric push; traces and logs remain unchanged.
  * Added configuration guidance for enabling the exporter.

* **Bug Fixes**
  * Updated deployment allowlists to permit the new metrics exporter setting.

* **Tests**
  * Added coverage for enabled, disabled, and default exporter configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->