### PR TITLE
fix: pin runAsGroup wherever the chart pins runAsUser

### DIFF
--- a/charts/kubescape-operator/templates/grype-offline-db/cronjob.yaml
+++ b/charts/kubescape-operator/templates/grype-offline-db/cronjob.yaml
@@ -54,6 +54,7 @@ spec:
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               runAsUser: 100
+              runAsGroup: 100
               capabilities:
                 drop:
                   - ALL

--- a/charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml
+++ b/charts/kubescape-operator/templates/kubescape-scheduler/cronjob.yaml
@@ -56,6 +56,7 @@ spec:
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               runAsUser: 100
+              runAsGroup: 100
               capabilities:
                 drop:
                   - ALL

--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -58,6 +58,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         runAsUser: 65532
+        runAsGroup: 65532
         fsGroup: 65532
       containers:
       - name: kubescape

--- a/charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml
+++ b/charts/kubescape-operator/templates/kubevuln-scheduler/cronjob.yaml
@@ -56,6 +56,7 @@ spec:
               readOnlyRootFilesystem: true
               runAsNonRoot: true
               runAsUser: 100
+              runAsGroup: 100
               capabilities:
                 drop:
                   - ALL

--- a/charts/kubescape-operator/templates/kubevuln/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubevuln/deployment.yaml
@@ -49,6 +49,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         runAsUser: 65532
+        runAsGroup: 65532
         fsGroup: 65532
       containers:
         - name: {{ .Values.kubevuln.name }}

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -58,6 +58,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         runAsUser: 65532
+        runAsGroup: 65532
         fsGroup: 65532
       {{- if and (eq .Values.capabilities.admissionController "enable") (eq (include "kubescape.certificates.strategy" .) "initContainer") }}
       {{- $admissionName := include "kubescape-admission.name" . }}
@@ -70,6 +71,7 @@ spec:
           imagePullPolicy: {{ .Values.certificates.certgen.image.pullPolicy }}
           securityContext:
             runAsUser: 65532
+            runAsGroup: 65532
             runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
@@ -102,6 +104,7 @@ spec:
           imagePullPolicy: {{ .Values.certificates.certgen.image.pullPolicy }}
           securityContext:
             runAsUser: 65532
+            runAsGroup: 65532
             runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         runAsUser: 65532
+        runAsGroup: 65532
         fsGroup: 65532
       containers:
         - name: {{ .Values.prometheusExporter.name }}

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -56,6 +56,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         runAsUser: 65532
+        runAsGroup: 65532
         fsGroup: 65532
       {{- if and .Values.storage.mtls.enabled (eq (include "kubescape.certificates.strategy" .) "initContainer") }}
       {{- $certgenImage := printf "%s:%s" .Values.certificates.certgen.image.repository (.Values.certificates.certgen.image.tag | toString) }}
@@ -67,6 +68,7 @@ spec:
           imagePullPolicy: {{ .Values.certificates.certgen.image.pullPolicy }}
           securityContext:
             runAsUser: 65532
+            runAsGroup: 65532
             runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
@@ -99,6 +101,7 @@ spec:
           imagePullPolicy: {{ .Values.certificates.certgen.image.pullPolicy }}
           securityContext:
             runAsUser: 65532
+            runAsGroup: 65532
             runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -50,6 +50,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         runAsUser: 65532
+        runAsGroup: 65532
         fsGroup: 65532
       containers:
         - name: {{ .Values.synchronizer.name }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -448,6 +448,7 @@ all capabilities:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
               imagePullSecrets:
@@ -774,6 +775,7 @@ all capabilities:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -1343,6 +1345,7 @@ all capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -1721,6 +1724,7 @@ all capabilities:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -2026,6 +2030,7 @@ all capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -4522,6 +4527,7 @@ all capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -5219,6 +5225,7 @@ all capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -5667,6 +5674,7 @@ all capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -6893,6 +6901,7 @@ all capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -7379,6 +7388,7 @@ autoscaler mode with sbom sidecar:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -7839,6 +7849,7 @@ autoscaler mode with sbom sidecar:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -8076,6 +8087,7 @@ autoscaler mode with sbom sidecar:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -8280,6 +8292,7 @@ autoscaler mode with sbom sidecar:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -9508,6 +9521,7 @@ autoscaler mode with sbom sidecar:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -10259,6 +10273,7 @@ autoscaler mode with sbom sidecar:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -11302,6 +11317,7 @@ autoscaler mode with sbom sidecar:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -11689,6 +11705,7 @@ autoscaler mode without sbom sidecar:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -12149,6 +12166,7 @@ autoscaler mode without sbom sidecar:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -12386,6 +12404,7 @@ autoscaler mode without sbom sidecar:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -12590,6 +12609,7 @@ autoscaler mode without sbom sidecar:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -13818,6 +13838,7 @@ autoscaler mode without sbom sidecar:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -14569,6 +14590,7 @@ autoscaler mode without sbom sidecar:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -15612,6 +15634,7 @@ autoscaler mode without sbom sidecar:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -16001,6 +16024,7 @@ backend-storage enabled allows scanning capabilities:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -16461,6 +16485,7 @@ backend-storage enabled allows scanning capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -16698,6 +16723,7 @@ backend-storage enabled allows scanning capabilities:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -16902,6 +16928,7 @@ backend-storage enabled allows scanning capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -19107,6 +19134,7 @@ backend-storage enabled allows scanning capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -19843,6 +19871,7 @@ backend-storage enabled allows scanning capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -20886,6 +20915,7 @@ backend-storage enabled allows scanning capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -21155,6 +21185,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -21316,6 +21347,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -21472,6 +21504,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -21760,6 +21793,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                 capabilities:
                   drop:
                     - ALL
+                runAsGroup: 65532
                 runAsNonRoot: true
                 runAsUser: 65532
               volumeMounts:
@@ -21793,6 +21827,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                 capabilities:
                   drop:
                     - ALL
+                runAsGroup: 65532
                 runAsNonRoot: true
                 runAsUser: 65532
               volumeMounts:
@@ -21803,6 +21838,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -22179,6 +22215,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                 capabilities:
                   drop:
                     - ALL
+                runAsGroup: 65532
                 runAsNonRoot: true
                 runAsUser: 65532
               volumeMounts:
@@ -22212,6 +22249,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                 capabilities:
                   drop:
                     - ALL
+                runAsGroup: 65532
                 runAsNonRoot: true
                 runAsUser: 65532
               volumeMounts:
@@ -22222,6 +22260,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -22389,6 +22428,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -22759,6 +22799,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                 capabilities:
                   drop:
                     - ALL
+                runAsGroup: 65532
                 runAsNonRoot: true
                 runAsUser: 65532
               volumeMounts:
@@ -22792,6 +22833,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                 capabilities:
                   drop:
                     - ALL
+                runAsGroup: 65532
                 runAsNonRoot: true
                 runAsUser: 65532
               volumeMounts:
@@ -22802,6 +22844,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -23096,6 +23139,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                 capabilities:
                   drop:
                     - ALL
+                runAsGroup: 65532
                 runAsNonRoot: true
                 runAsUser: 65532
               volumeMounts:
@@ -23129,6 +23173,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                 capabilities:
                   drop:
                     - ALL
+                runAsGroup: 65532
                 runAsNonRoot: true
                 runAsUser: 65532
               volumeMounts:
@@ -23139,6 +23184,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -23301,6 +23347,7 @@ cert strategy template, admission disabled, mtls disabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -23462,6 +23509,7 @@ cert strategy template, admission disabled, mtls disabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -23618,6 +23666,7 @@ cert strategy template, admission disabled, mtls enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -23828,6 +23877,7 @@ cert strategy template, admission disabled, mtls enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -24123,6 +24173,7 @@ cert strategy template, admission enabled, mtls disabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -24287,6 +24338,7 @@ cert strategy template, admission enabled, mtls disabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -24579,6 +24631,7 @@ cert strategy template, admission enabled, mtls enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -24792,6 +24845,7 @@ cert strategy template, admission enabled, mtls enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -25238,6 +25292,7 @@ default capabilities:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -25753,6 +25808,7 @@ default capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -26094,6 +26150,7 @@ default capabilities:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -26353,6 +26410,7 @@ default capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -28554,6 +28612,7 @@ default capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -29399,6 +29458,7 @@ default capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -30503,6 +30563,7 @@ default capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -30955,6 +31016,7 @@ disable otel:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -31415,6 +31477,7 @@ disable otel:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -31652,6 +31715,7 @@ disable otel:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -31856,6 +31920,7 @@ disable otel:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -33285,6 +33350,7 @@ disable otel:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -34021,6 +34087,7 @@ disable otel:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -35064,6 +35131,7 @@ disable otel:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -35457,6 +35525,7 @@ minimal capabilities:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -35913,6 +35982,7 @@ minimal capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -36150,6 +36220,7 @@ minimal capabilities:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -36352,6 +36423,7 @@ minimal capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -37778,6 +37850,7 @@ minimal capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -38514,6 +38587,7 @@ minimal capabilities:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -39408,6 +39482,7 @@ multiple node agents:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
               imagePullSecrets:
@@ -39734,6 +39809,7 @@ multiple node agents:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -40303,6 +40379,7 @@ multiple node agents:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -40681,6 +40758,7 @@ multiple node agents:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -40986,6 +41064,7 @@ multiple node agents:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -43737,6 +43816,7 @@ multiple node agents:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -44434,6 +44514,7 @@ multiple node agents:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -44882,6 +44963,7 @@ multiple node agents:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -46108,6 +46190,7 @@ multiple node agents:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -46594,6 +46677,7 @@ priority class scheduling:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -47056,6 +47140,7 @@ priority class scheduling:
           priorityClassName: kubescape-priority
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -47293,6 +47378,7 @@ priority class scheduling:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -47499,6 +47585,7 @@ priority class scheduling:
           priorityClassName: global-priority
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -48929,6 +49016,7 @@ priority class scheduling:
           priorityClassName: global-priority
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -49666,6 +49754,7 @@ priority class scheduling:
           priorityClassName: global-priority
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -50710,6 +50799,7 @@ priority class scheduling:
           priorityClassName: global-priority
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -51096,6 +51186,7 @@ relevancy only:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -51552,6 +51643,7 @@ relevancy only:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -51789,6 +51881,7 @@ relevancy only:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -51991,6 +52084,7 @@ relevancy only:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -53281,6 +53375,7 @@ relevancy only:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -54014,6 +54109,7 @@ relevancy only:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -54908,6 +55004,7 @@ skipPersistence enabled:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
               imagePullSecrets:
@@ -55234,6 +55331,7 @@ skipPersistence enabled:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -55803,6 +55901,7 @@ skipPersistence enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -56184,6 +56283,7 @@ skipPersistence enabled:
                       drop:
                         - ALL
                     readOnlyRootFilesystem: true
+                    runAsGroup: 100
                     runAsNonRoot: true
                     runAsUser: 100
                   volumeMounts:
@@ -56489,6 +56589,7 @@ skipPersistence enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -58985,6 +59086,7 @@ skipPersistence enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -59682,6 +59784,7 @@ skipPersistence enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -60130,6 +60233,7 @@ skipPersistence enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
@@ -61356,6 +61460,7 @@ skipPersistence enabled:
             kubernetes.io/os: linux
           securityContext:
             fsGroup: 65532
+            runAsGroup: 65532
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault


### PR DESCRIPTION
The chart fails its own **C-0013 (non-root containers)** on almost every component it deploys.

The rule resolves `runAsGroup` from the container context, then the pod context, then defaults to 0. No `securityContext` in this chart sets it except the autoupdater CronJob, even where `runAsUser` is set right next to it.

PR #897 closed the same self-scan gap for capabilities.

This adds the matching `runAsGroup` to all 13 sites, each taking the `runAsUser` already
on that context:

| Site | Context | Value |
|---|---|---|
| `kubescape`, `kubevuln`, `operator`, `prometheus-exporter`, `storage`, `synchronizer` | pod | 65532 |
| `operator` ×2, `storage` ×2 | certgen init container | 65532 |
| `grype-offline-db`, `kubescape-scheduler`, `kubevuln-scheduler` | CronJob container | 100 |

The node-agent keeps `runAsUser: 0` and is untouched. `fsGroup` does not cover this:
it adds a supplementary group and leaves the primary GID alone.

Where the pod sets `runAsUser: 65532` the group already resolves to 65532 from the image, so pinning is a formality. Where a *container* sets `runAsUser: 100`, the uid overrides the image's user, nothing resolves the group, and it falls back to root. `/proc/<pid>/status` for a running `kubescape-scheduler`:

```
Name:   http_request
Uid:    100     100     100     100
Gid:    0       0       0       0
Groups: 0
```

`kubevuln-scheduler` shares that image and context; `grype-offline-db`'s rollout has the
same `runAsUser: 100` over a different image. So three CronJob containers run as group
root today.

`runAsUser: 100` matches no user in the `http-request` image, whose `USER` is `nonroot`
(65532). I kept each context internally consistent with `runAsGroup: 100`, but if the
intent was the image's own user, it should be 65532 in both fields. Happy to switch.

The `grype-offline-db` Deployment sets no `runAsUser` at all, so there is no user there to
match a group to, and it is left alone.

## How to Test

```
helm unittest charts/kubescape-operator/
```

105 tests and 993 snapshots pass. The snapshot diff is 105 added `runAsGroup` lines, no removals and nothing else.

## Related issues/PRs:

* Follows #897, which closed the capabilities half of the same self-scan gap.
* Related: #740 asked for configurable securityContexts.
  As with #897, the hardcoded contexts were nearly complete already, so finishing them closes these rows without a knob.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests. — not a core feature; the
  existing snapshot suite covers every added line
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - Added explicit group IDs to operator components, scheduled jobs, and supporting services.
  - Improved consistency between configured user and group identities.
  - Ensured workloads and certificate-generation processes run with defined non-root group permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->