### PR TITLE
fix: bump kubescape scanner to v4.0.12 to unbreak standalone configuration scanning

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -15,14 +15,14 @@ kubeVersion: ">=1.28.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.40.3
+version: 1.40.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.40.3
+appVersion: 1.40.4
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 all capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.3.
+      Thank you for installing kubescape-operator version 1.40.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -35,8 +35,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -55,8 +55,8 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
-                helm.sh/chart: kubescape-operator-1.40.3
+                app.kubernetes.io/version: 1.40.4
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -117,8 +117,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -161,8 +161,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -186,8 +186,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -212,8 +212,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -233,8 +233,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -281,8 +281,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -311,8 +311,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -332,8 +332,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -355,8 +355,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -376,8 +376,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -394,9 +394,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -416,9 +416,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -476,8 +476,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -507,9 +507,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
+            app.kubernetes.io/version: 1.40.4
             bar: baz
-            helm.sh/chart: kubescape-operator-1.40.3
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -568,8 +568,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -603,8 +603,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -628,8 +628,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -653,8 +653,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -681,8 +681,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -701,8 +701,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -720,9 +720,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -742,9 +742,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -811,8 +811,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -863,8 +863,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1149,8 +1149,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1174,8 +1174,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1207,8 +1207,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1281,7 +1281,7 @@ all capabilities:
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v4.0.11
+              image: quay.io/kubescape/kubescape:v4.0.12
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -1390,8 +1390,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1409,8 +1409,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1486,8 +1486,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1517,8 +1517,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1543,8 +1543,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -1569,8 +1569,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1599,8 +1599,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1617,8 +1617,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -1650,8 +1650,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1669,9 +1669,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1691,9 +1691,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -1760,8 +1760,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -1812,8 +1812,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1886,8 +1886,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1911,8 +1911,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1941,8 +1941,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -2071,8 +2071,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2128,8 +2128,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -2152,8 +2152,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -2178,8 +2178,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2207,8 +2207,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2594,8 +2594,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-gke-allowlist
@@ -2614,8 +2614,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2770,8 +2770,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2842,8 +2842,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2861,8 +2861,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2889,9 +2889,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
+            app.kubernetes.io/version: 1.40.4
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.3
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -3114,8 +3114,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -3165,8 +3165,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -3887,8 +3887,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -3946,8 +3946,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -3972,8 +3972,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -4000,8 +4000,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -4022,8 +4022,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -4045,8 +4045,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -4064,8 +4064,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -4091,8 +4091,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -4148,8 +4148,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4307,8 +4307,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4366,8 +4366,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4385,8 +4385,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4421,8 +4421,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -4436,7 +4436,7 @@ all capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -4653,8 +4653,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4741,8 +4741,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4760,8 +4760,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4925,8 +4925,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4944,8 +4944,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4988,8 +4988,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5014,8 +5014,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -5040,8 +5040,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5069,8 +5069,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5086,8 +5086,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5114,8 +5114,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5139,8 +5139,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5165,8 +5165,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -5250,8 +5250,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5308,8 +5308,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5336,8 +5336,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5354,8 +5354,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5390,8 +5390,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -5409,8 +5409,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -5435,8 +5435,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5501,8 +5501,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -5526,8 +5526,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5564,8 +5564,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5583,8 +5583,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5612,8 +5612,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -5708,8 +5708,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5767,8 +5767,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -5791,8 +5791,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -5817,8 +5817,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -5842,8 +5842,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -6166,8 +6166,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -6195,8 +6195,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -6213,8 +6213,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6452,8 +6452,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6773,8 +6773,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6792,8 +6792,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6823,8 +6823,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -6836,7 +6836,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -6941,8 +6941,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7008,8 +7008,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7051,8 +7051,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7076,8 +7076,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -7101,8 +7101,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7129,8 +7129,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7138,7 +7138,7 @@ all capabilities:
 autoscaler mode with sbom sidecar:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.3.
+      Thank you for installing kubescape-operator version 1.40.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -7174,8 +7174,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -7221,8 +7221,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -7251,8 +7251,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7273,8 +7273,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7294,8 +7294,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -7314,8 +7314,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7333,9 +7333,9 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7355,9 +7355,9 @@ autoscaler mode with sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -7422,8 +7422,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7692,8 +7692,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7717,8 +7717,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7749,8 +7749,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -7794,7 +7794,7 @@ autoscaler mode with sbom sidecar:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.11
+              image: quay.io/kubescape/kubescape:v4.0.12
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -7888,8 +7888,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7907,8 +7907,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7938,8 +7938,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7964,8 +7964,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7994,8 +7994,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -8013,8 +8013,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8032,9 +8032,9 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8054,9 +8054,9 @@ autoscaler mode with sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -8121,8 +8121,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8162,8 +8162,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8187,8 +8187,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8216,8 +8216,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -8326,8 +8326,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8355,8 +8355,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8742,8 +8742,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8898,8 +8898,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8970,8 +8970,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8989,8 +8989,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -9017,8 +9017,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -9026,7 +9026,7 @@ autoscaler mode with sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: dea3d85c79809741877283d857ea833676eddf1c09c5e1e05d17ac1280f49b86\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.158\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: dea3d85c79809741877283d857ea833676eddf1c09c5e1e05d17ac1280f49b86\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.158\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -9037,8 +9037,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9060,8 +9060,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -9083,8 +9083,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -9102,8 +9102,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -9129,8 +9129,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -9186,8 +9186,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9312,8 +9312,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9371,8 +9371,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9390,8 +9390,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9425,8 +9425,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -9440,7 +9440,7 @@ autoscaler mode with sbom sidecar:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -9641,8 +9641,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9726,8 +9726,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9811,8 +9811,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9830,8 +9830,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9886,8 +9886,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9912,8 +9912,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9941,8 +9941,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9959,8 +9959,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -9989,8 +9989,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -10012,8 +10012,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -10031,8 +10031,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10097,8 +10097,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -10122,8 +10122,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10163,8 +10163,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10182,8 +10182,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10211,8 +10211,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -10310,8 +10310,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -10334,8 +10334,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -10359,8 +10359,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -10683,8 +10683,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10712,8 +10712,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10730,8 +10730,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10900,8 +10900,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11203,8 +11203,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11222,8 +11222,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11252,8 +11252,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -11265,7 +11265,7 @@ autoscaler mode with sbom sidecar:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -11350,8 +11350,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11393,8 +11393,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11418,8 +11418,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11446,8 +11446,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11455,7 +11455,7 @@ autoscaler mode with sbom sidecar:
 autoscaler mode without sbom sidecar:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.3.
+      Thank you for installing kubescape-operator version 1.40.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -11491,8 +11491,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -11538,8 +11538,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -11568,8 +11568,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11590,8 +11590,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11611,8 +11611,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -11631,8 +11631,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11650,9 +11650,9 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11672,9 +11672,9 @@ autoscaler mode without sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11739,8 +11739,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12009,8 +12009,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12034,8 +12034,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12066,8 +12066,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -12111,7 +12111,7 @@ autoscaler mode without sbom sidecar:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.11
+              image: quay.io/kubescape/kubescape:v4.0.12
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -12205,8 +12205,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12224,8 +12224,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12255,8 +12255,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12281,8 +12281,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12311,8 +12311,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12330,8 +12330,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12349,9 +12349,9 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12371,9 +12371,9 @@ autoscaler mode without sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -12438,8 +12438,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12479,8 +12479,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12504,8 +12504,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12533,8 +12533,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -12643,8 +12643,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12672,8 +12672,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -13059,8 +13059,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13215,8 +13215,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13287,8 +13287,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13306,8 +13306,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13334,8 +13334,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13343,7 +13343,7 @@ autoscaler mode without sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.3\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.3\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: dea3d85c79809741877283d857ea833676eddf1c09c5e1e05d17ac1280f49b86\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.3\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.3\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.158\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: dea3d85c79809741877283d857ea833676eddf1c09c5e1e05d17ac1280f49b86\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.158\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.158\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -13354,8 +13354,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13377,8 +13377,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -13400,8 +13400,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -13419,8 +13419,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -13446,8 +13446,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -13503,8 +13503,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13629,8 +13629,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13688,8 +13688,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13707,8 +13707,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13742,8 +13742,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -13757,7 +13757,7 @@ autoscaler mode without sbom sidecar:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -13958,8 +13958,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14043,8 +14043,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14128,8 +14128,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14147,8 +14147,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14203,8 +14203,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14229,8 +14229,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14258,8 +14258,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14276,8 +14276,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -14306,8 +14306,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -14329,8 +14329,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -14348,8 +14348,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14414,8 +14414,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -14439,8 +14439,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14480,8 +14480,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14499,8 +14499,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14528,8 +14528,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -14627,8 +14627,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -14651,8 +14651,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -14676,8 +14676,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -15000,8 +15000,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -15029,8 +15029,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -15047,8 +15047,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15217,8 +15217,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15520,8 +15520,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15539,8 +15539,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15569,8 +15569,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15582,7 +15582,7 @@ autoscaler mode without sbom sidecar:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -15667,8 +15667,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15710,8 +15710,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15735,8 +15735,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15763,8 +15763,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15772,7 +15772,7 @@ autoscaler mode without sbom sidecar:
 backend-storage enabled allows scanning capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.3.
+      Thank you for installing kubescape-operator version 1.40.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -15810,8 +15810,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -15857,8 +15857,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -15887,8 +15887,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15909,8 +15909,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15930,8 +15930,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -15950,8 +15950,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15969,9 +15969,9 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15991,9 +15991,9 @@ backend-storage enabled allows scanning capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -16058,8 +16058,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -16328,8 +16328,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -16353,8 +16353,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16385,8 +16385,8 @@ backend-storage enabled allows scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16430,7 +16430,7 @@ backend-storage enabled allows scanning capabilities:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease
-              image: quay.io/kubescape/kubescape:v4.0.11
+              image: quay.io/kubescape/kubescape:v4.0.12
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16524,8 +16524,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16543,8 +16543,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -16574,8 +16574,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -16600,8 +16600,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -16630,8 +16630,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -16649,8 +16649,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16668,9 +16668,9 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16690,9 +16690,9 @@ backend-storage enabled allows scanning capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -16757,8 +16757,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -16798,8 +16798,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -16823,8 +16823,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16852,8 +16852,8 @@ backend-storage enabled allows scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16962,8 +16962,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -16991,8 +16991,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -17378,8 +17378,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -17534,8 +17534,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -17606,8 +17606,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17625,8 +17625,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17652,8 +17652,8 @@ backend-storage enabled allows scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17850,8 +17850,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -17904,8 +17904,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -18626,8 +18626,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -18654,8 +18654,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -18676,8 +18676,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -18699,8 +18699,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -18718,8 +18718,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -18745,8 +18745,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -18802,8 +18802,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18928,8 +18928,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -18987,8 +18987,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19006,8 +19006,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19041,8 +19041,8 @@ backend-storage enabled allows scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19056,7 +19056,7 @@ backend-storage enabled allows scanning capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19251,8 +19251,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19336,8 +19336,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19421,8 +19421,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19440,8 +19440,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -19484,8 +19484,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -19510,8 +19510,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -19539,8 +19539,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -19557,8 +19557,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -19587,8 +19587,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -19610,8 +19610,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -19629,8 +19629,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -19695,8 +19695,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -19720,8 +19720,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -19761,8 +19761,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19780,8 +19780,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19809,8 +19809,8 @@ backend-storage enabled allows scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19908,8 +19908,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -19932,8 +19932,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -19957,8 +19957,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -20281,8 +20281,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -20310,8 +20310,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -20328,8 +20328,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -20498,8 +20498,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -20801,8 +20801,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20820,8 +20820,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20850,8 +20850,8 @@ backend-storage enabled allows scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20863,7 +20863,7 @@ backend-storage enabled allows scanning capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -20948,8 +20948,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -20991,8 +20991,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -21016,8 +21016,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -21044,8 +21044,8 @@ backend-storage enabled allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -21063,8 +21063,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21098,8 +21098,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21113,7 +21113,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -21233,8 +21233,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -21259,8 +21259,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21288,8 +21288,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21382,8 +21382,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21417,8 +21417,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21432,7 +21432,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -21552,8 +21552,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -21577,8 +21577,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -21602,8 +21602,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -21627,8 +21627,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -21653,8 +21653,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -21679,8 +21679,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21709,8 +21709,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21879,8 +21879,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -21904,8 +21904,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -21929,8 +21929,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21955,8 +21955,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -21981,8 +21981,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22008,8 +22008,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22064,8 +22064,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22100,8 +22100,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22115,7 +22115,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -22314,8 +22314,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -22340,8 +22340,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22369,8 +22369,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22463,8 +22463,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -22488,8 +22488,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -22513,8 +22513,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22539,8 +22539,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22565,8 +22565,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22592,8 +22592,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -22648,8 +22648,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -22684,8 +22684,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22699,7 +22699,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -22898,8 +22898,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -22923,8 +22923,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -22948,8 +22948,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -22973,8 +22973,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -22999,8 +22999,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -23025,8 +23025,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23055,8 +23055,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23225,8 +23225,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23260,8 +23260,8 @@ cert strategy template, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23275,7 +23275,7 @@ cert strategy template, admission disabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -23395,8 +23395,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -23421,8 +23421,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23450,8 +23450,8 @@ cert strategy template, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23544,8 +23544,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23579,8 +23579,8 @@ cert strategy template, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23594,7 +23594,7 @@ cert strategy template, admission disabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -23714,8 +23714,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -23744,8 +23744,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -23767,8 +23767,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -23786,8 +23786,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23815,8 +23815,8 @@ cert strategy template, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23919,8 +23919,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -23942,8 +23942,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -23961,8 +23961,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -23988,8 +23988,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -24045,8 +24045,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24080,8 +24080,8 @@ cert strategy template, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24095,7 +24095,7 @@ cert strategy template, admission enabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -24224,8 +24224,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -24250,8 +24250,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24279,8 +24279,8 @@ cert strategy template, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24377,8 +24377,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -24400,8 +24400,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -24419,8 +24419,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -24446,8 +24446,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -24503,8 +24503,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24538,8 +24538,8 @@ cert strategy template, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24553,7 +24553,7 @@ cert strategy template, admission enabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -24682,8 +24682,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -24712,8 +24712,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -24735,8 +24735,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -24754,8 +24754,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24783,8 +24783,8 @@ cert strategy template, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24873,7 +24873,7 @@ cert strategy template, admission enabled, mtls enabled:
 default capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.3.
+      Thank you for installing kubescape-operator version 1.40.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -24909,8 +24909,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -24957,8 +24957,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -24987,8 +24987,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25009,8 +25009,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25030,8 +25030,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -25048,8 +25048,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25078,8 +25078,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -25135,8 +25135,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -25170,8 +25170,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -25198,8 +25198,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -25218,8 +25218,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25237,9 +25237,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25259,9 +25259,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -25325,8 +25325,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -25371,8 +25371,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -25641,8 +25641,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -25666,8 +25666,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25699,8 +25699,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -25744,7 +25744,7 @@ default capabilities:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.11
+              image: quay.io/kubescape/kubescape:v4.0.12
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -25853,8 +25853,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25872,8 +25872,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -25938,8 +25938,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -25969,8 +25969,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -25995,8 +25995,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -26025,8 +26025,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -26043,8 +26043,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -26076,8 +26076,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26095,9 +26095,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26117,9 +26117,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -26183,8 +26183,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -26229,8 +26229,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -26270,8 +26270,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -26295,8 +26295,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26325,8 +26325,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -26450,8 +26450,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -26501,8 +26501,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -26530,8 +26530,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -26917,8 +26917,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -27073,8 +27073,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -27145,8 +27145,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27164,8 +27164,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27192,8 +27192,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -27408,8 +27408,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -27465,8 +27465,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -28187,8 +28187,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -28230,8 +28230,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -28258,8 +28258,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -28276,8 +28276,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -28402,8 +28402,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -28461,8 +28461,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28480,8 +28480,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28516,8 +28516,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -28531,7 +28531,7 @@ default capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -28732,8 +28732,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28817,8 +28817,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28836,8 +28836,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -28984,8 +28984,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29003,8 +29003,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -29047,8 +29047,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -29073,8 +29073,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -29102,8 +29102,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -29125,8 +29125,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -29144,8 +29144,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -29174,8 +29174,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -29197,8 +29197,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -29216,8 +29216,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -29282,8 +29282,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -29307,8 +29307,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -29348,8 +29348,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29367,8 +29367,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29396,8 +29396,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -29495,8 +29495,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -29546,8 +29546,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -29570,8 +29570,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -29595,8 +29595,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -29919,8 +29919,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -29948,8 +29948,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -29966,8 +29966,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -30136,8 +30136,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -30439,8 +30439,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30458,8 +30458,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30489,8 +30489,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -30502,7 +30502,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -30603,8 +30603,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -30659,8 +30659,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -30702,8 +30702,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -30727,8 +30727,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -30755,8 +30755,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -30764,7 +30764,7 @@ default capabilities:
 disable otel:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.3.
+      Thank you for installing kubescape-operator version 1.40.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -30802,8 +30802,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -30849,8 +30849,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -30879,8 +30879,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30901,8 +30901,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30922,8 +30922,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -30942,8 +30942,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30961,9 +30961,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30983,9 +30983,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -31050,8 +31050,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -31320,8 +31320,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -31345,8 +31345,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31377,8 +31377,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -31422,7 +31422,7 @@ disable otel:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.11
+              image: quay.io/kubescape/kubescape:v4.0.12
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -31516,8 +31516,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31535,8 +31535,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -31566,8 +31566,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -31592,8 +31592,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -31622,8 +31622,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -31641,8 +31641,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31660,9 +31660,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31682,9 +31682,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -31749,8 +31749,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -31790,8 +31790,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -31815,8 +31815,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31844,8 +31844,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -31954,8 +31954,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -31983,8 +31983,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -32370,8 +32370,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -32526,8 +32526,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -32598,8 +32598,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32617,8 +32617,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -32644,8 +32644,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -32842,8 +32842,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -32870,8 +32870,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -32892,8 +32892,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -32915,8 +32915,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -32934,8 +32934,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -32961,8 +32961,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -33018,8 +33018,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -33144,8 +33144,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -33203,8 +33203,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33222,8 +33222,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33257,8 +33257,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -33272,7 +33272,7 @@ disable otel:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -33467,8 +33467,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33552,8 +33552,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33637,8 +33637,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33656,8 +33656,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -33700,8 +33700,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -33726,8 +33726,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -33755,8 +33755,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -33773,8 +33773,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -33803,8 +33803,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -33826,8 +33826,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -33845,8 +33845,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -33911,8 +33911,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -33936,8 +33936,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -33977,8 +33977,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33996,8 +33996,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34025,8 +34025,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -34124,8 +34124,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -34148,8 +34148,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -34173,8 +34173,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -34497,8 +34497,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -34526,8 +34526,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -34544,8 +34544,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -34714,8 +34714,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -35017,8 +35017,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35036,8 +35036,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35066,8 +35066,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -35079,7 +35079,7 @@ disable otel:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -35164,8 +35164,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -35207,8 +35207,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -35232,8 +35232,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -35260,8 +35260,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -35269,7 +35269,7 @@ disable otel:
 minimal capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.3.
+      Thank you for installing kubescape-operator version 1.40.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -35311,8 +35311,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -35358,8 +35358,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -35388,8 +35388,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35410,8 +35410,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35431,8 +35431,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -35451,8 +35451,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35470,9 +35470,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35492,9 +35492,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -35559,8 +35559,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -35829,8 +35829,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -35854,8 +35854,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35886,8 +35886,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -35927,7 +35927,7 @@ minimal capabilities:
                   value: /home/nonroot/.kubescape/host-scanner.yaml
                 - name: LARGE_CLUSTER_SIZE
                   value: "1500"
-              image: quay.io/kubescape/kubescape:v4.0.11
+              image: quay.io/kubescape/kubescape:v4.0.12
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -36021,8 +36021,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36040,8 +36040,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -36071,8 +36071,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -36097,8 +36097,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -36127,8 +36127,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -36146,8 +36146,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36165,9 +36165,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36187,9 +36187,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -36254,8 +36254,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -36295,8 +36295,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -36320,8 +36320,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36349,8 +36349,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -36457,8 +36457,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -36486,8 +36486,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -36873,8 +36873,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -37029,8 +37029,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -37099,8 +37099,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37118,8 +37118,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37145,8 +37145,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -37344,8 +37344,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -37372,8 +37372,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -37394,8 +37394,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -37417,8 +37417,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -37436,8 +37436,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -37463,8 +37463,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -37520,8 +37520,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37646,8 +37646,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37703,8 +37703,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37722,8 +37722,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37757,8 +37757,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -37772,7 +37772,7 @@ minimal capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -37967,8 +37967,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38052,8 +38052,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38137,8 +38137,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38156,8 +38156,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -38200,8 +38200,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -38226,8 +38226,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -38255,8 +38255,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -38273,8 +38273,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -38303,8 +38303,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -38326,8 +38326,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -38345,8 +38345,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -38411,8 +38411,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -38436,8 +38436,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -38477,8 +38477,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38496,8 +38496,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38525,8 +38525,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -38624,8 +38624,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -38648,8 +38648,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -38673,8 +38673,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -38997,8 +38997,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -39026,8 +39026,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -39035,7 +39035,7 @@ minimal capabilities:
 multiple node agents:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.3.
+      Thank you for installing kubescape-operator version 1.40.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -39069,8 +39069,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -39089,8 +39089,8 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
-                helm.sh/chart: kubescape-operator-1.40.3
+                app.kubernetes.io/version: 1.40.4
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -39151,8 +39151,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -39195,8 +39195,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -39220,8 +39220,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -39246,8 +39246,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -39267,8 +39267,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -39315,8 +39315,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -39345,8 +39345,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39366,8 +39366,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -39389,8 +39389,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39410,8 +39410,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -39428,9 +39428,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39450,9 +39450,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -39510,8 +39510,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39541,9 +39541,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
+            app.kubernetes.io/version: 1.40.4
             bar: baz
-            helm.sh/chart: kubescape-operator-1.40.3
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -39602,8 +39602,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -39637,8 +39637,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -39662,8 +39662,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -39687,8 +39687,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -39715,8 +39715,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -39735,8 +39735,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39754,9 +39754,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39776,9 +39776,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -39845,8 +39845,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -39897,8 +39897,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40183,8 +40183,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40208,8 +40208,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40241,8 +40241,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -40315,7 +40315,7 @@ multiple node agents:
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v4.0.11
+              image: quay.io/kubescape/kubescape:v4.0.12
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -40424,8 +40424,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40443,8 +40443,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40520,8 +40520,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40551,8 +40551,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40577,8 +40577,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -40603,8 +40603,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40633,8 +40633,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40651,8 +40651,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -40684,8 +40684,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40703,9 +40703,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40725,9 +40725,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -40794,8 +40794,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -40846,8 +40846,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -40920,8 +40920,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -40945,8 +40945,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40975,8 +40975,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -41105,8 +41105,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -41162,8 +41162,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -41186,8 +41186,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -41212,8 +41212,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -41241,8 +41241,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -41628,8 +41628,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-gke-allowlist
@@ -41648,8 +41648,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -41804,8 +41804,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -41876,8 +41876,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -41895,8 +41895,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -41923,9 +41923,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
+            app.kubernetes.io/version: 1.40.4
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.3
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -42149,8 +42149,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42177,9 +42177,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
+            app.kubernetes.io/version: 1.40.4
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.3
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -42403,8 +42403,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -42454,8 +42454,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -43176,8 +43176,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -43235,8 +43235,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -43261,8 +43261,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -43289,8 +43289,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -43311,8 +43311,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -43334,8 +43334,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -43353,8 +43353,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -43380,8 +43380,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -43437,8 +43437,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -43596,8 +43596,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -43655,8 +43655,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43674,8 +43674,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43710,8 +43710,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -43725,7 +43725,7 @@ multiple node agents:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -43942,8 +43942,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44030,8 +44030,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44049,8 +44049,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -44214,8 +44214,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44233,8 +44233,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -44277,8 +44277,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -44303,8 +44303,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -44329,8 +44329,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -44358,8 +44358,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -44375,8 +44375,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44403,8 +44403,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44428,8 +44428,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44454,8 +44454,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -44539,8 +44539,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44597,8 +44597,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44625,8 +44625,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44643,8 +44643,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44679,8 +44679,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -44698,8 +44698,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -44724,8 +44724,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -44790,8 +44790,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -44815,8 +44815,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -44853,8 +44853,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44872,8 +44872,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44901,8 +44901,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -44997,8 +44997,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -45056,8 +45056,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -45080,8 +45080,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -45106,8 +45106,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -45131,8 +45131,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -45455,8 +45455,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -45484,8 +45484,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -45502,8 +45502,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -45741,8 +45741,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -46062,8 +46062,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46081,8 +46081,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46112,8 +46112,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -46125,7 +46125,7 @@ multiple node agents:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -46230,8 +46230,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -46297,8 +46297,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -46340,8 +46340,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -46365,8 +46365,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -46390,8 +46390,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -46418,8 +46418,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -46427,7 +46427,7 @@ multiple node agents:
 priority class scheduling:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.3.
+      Thank you for installing kubescape-operator version 1.40.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -46463,8 +46463,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -46510,8 +46510,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -46540,8 +46540,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46562,8 +46562,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46583,8 +46583,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -46603,8 +46603,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46622,9 +46622,9 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46644,9 +46644,9 @@ priority class scheduling:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -46712,8 +46712,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -46982,8 +46982,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -47007,8 +47007,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47039,8 +47039,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -47084,7 +47084,7 @@ priority class scheduling:
                   value: https://api.armosec.io
                 - name: KS_EXCLUDE_NAMESPACES
                   value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
-              image: quay.io/kubescape/kubescape:v4.0.11
+              image: quay.io/kubescape/kubescape:v4.0.12
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -47179,8 +47179,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47198,8 +47198,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -47229,8 +47229,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -47255,8 +47255,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -47285,8 +47285,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -47304,8 +47304,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47323,9 +47323,9 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47345,9 +47345,9 @@ priority class scheduling:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -47413,8 +47413,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -47454,8 +47454,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -47479,8 +47479,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47508,8 +47508,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -47619,8 +47619,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -47648,8 +47648,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -48035,8 +48035,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -48191,8 +48191,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -48263,8 +48263,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48282,8 +48282,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48309,8 +48309,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -48507,8 +48507,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -48535,8 +48535,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -48557,8 +48557,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -48580,8 +48580,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -48599,8 +48599,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -48626,8 +48626,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -48683,8 +48683,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -48809,8 +48809,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -48868,8 +48868,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48887,8 +48887,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48922,8 +48922,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -48937,7 +48937,7 @@ priority class scheduling:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -49133,8 +49133,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49218,8 +49218,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49303,8 +49303,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49322,8 +49322,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -49366,8 +49366,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -49392,8 +49392,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -49421,8 +49421,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -49439,8 +49439,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -49469,8 +49469,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -49492,8 +49492,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -49511,8 +49511,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -49577,8 +49577,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -49602,8 +49602,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -49643,8 +49643,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49662,8 +49662,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49691,8 +49691,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -49791,8 +49791,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -49815,8 +49815,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -49840,8 +49840,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -50164,8 +50164,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -50193,8 +50193,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -50211,8 +50211,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50381,8 +50381,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50684,8 +50684,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50703,8 +50703,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50733,8 +50733,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -50746,7 +50746,7 @@ priority class scheduling:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -50832,8 +50832,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50875,8 +50875,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50900,8 +50900,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50928,8 +50928,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50937,7 +50937,7 @@ priority class scheduling:
 relevancy only:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.3.
+      Thank you for installing kubescape-operator version 1.40.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -50972,8 +50972,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -51019,8 +51019,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -51049,8 +51049,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51071,8 +51071,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51092,8 +51092,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -51112,8 +51112,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51131,9 +51131,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51153,9 +51153,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -51220,8 +51220,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -51490,8 +51490,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -51515,8 +51515,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51547,8 +51547,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -51588,7 +51588,7 @@ relevancy only:
                   value: /home/nonroot/.kubescape/host-scanner.yaml
                 - name: LARGE_CLUSTER_SIZE
                   value: "1500"
-              image: quay.io/kubescape/kubescape:v4.0.11
+              image: quay.io/kubescape/kubescape:v4.0.12
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -51682,8 +51682,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51701,8 +51701,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -51732,8 +51732,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -51758,8 +51758,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -51788,8 +51788,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -51807,8 +51807,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51826,9 +51826,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51848,9 +51848,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -51915,8 +51915,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -51956,8 +51956,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -51981,8 +51981,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52010,8 +52010,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -52118,8 +52118,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -52147,8 +52147,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -52534,8 +52534,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -52690,8 +52690,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -52760,8 +52760,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52779,8 +52779,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52806,8 +52806,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -53005,8 +53005,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -53033,8 +53033,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -53051,8 +53051,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -53177,8 +53177,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -53234,8 +53234,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53253,8 +53253,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53288,8 +53288,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -53303,7 +53303,7 @@ relevancy only:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -53489,8 +53489,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53574,8 +53574,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53659,8 +53659,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53678,8 +53678,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -53722,8 +53722,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -53748,8 +53748,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -53777,8 +53777,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -53795,8 +53795,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -53825,8 +53825,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -53848,8 +53848,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -53867,8 +53867,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -53933,8 +53933,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -53958,8 +53958,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -53999,8 +53999,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54018,8 +54018,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54047,8 +54047,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -54146,8 +54146,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -54170,8 +54170,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -54195,8 +54195,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -54519,8 +54519,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -54548,8 +54548,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -54557,7 +54557,7 @@ relevancy only:
 skipPersistence enabled:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.3.
+      Thank you for installing kubescape-operator version 1.40.4.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -54591,8 +54591,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -54611,8 +54611,8 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
-                helm.sh/chart: kubescape-operator-1.40.3
+                app.kubernetes.io/version: 1.40.4
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -54673,8 +54673,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -54717,8 +54717,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -54742,8 +54742,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -54768,8 +54768,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -54789,8 +54789,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -54837,8 +54837,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -54867,8 +54867,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54888,8 +54888,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -54911,8 +54911,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54932,8 +54932,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -54950,9 +54950,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54972,9 +54972,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -55032,8 +55032,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55063,9 +55063,9 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
+            app.kubernetes.io/version: 1.40.4
             bar: baz
-            helm.sh/chart: kubescape-operator-1.40.3
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -55124,8 +55124,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -55159,8 +55159,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -55184,8 +55184,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -55209,8 +55209,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -55237,8 +55237,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -55257,8 +55257,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55276,9 +55276,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55298,9 +55298,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -55367,8 +55367,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -55419,8 +55419,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -55705,8 +55705,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -55730,8 +55730,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55763,8 +55763,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -55837,7 +55837,7 @@ skipPersistence enabled:
                   value: kubescape,kubevuln,node-agent,operator,kubernetes.default.svc.*,127.0.0.1,*.foo,bar.baz
                 - name: KS_INCLUDE_NAMESPACES
                   value: my-namespace
-              image: quay.io/kubescape/kubescape:v4.0.11
+              image: quay.io/kubescape/kubescape:v4.0.12
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -55946,8 +55946,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55965,8 +55965,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -56042,8 +56042,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -56073,8 +56073,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -56099,8 +56099,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -56125,8 +56125,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -56155,8 +56155,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -56173,8 +56173,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -56209,8 +56209,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -56228,9 +56228,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
+        app.kubernetes.io/version: 1.40.4
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.3
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -56250,9 +56250,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.3
+                app.kubernetes.io/version: 1.40.4
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.3
+                helm.sh/chart: kubescape-operator-1.40.4
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -56319,8 +56319,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -56371,8 +56371,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -56445,8 +56445,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -56470,8 +56470,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -56500,8 +56500,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -56630,8 +56630,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -56687,8 +56687,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -56711,8 +56711,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -56737,8 +56737,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -56766,8 +56766,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -57153,8 +57153,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-gke-allowlist
@@ -57173,8 +57173,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -57329,8 +57329,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -57401,8 +57401,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57420,8 +57420,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57448,9 +57448,9 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
+            app.kubernetes.io/version: 1.40.4
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.3
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -57673,8 +57673,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -57724,8 +57724,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -58446,8 +58446,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -58505,8 +58505,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -58531,8 +58531,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -58559,8 +58559,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -58581,8 +58581,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -58604,8 +58604,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -58623,8 +58623,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -58650,8 +58650,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -58707,8 +58707,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58866,8 +58866,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58925,8 +58925,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58944,8 +58944,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58980,8 +58980,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -58995,7 +58995,7 @@ skipPersistence enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -59212,8 +59212,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -59300,8 +59300,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -59319,8 +59319,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -59484,8 +59484,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -59503,8 +59503,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -59547,8 +59547,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -59573,8 +59573,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -59599,8 +59599,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -59628,8 +59628,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -59645,8 +59645,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59673,8 +59673,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59698,8 +59698,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59724,8 +59724,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -59809,8 +59809,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59867,8 +59867,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59895,8 +59895,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59913,8 +59913,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59949,8 +59949,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -59968,8 +59968,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -59994,8 +59994,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -60060,8 +60060,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -60085,8 +60085,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -60123,8 +60123,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -60142,8 +60142,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -60171,8 +60171,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -60267,8 +60267,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -60326,8 +60326,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -60350,8 +60350,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -60376,8 +60376,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -60401,8 +60401,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -60725,8 +60725,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -60754,8 +60754,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -60772,8 +60772,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61011,8 +61011,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61332,8 +61332,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -61351,8 +61351,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -61382,8 +61382,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.3
-            helm.sh/chart: kubescape-operator-1.40.3
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -61395,7 +61395,7 @@ skipPersistence enabled:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.3
+                  value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -61500,8 +61500,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61567,8 +61567,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61610,8 +61610,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61635,8 +61635,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -61660,8 +61660,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61688,8 +61688,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61717,8 +61717,8 @@ with multiple private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets
@@ -61755,8 +61755,8 @@ with single private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.3
-        helm.sh/chart: kubescape-operator-1.40.3
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -321,7 +321,7 @@ kubescape:
   image:
     # -- source code: https://github.com/kubescape/kubescape/tree/master/httphandler (public repo)
     repository: quay.io/kubescape/kubescape
-    tag: v4.0.11
+    tag: v4.0.12
     pullPolicy: IfNotPresent
 
   nodeSelector:


### PR DESCRIPTION
Fixes configuration scanning on standalone (no ARMO account) installs, which is currently **completely broken**: no `WorkloadConfigurationScan` or `ConfigurationScanSummary` object is ever persisted.

Reported in kubescape/kubescape#3707.

## The bug

The chart pins `quay.io/kubescape/kubescape:v4.0.11`. On a standalone install `accountID` is empty, so `Submit()` always takes the account-ID generation path, and in v4.0.11 `updateConfigFile()` hard-fails on chmod:

```go
if err := os.Chmod(dir, 0700); err != nil {
    return err
}
```

The scanner runs `runAsNonRoot: true` + `readOnlyRootFilesystem: true`, and `/home/nonroot/.kubescape` is a **root-owned `emptyDir` subPath mount** — a non-root process cannot chmod it. The `EPERM` propagates out and aborts the scan *after* it has already succeeded:

```
info  Scan results saved              filename=results/03dca245-....json
error failed to generate account ID   reason=chmod /home/nonroot/.kubescape: operation not permitted
error scanning failed                 error=failed to scan. reason: 'chmod ...'
```

Deterministic — every scan trigger observed failed identically. Vulnerability scanning and runtime observability are unaffected, which is what makes it easy to miss:

| resource | count |
|---|---|
| `vulnerabilitymanifests` | 6 |
| `applicationprofiles` | 4 |
| `networkneighborhoods` | 4 |
| `workloadconfigurationscans` | **0** |
| `configurationscansummaries` | **0** |

## Why the tag bump is the whole fix

`v4.0.12` already contains the fix — chmod is best-effort (logged as a warning) and the config is written via temp-file + rename, so no chmod on the target is needed at all. Only the pinned tag keeps it from users. The running v4.0.11 scanner even logs:

```
warn  current version '4.0.11' is not updated to the latest release: 'v4.0.12'
```

Because the account-ID path only runs when `accountID` is empty, this affects **standalone installs only** — likely why cloud-connected testing does not surface it.

## Changes

- `values.yaml`: `kubescape.image.tag` `v4.0.11` → `v4.0.12` (no other image touched)
- `Chart.yaml`: patch bump `1.40.3` → `1.40.4` (version + appVersion)
- Snapshots regenerated with `helm unittest -u`

## Verification

`helm unittest charts/kubescape-operator` — **105 tests / 993 snapshots pass**.

Found while verifying the Kubescape tool provider in `kagent-dev/tools` (`pkg/kubescape`), where this also silently disables the `kubescape_list_configuration_scans` and `kubescape_get_configuration_scan` tools.

Environment: DOKS k8s 1.34.10, Debian 13, kernel 6.12.96, 3 × s-4vcpu-8gb, chart 1.40.3 defaults + `continuousScan=enable`.

AI-skills: superpowers:using-git-worktrees

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Kubescape Operator chart and application versions to 1.40.4.
  * Updated the Kubescape scanner image to version 4.0.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->