### PR TITLE
[LFX 2026] feat(crds): align SecurityException vulnerability schema with the kubevuln types

### DIFF
--- a/charts/kubescape-operator/README.md
+++ b/charts/kubescape-operator/README.md
@@ -30,6 +30,32 @@ kubescape     operator-5d745b5b84-ts7zq                           1/1     Runnin
 kubescape     storage-59567854fd-hg8n8                            1/1     Running   0               60m
 ```
 
+## Upgrade
+
+`helm upgrade` updates everything in the chart **except** the CRDs under `crds/`. Helm installs those
+once, on first install, and [never touches them again](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/).
+So when a release changes a CRD schema, the cluster keeps the old one: the API server rejects fields it
+does not know about under a strict apply, and silently prunes them otherwise.
+
+If a release notes a CRD change, apply the chart's CRDs yourself before upgrading:
+
+```shell
+helm repo update
+helm pull kubescape/kubescape-operator --untar --untardir /tmp
+kubectl apply --server-side --force-conflicts -f /tmp/kubescape-operator/crds/
+```
+
+Then run the usual `helm upgrade`. Applying the CRDs is safe to repeat and does not touch existing
+custom resources.
+
+> **`capabilities.riskAcceptance`:** the `SecurityException` and `ClusterSecurityException` schemas
+grew per-vulnerability `expiresAt`, `actionStatement`, `response`, `subcomponents`, and the `affected`
+status. Clusters that installed the chart before that change need the apply above, otherwise those
+fields are pruned or rejected.
+
+The CRDs under `templates/` (the node-agent sensing CRDs and `seccompprofiles`) are managed by Helm and
+do upgrade on their own.
+
 ## View results
 
 The scanning results will be available gradually as the scans are completed.

--- a/charts/kubescape-operator/crds/cluster-security-exception.crd.yaml
+++ b/charts/kubescape-operator/crds/cluster-security-exception.crd.yaml
@@ -67,6 +67,8 @@ spec:
                     x-kubernetes-validations:
                       - rule: "self.status != 'not_affected' || has(self.justification)"
                         message: "justification is required when status is not_affected"
+                      - rule: "self.status != 'affected' || has(self.actionStatement)"
+                        message: "actionStatement is required when status is affected"
                     required:
                       - vulnerability
                       - status
@@ -86,6 +88,7 @@ spec:
                         type: string
                         enum:
                           - not_affected
+                          - affected
                           - fixed
                           - under_investigation
                       justification:
@@ -100,6 +103,29 @@ spec:
                         type: string
                       expiredOnFix:
                         type: boolean
+                      # Overrides the document-level spec.expiresAt for this entry only.
+                      expiresAt:
+                        type: string
+                        format: date-time
+                      # Counterpart to impactStatement on the affected path; OpenVEX
+                      # requires an action statement for every affected statement.
+                      actionStatement:
+                        type: string
+                      response:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                            - can_not_fix
+                            - will_not_fix
+                            - update
+                            - rollback
+                            - workaround_available
+                      # Scopes the exception to packages within the matched product, as PURLs.
+                      subcomponents:
+                        type: array
+                        items:
+                          type: string
                 posture:
                   type: array
                   items:

--- a/charts/kubescape-operator/crds/cluster-security-exception.crd.yaml
+++ b/charts/kubescape-operator/crds/cluster-security-exception.crd.yaml
@@ -109,8 +109,11 @@ spec:
                         format: date-time
                       # Counterpart to impactStatement on the affected path; OpenVEX
                       # requires an action statement for every affected statement.
+                      # The pattern rejects blank text: the rule above only checks the
+                      # field is present, and a CEL trim() here blows the rule cost budget.
                       actionStatement:
                         type: string
+                        pattern: '\S'
                       response:
                         type: array
                         items:

--- a/charts/kubescape-operator/crds/security-exception.crd.yaml
+++ b/charts/kubescape-operator/crds/security-exception.crd.yaml
@@ -106,8 +106,11 @@ spec:
                         format: date-time
                       # Counterpart to impactStatement on the affected path; OpenVEX
                       # requires an action statement for every affected statement.
+                      # The pattern rejects blank text: the rule above only checks the
+                      # field is present, and a CEL trim() here blows the rule cost budget.
                       actionStatement:
                         type: string
+                        pattern: '\S'
                       response:
                         type: array
                         items:

--- a/charts/kubescape-operator/crds/security-exception.crd.yaml
+++ b/charts/kubescape-operator/crds/security-exception.crd.yaml
@@ -64,6 +64,8 @@ spec:
                     x-kubernetes-validations:
                       - rule: "self.status != 'not_affected' || has(self.justification)"
                         message: "justification is required when status is not_affected"
+                      - rule: "self.status != 'affected' || has(self.actionStatement)"
+                        message: "actionStatement is required when status is affected"
                     required:
                       - vulnerability
                       - status
@@ -83,6 +85,7 @@ spec:
                         type: string
                         enum:
                           - not_affected
+                          - affected
                           - fixed
                           - under_investigation
                       justification:
@@ -97,6 +100,29 @@ spec:
                         type: string
                       expiredOnFix:
                         type: boolean
+                      # Overrides the document-level spec.expiresAt for this entry only.
+                      expiresAt:
+                        type: string
+                        format: date-time
+                      # Counterpart to impactStatement on the affected path; OpenVEX
+                      # requires an action statement for every affected statement.
+                      actionStatement:
+                        type: string
+                      response:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                            - can_not_fix
+                            - will_not_fix
+                            - update
+                            - rollback
+                            - workaround_available
+                      # Scopes the exception to packages within the matched product, as PURLs.
+                      subcomponents:
+                        type: array
+                        items:
+                          type: string
                 posture:
                   type: array
                   items:


### PR DESCRIPTION
## What

Adds the vulnerability exception fields that kubevuln already reads to both SecurityException CRD schemas.

## Why

I found this while testing the SecurityException feature end to end on a kind cluster. `kubevuln/pkg/securityexception/v1beta1/types.go` has grown five fields that the shipped CRD schema does not know about, so anything a user writes into them either gets dropped on the floor or is refused outright:

- `status: affected` (plus the matching `VulnerabilityResponse` values)
- `actionStatement`
- `response[]`
- `subcomponents[]`
- a per entry `expiresAt` that overrides the document level one, resolved by `effectiveExpiresAt` in `adapters/v1/securityexception.go`

Before this change, on a cluster running the current chart:

```
$ kubectl apply -f se.yaml
Error from server (BadRequest): strict decoding error: unknown field
"spec.vulnerabilities[0].actionStatement", unknown field
"spec.vulnerabilities[0].expiresAt", unknown field
"spec.vulnerabilities[0].response", unknown field
"spec.vulnerabilities[0].subcomponents"

$ kubectl apply --validate=ignore -f se.yaml
securityexception.kubescape.io/probe created
$ kubectl get se probe -o jsonpath='{.spec.vulnerabilities}'
[{"status":"under_investigation","vulnerability":{"id":"CVE-2024-0001"}}]   # all four silently pruned

$ kubectl apply -f affected.yaml
The SecurityException "probe" is invalid: spec.vulnerabilities[0].status:
Unsupported value: "affected": supported values: "not_affected", "fixed", "under_investigation"
```

So the code in kubevuln for `affected` statements, typed responses, subcomponent scoping and per entry expiry is unreachable through the CRD. The schema has not been touched since #859 while kubevuln kept moving.

## Changes

Both `security-exception.crd.yaml` and `cluster-security-exception.crd.yaml`, which carry an identical `vulnerabilities` block:

- `status` enum gains `affected`
- new `expiresAt` (date-time), `actionStatement` (string), `response[]` (enum), `subcomponents[]` (string)
- a new CEL rule, `self.status != 'affected' || has(self.actionStatement)`, mirroring the existing justification rule. OpenVEX requires an action statement on every affected statement, and the kubevuln type comment says the same.

The `response` enum values come straight from the `VulnerabilityResponse` constants: `can_not_fix`, `will_not_fix`, `update`, `rollback`, `workaround_available`.

## Testing

Applied both CRDs to a kind cluster and checked each case by hand.

The five fields now survive a strict apply and read back intact:

```
$ kubectl apply -f verify-new.yaml
securityexception.kubescape.io/verify-newfields created
$ kubectl get se verify-newfields -n production -o jsonpath='{.spec.vulnerabilities}'
[{"actionStatement":"patching in the next release","expiresAt":"2030-01-01T00:00:00Z",
  "response":["will_not_fix"],"status":"affected",
  "subcomponents":["pkg:deb/debian/openssl@3.0.11"],
  "vulnerability":{"aliases":["GHSA-xxxx"],"id":"CVE-2024-0001"}}]
```

Validation still rejects what it should:

```
affected with no actionStatement  -> actionStatement is required when status is affected
not_affected with no justification -> justification is required when status is not_affected
response: ["not_a_real_response"]  -> Unsupported value, supported values: "can_not_fix", ...
```

Backward compatible. An existing exception in the old format is still accepted and still behaves the same. A posture scan with an SE excepting C-0034 on `Deployment/nginx` gives 4 failed out of 6 and a 33.33 compliance score, same as before the schema change.

## Notes

This is schema only, no chart version bump, matching how #859 was done. Related to kubescape/kubescape#1982.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security exceptions can now target specific subcomponents within a product.
  * Added per-vulnerability expiry dates, response actions, and action statements.
  * Added support for the `affected` vulnerability status.
* **Validation**
  * Vulnerabilities marked as `affected` must now include an action statement.
  * Per-vulnerability expiry dates can override the exception’s default expiry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->