### PR TITLE
feat(storage,node-agent): expose profile size caps and add GOMEMLIMIT headroom

### DIFF
--- a/charts/kubescape-operator/templates/node-agent/configmap.yaml
+++ b/charts/kubescape-operator/templates/node-agent/configmap.yaml
@@ -37,6 +37,7 @@ data:
         "networkStreamingEnabled": {{ $gates.networkStreamingEnabled }},
         "maxImageSize": {{ .Values.kubevuln.config.maxImageSize }},
         "maxSBOMSize": {{ .Values.kubevuln.config.maxSBOMSize }},
+        "maxTsProfileSize": {{ .Values.nodeAgent.config.maxTsProfileSize }},
         "sbomGenerationEnabled": {{ eq .Values.capabilities.nodeSbomGeneration "enable" }},
         "enableEmbeddedSBOMs": {{ eq .Values.capabilities.scanEmbeddedSBOMs "enable" }},
         "seccompServiceEnabled": {{ eq .Values.capabilities.seccompProfileService "enable" }},

--- a/charts/kubescape-operator/templates/storage/configmap.yaml
+++ b/charts/kubescape-operator/templates/storage/configmap.yaml
@@ -23,6 +23,7 @@ data:
       "defaultQueueLength": {{ .Values.storage.defaultQueueLength }},
       "defaultWorkerCount": {{ .Values.storage.defaultWorkerCount }},
       "defaultMaxObjectSize": {{ .Values.storage.defaultMaxObjectSize }},
+      "maxContainerProfileSize": {{ .Values.storage.maxContainerProfileSize }},
       "queueManagerEnabled": {{ .Values.storage.queueManagerEnabled }},
       "kindQueues": {{ .Values.storage.kindQueues | toJson }},
       {{- if hasKey .Values.storage "singleWriterEnabled" }}

--- a/charts/kubescape-operator/templates/storage/deployment.yaml
+++ b/charts/kubescape-operator/templates/storage/deployment.yaml
@@ -149,11 +149,10 @@ spec:
             port: {{ .Values.storage.serverPort }}
             scheme: HTTPS
         env:
+          {{- if .Values.storage.resources.limits.memory }}
           - name: GOMEMLIMIT
-            valueFrom:
-              resourceFieldRef:
-                resource: limits.memory
-                divisor: '1'
+            value: {{ include "kubescape-operator.gomemlimit" (dict "memory" .Values.storage.resources.limits.memory "percentage" .Values.storage.gomemlimitPercentage) | quote }}
+          {{- end }}
           - name: KS_LOGGER_LEVEL
             value: "{{ .Values.logger.level }}"
           - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -2791,6 +2791,7 @@ all capabilities:
             "networkStreamingEnabled": true,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
+            "maxTsProfileSize": 2.097152e+06,
             "sbomGenerationEnabled": true,
             "enableEmbeddedSBOMs": true,
             "seccompServiceEnabled": true,
@@ -2885,7 +2886,7 @@ all capabilities:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 79112123f09fe8f490d4718eb80bb5a09733501e605dc1bba9c272152d54c8c8
+            checksum/node-agent-config: 7973819215ea1590cbfb9606e3fad6a6af943ab429b1fbf0cfd8f77c8c873a99
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -5557,6 +5558,7 @@ all capabilities:
           "defaultQueueLength": 100,
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
+          "maxContainerProfileSize": 40000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "singleWriterEnabled": true,
@@ -5613,7 +5615,7 @@ all capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
-            checksum/storage-config: 98647d83976afeb253cb21e3e9e198a7ea2cccd0aa2bf08621da3aae776fcbd0
+            checksum/storage-config: f7617b3645473b744abec1f00c80a00f6684918d27140264c572277d29d78935
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -5631,10 +5633,7 @@ all capabilities:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -8914,6 +8913,7 @@ autoscaler mode with sbom sidecar:
             "networkStreamingEnabled": true,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
+            "maxTsProfileSize": 2.097152e+06,
             "sbomGenerationEnabled": true,
             "enableEmbeddedSBOMs": false,
             "seccompServiceEnabled": true,
@@ -9027,7 +9027,7 @@ autoscaler mode with sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 2f3c9ccddd8dce1cc17782a69046a5f905f6a408366b731f78ce0b103c691917\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.219\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 7b65380acf10117daf2388c2ea4ae90974ad08e1918d145231398a4eeac7b3e0\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.219\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -10148,6 +10148,7 @@ autoscaler mode with sbom sidecar:
           "defaultQueueLength": 100,
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
+          "maxContainerProfileSize": 40000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "singleWriterEnabled": true,
@@ -10207,7 +10208,7 @@ autoscaler mode with sbom sidecar:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 590c6ecbb0da091594f8b56720497bbe048f88fc50e2896f953f06faafefe0a3
+            checksum/storage-config: b5f796e916e46de5d30a0891343c36fe93b37facc912a211e609364d4c9da2e9
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -10225,10 +10226,7 @@ autoscaler mode with sbom sidecar:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -13226,6 +13224,7 @@ autoscaler mode without sbom sidecar:
             "networkStreamingEnabled": true,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
+            "maxTsProfileSize": 2.097152e+06,
             "sbomGenerationEnabled": true,
             "enableEmbeddedSBOMs": false,
             "seccompServiceEnabled": true,
@@ -13339,7 +13338,7 @@ autoscaler mode without sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 2f3c9ccddd8dce1cc17782a69046a5f905f6a408366b731f78ce0b103c691917\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.219\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 7b65380acf10117daf2388c2ea4ae90974ad08e1918d145231398a4eeac7b3e0\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.219\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -14460,6 +14459,7 @@ autoscaler mode without sbom sidecar:
           "defaultQueueLength": 100,
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
+          "maxContainerProfileSize": 40000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "singleWriterEnabled": true,
@@ -14519,7 +14519,7 @@ autoscaler mode without sbom sidecar:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 590c6ecbb0da091594f8b56720497bbe048f88fc50e2896f953f06faafefe0a3
+            checksum/storage-config: b5f796e916e46de5d30a0891343c36fe93b37facc912a211e609364d4c9da2e9
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -14537,10 +14537,7 @@ autoscaler mode without sbom sidecar:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -15984,7 +15981,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: 5e8458623c44b5fae66b5d816abab8fd02a7996758b510dbb4afb5a221918b0d
+            checksum/storage-config: 57703d32c113515acf1ae3b223abd76ce8cffaf02ff1546a6b11d3d0981af62b
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -16002,10 +15999,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -16405,7 +16399,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/storage-certgen-scripts: 0437bf4a87439f0a5e709a25751946c2ea0940389b61c553aeac7c899fc362a4
-            checksum/storage-config: 3bb611086ab7fc5b5acbd122deb6ed76612809110a19007d5e686e45310a0979
+            checksum/storage-config: 5690bf025cf52e0c959c7a58df6f4a13accdf894ad9cc6364bde8eb2f3ab69a5
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -16423,10 +16417,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -17065,7 +17056,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: 5e8458623c44b5fae66b5d816abab8fd02a7996758b510dbb4afb5a221918b0d
+            checksum/storage-config: 57703d32c113515acf1ae3b223abd76ce8cffaf02ff1546a6b11d3d0981af62b
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -17083,10 +17074,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -17751,7 +17739,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
             checksum/storage-certgen-scripts: 0437bf4a87439f0a5e709a25751946c2ea0940389b61c553aeac7c899fc362a4
-            checksum/storage-config: 3bb611086ab7fc5b5acbd122deb6ed76612809110a19007d5e686e45310a0979
+            checksum/storage-config: 5690bf025cf52e0c959c7a58df6f4a13accdf894ad9cc6364bde8eb2f3ab69a5
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -17769,10 +17757,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -18146,7 +18131,7 @@ cert strategy template, admission disabled, mtls disabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: 5e8458623c44b5fae66b5d816abab8fd02a7996758b510dbb4afb5a221918b0d
+            checksum/storage-config: 57703d32c113515acf1ae3b223abd76ce8cffaf02ff1546a6b11d3d0981af62b
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -18164,10 +18149,7 @@ cert strategy template, admission disabled, mtls disabled:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -18511,7 +18493,7 @@ cert strategy template, admission disabled, mtls enabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: 3bb611086ab7fc5b5acbd122deb6ed76612809110a19007d5e686e45310a0979
+            checksum/storage-config: 5690bf025cf52e0c959c7a58df6f4a13accdf894ad9cc6364bde8eb2f3ab69a5
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -18529,10 +18511,7 @@ cert strategy template, admission disabled, mtls enabled:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -18975,7 +18954,7 @@ cert strategy template, admission enabled, mtls disabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: 5e8458623c44b5fae66b5d816abab8fd02a7996758b510dbb4afb5a221918b0d
+            checksum/storage-config: 57703d32c113515acf1ae3b223abd76ce8cffaf02ff1546a6b11d3d0981af62b
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -18993,10 +18972,7 @@ cert strategy template, admission enabled, mtls disabled:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -19479,7 +19455,7 @@ cert strategy template, admission enabled, mtls enabled:
         metadata:
           annotations:
             checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
-            checksum/storage-config: 3bb611086ab7fc5b5acbd122deb6ed76612809110a19007d5e686e45310a0979
+            checksum/storage-config: 5690bf025cf52e0c959c7a58df6f4a13accdf894ad9cc6364bde8eb2f3ab69a5
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -19497,10 +19473,7 @@ cert strategy template, admission enabled, mtls enabled:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -21798,6 +21771,7 @@ default capabilities:
             "networkStreamingEnabled": true,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
+            "maxTsProfileSize": 2.097152e+06,
             "sbomGenerationEnabled": true,
             "enableEmbeddedSBOMs": false,
             "seccompServiceEnabled": true,
@@ -21892,7 +21866,7 @@ default capabilities:
           annotations:
             checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: e08b4fe1b91b06ade33e377703005e52baf586e4d20bd940456ffcd7a9e78203
+            checksum/node-agent-config: beb859885f04dcaf7670d16c1c7cf019ad51a7862b8dba3eca3a3eb9b833a59a
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -24042,6 +24016,7 @@ default capabilities:
           "defaultQueueLength": 100,
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
+          "maxContainerProfileSize": 40000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "singleWriterEnabled": true,
@@ -24101,7 +24076,7 @@ default capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 719d88462288fae1490ad7bb25c35ba14212abccaba0790e4b537d313825242c
-            checksum/storage-config: 590c6ecbb0da091594f8b56720497bbe048f88fc50e2896f953f06faafefe0a3
+            checksum/storage-config: b5f796e916e46de5d30a0891343c36fe93b37facc912a211e609364d4c9da2e9
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -24119,10 +24094,7 @@ default capabilities:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -27246,6 +27218,7 @@ disable otel:
             "networkStreamingEnabled": true,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
+            "maxTsProfileSize": 2.097152e+06,
             "sbomGenerationEnabled": true,
             "enableEmbeddedSBOMs": false,
             "seccompServiceEnabled": true,
@@ -27340,7 +27313,7 @@ disable otel:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 12928b52abdfb6d538a5e60aaa7767bdf5c178b9aedc52605ceb97118024af02
+            checksum/node-agent-config: 0d40fcc2b7d386febfa670163ce5a9916725f079e29e0c9c126e677a2cbd2ff8
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -28666,6 +28639,7 @@ disable otel:
           "defaultQueueLength": 100,
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
+          "maxContainerProfileSize": 40000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "singleWriterEnabled": true,
@@ -28725,7 +28699,7 @@ disable otel:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 590c6ecbb0da091594f8b56720497bbe048f88fc50e2896f953f06faafefe0a3
+            checksum/storage-config: b5f796e916e46de5d30a0891343c36fe93b37facc912a211e609364d4c9da2e9
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -28743,10 +28717,7 @@ disable otel:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -31747,6 +31718,7 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
             "networkStreamingEnabled": true,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
+            "maxTsProfileSize": 2.097152e+06,
             "sbomGenerationEnabled": true,
             "enableEmbeddedSBOMs": false,
             "seccompServiceEnabled": true,
@@ -31843,7 +31815,7 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 163e42cdeb972e8d05e42ec0abbdce5483296aafb43305736e113c93c7ffa467
+            checksum/node-agent-config: 7765de84fd06d30072b172a6611e2649739b7950966e3477e509c84ede5a8955
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -33945,6 +33917,7 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
           "defaultQueueLength": 100,
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
+          "maxContainerProfileSize": 40000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "singleWriterEnabled": true,
@@ -34004,7 +33977,7 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 590c6ecbb0da091594f8b56720497bbe048f88fc50e2896f953f06faafefe0a3
+            checksum/storage-config: b5f796e916e46de5d30a0891343c36fe93b37facc912a211e609364d4c9da2e9
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -34022,10 +33995,7 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -37005,6 +36975,7 @@ minimal capabilities:
             "networkStreamingEnabled": false,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
+            "maxTsProfileSize": 2.097152e+06,
             "sbomGenerationEnabled": true,
             "enableEmbeddedSBOMs": false,
             "seccompServiceEnabled": true,
@@ -37097,7 +37068,7 @@ minimal capabilities:
           annotations:
             checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
-            checksum/node-agent-config: 0a509d161a34fd9354431b9cb5485ed05eff251a068c1d2e29f8fb1a2dbb550b
+            checksum/node-agent-config: ea9abc705096535bfc5d5f11c779cbaa1f25bbbe7dcc35275befd4dc81fef944
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -38422,6 +38393,7 @@ minimal capabilities:
           "defaultQueueLength": 100,
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
+          "maxContainerProfileSize": 40000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "singleWriterEnabled": true,
@@ -38481,7 +38453,7 @@ minimal capabilities:
         metadata:
           annotations:
             checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
-            checksum/storage-config: 3bb611086ab7fc5b5acbd122deb6ed76612809110a19007d5e686e45310a0979
+            checksum/storage-config: 5690bf025cf52e0c959c7a58df6f4a13accdf894ad9cc6364bde8eb2f3ab69a5
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -38499,10 +38471,7 @@ minimal capabilities:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -41789,6 +41758,7 @@ multiple node agents:
             "networkStreamingEnabled": true,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
+            "maxTsProfileSize": 2.097152e+06,
             "sbomGenerationEnabled": true,
             "enableEmbeddedSBOMs": true,
             "seccompServiceEnabled": true,
@@ -41883,7 +41853,7 @@ multiple node agents:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 79112123f09fe8f490d4718eb80bb5a09733501e605dc1bba9c272152d54c8c8
+            checksum/node-agent-config: 7973819215ea1590cbfb9606e3fad6a6af943ab429b1fbf0cfd8f77c8c873a99
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -42137,7 +42107,7 @@ multiple node agents:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 79112123f09fe8f490d4718eb80bb5a09733501e605dc1bba9c272152d54c8c8
+            checksum/node-agent-config: 7973819215ea1590cbfb9606e3fad6a6af943ab429b1fbf0cfd8f77c8c873a99
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -44810,6 +44780,7 @@ multiple node agents:
           "defaultQueueLength": 100,
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
+          "maxContainerProfileSize": 40000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "singleWriterEnabled": true,
@@ -44866,7 +44837,7 @@ multiple node agents:
         metadata:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
-            checksum/storage-config: 98647d83976afeb253cb21e3e9e198a7ea2cccd0aa2bf08621da3aae776fcbd0
+            checksum/storage-config: f7617b3645473b744abec1f00c80a00f6684918d27140264c572277d29d78935
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -44884,10 +44855,7 @@ multiple node agents:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -48171,6 +48139,7 @@ priority class scheduling:
             "networkStreamingEnabled": true,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
+            "maxTsProfileSize": 2.097152e+06,
             "sbomGenerationEnabled": true,
             "enableEmbeddedSBOMs": false,
             "seccompServiceEnabled": true,
@@ -48265,7 +48234,7 @@ priority class scheduling:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 2f3c9ccddd8dce1cc17782a69046a5f905f6a408366b731f78ce0b103c691917
+            checksum/node-agent-config: 7b65380acf10117daf2388c2ea4ae90974ad08e1918d145231398a4eeac7b3e0
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -49592,6 +49561,7 @@ priority class scheduling:
           "defaultQueueLength": 100,
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
+          "maxContainerProfileSize": 40000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "singleWriterEnabled": true,
@@ -49651,7 +49621,7 @@ priority class scheduling:
         metadata:
           annotations:
             checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a
-            checksum/storage-config: 590c6ecbb0da091594f8b56720497bbe048f88fc50e2896f953f06faafefe0a3
+            checksum/storage-config: b5f796e916e46de5d30a0891343c36fe93b37facc912a211e609364d4c9da2e9
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -49669,10 +49639,7 @@ priority class scheduling:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -52665,6 +52632,7 @@ relevancy only:
             "networkStreamingEnabled": false,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
+            "maxTsProfileSize": 2.097152e+06,
             "sbomGenerationEnabled": false,
             "enableEmbeddedSBOMs": false,
             "seccompServiceEnabled": false,
@@ -52757,7 +52725,7 @@ relevancy only:
           annotations:
             checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
             checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
-            checksum/node-agent-config: a7fda7c74cdedd28319360bdf1a211edb4dac26bac40e0a1fcefe1b844d30401
+            checksum/node-agent-config: 97d80ac2e375ecf91f747b74c280a10973be52b79cb96ba4607856c0a8e5bb04
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
             app: node-agent
@@ -53943,6 +53911,7 @@ relevancy only:
           "defaultQueueLength": 100,
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
+          "maxContainerProfileSize": 40000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "singleWriterEnabled": true,
@@ -54002,7 +53971,7 @@ relevancy only:
         metadata:
           annotations:
             checksum/cloud-config: 4412fb00c4beca01a812d925460a5bd2a4fa14469527d28622d8b987f3649f46
-            checksum/storage-config: 3bb611086ab7fc5b5acbd122deb6ed76612809110a19007d5e686e45310a0979
+            checksum/storage-config: 5690bf025cf52e0c959c7a58df6f4a13accdf894ad9cc6364bde8eb2f3ab69a5
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -54020,10 +53989,7 @@ relevancy only:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -57313,6 +57279,7 @@ skipPersistence enabled:
             "networkStreamingEnabled": true,
             "maxImageSize": 5.36870912e+09,
             "maxSBOMSize": 2.097152e+07,
+            "maxTsProfileSize": 2.097152e+06,
             "sbomGenerationEnabled": true,
             "enableEmbeddedSBOMs": true,
             "seccompServiceEnabled": true,
@@ -57407,7 +57374,7 @@ skipPersistence enabled:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
             checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424
-            checksum/node-agent-config: 79112123f09fe8f490d4718eb80bb5a09733501e605dc1bba9c272152d54c8c8
+            checksum/node-agent-config: 7973819215ea1590cbfb9606e3fad6a6af943ab429b1fbf0cfd8f77c8c873a99
             checksum/proxy-config: c03b6781aa61faaacfa84a96809236591dde0cbd43a204e05d5ba3044bb9d5d8
             container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
           labels:
@@ -60079,6 +60046,7 @@ skipPersistence enabled:
           "defaultQueueLength": 100,
           "defaultWorkerCount": 2,
           "defaultMaxObjectSize": 400000,
+          "maxContainerProfileSize": 40000,
           "queueManagerEnabled": true,
           "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
           "singleWriterEnabled": true,
@@ -60135,7 +60103,7 @@ skipPersistence enabled:
         metadata:
           annotations:
             checksum/cloud-config: 386f162ec439ff76392d3c4e2ce2148fc09014faeed572df68565cffd4589bb6
-            checksum/storage-config: 98647d83976afeb253cb21e3e9e198a7ea2cccd0aa2bf08621da3aae776fcbd0
+            checksum/storage-config: f7617b3645473b744abec1f00c80a00f6684918d27140264c572277d29d78935
           labels:
             app: storage
             app.kubernetes.io/component: storage
@@ -60153,10 +60121,7 @@ skipPersistence enabled:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 1200MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -61651,6 +61616,3781 @@ skipPersistence enabled:
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
+      namespace: kubescape
+storage profile size caps and GOMEMLIMIT headroom:
+  1: |+
+    raw: |+
+      Thank you for installing kubescape-operator version 1.40.4.
+      View your cluster's configuration scanning schedule:
+      > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
+
+      To change the schedule, set `.spec.schedule`:
+      > kubectl -n kubescape edit cj kubescape-scheduler
+      View your cluster's image scanning schedule:
+      > kubectl -n kubescape get cj kubevuln-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
+
+      To change the schedule, edit `.spec.schedule`:
+      > kubectl -n kubescape edit cj kubevuln-scheduler
+
+      View your image vulnerabilities scan summaries:
+      > kubectl get vulnerabilitymanifestsummaries -A
+
+      Detailed reports are also available:
+      > kubectl get vulnerabilitymanifests -A
+
+      kubescape-operator generates suggested network policies. To view them:
+      > kubectl get generatednetworkpolicies -n <namespace>
+
+      WARNING: capabilities.nodeProfileService=enable but the backend is not configured (.Values.server is empty / submit is disabled). This capability requires the synchronizer, which is only enabled when connected to a backend, so nodeProfileServiceEnabled renders as FALSE in the node-agent configmap and node profiles will NOT be generated. To use it, set .Values.server (requires account and accessKey, or an existing credentials.cloudSecret).
+
+      WARNING: capabilities.networkEventsStreaming=enable but the backend is not configured (.Values.server is empty / submit is disabled). This capability requires submitting data to a backend, so networkStreamingEnabled renders as FALSE in the node-agent configmap and network events will NOT be streamed. To use it, set .Values.server (requires account and accessKey, or an existing credentials.cloudSecret).
+
+      WARNING: capabilities.httpDetection=enable but capabilities.runtimeDetection is not enabled. HTTP detection runs on top of runtime detection, so httpDetectionEnabled renders as FALSE in the node-agent configmap. To use it, set capabilities.runtimeDetection=enable.
+
+  2: |
+    apiVersion: v1
+    data:
+      accessKey: ""
+      account: ""
+    kind: Secret
+    metadata:
+      annotations: null
+      labels:
+        app: cloud-secret
+        app.kubernetes.io/component: cloud-secret
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/infra: credentials
+        tier: ks-control-plane
+      name: cloud-secret
+      namespace: kubescape
+    type: Opaque
+  3: |
+    apiVersion: v1
+    data:
+      clusterData: |
+        {
+          "serviceDiscovery": false,
+          "vulnScanURL": "kubevuln:8080",
+          "kubevulnURL": "kubevuln:8080",
+          "kubescapeURL": "kubescape:8080",
+          "clusterName": "cluster",
+          "storage": true,
+          "relevantImageVulnerabilitiesEnabled": true,
+          "namespace": "kubescape",
+          "imageVulnerabilitiesScanningEnabled": true,
+          "postureScanEnabled": true,
+          "nodeAgent": "true",
+          "maxImageSize": 5.36870912e+09,
+          "maxSBOMSize": 2.097152e+07,
+          "keepLocal": true,
+          "scanTimeout": "5m",
+          "scanEmbeddedSBOMs": false,
+          "vexGeneration": false,
+          "cveMatchingMode": "adaptive",
+          "useDefaultMatchers": false,
+          "storeFilteredSbom": false,
+          "continuousPostureScan": false,
+          "relevantImageVulnerabilitiesConfiguration": "enable",
+          "riskAcceptance": false
+        }
+    kind: ConfigMap
+    metadata:
+      annotations: null
+      labels:
+        app: ks-cloud-config
+        app.kubernetes.io/component: ks-cloud-config
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/infra: config
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: ks-cloud-config
+      namespace: kubescape
+  4: |
+    apiVersion: v1
+    data:
+      capabilities: |
+        {
+          "capabilities":{"admissionController":"enable","agentRuntimePosture":"disable","autoUpgrading":"disable","configurationScan":"enable","continuousScan":"disable","httpDetection":"enable","kubescapeOffline":"disable","malwareDetection":"disable","manageWorkloads":"disable","networkEventsStreaming":"enable","networkPolicyService":"enable","nodeProfileService":"enable","nodeSbomGeneration":"enable","nodeScan":"enable","operator":"enable","prometheusExporter":"disable","relevancy":"enable","remediation":"disable","riskAcceptance":"disable","runtimeDetection":"disable","runtimeObservability":"enable","scanEmbeddedSBOMs":"disable","seccompProfileBackend":"crd","seccompProfileService":"enable","syncSBOM":"disable","testing":{"nodeAgentMultiplication":{"enabled":false,"replicas":5}},"vexGeneration":"disable","vulnerabilityScan":"enable"},
+          "effectiveCapabilities":{"configurationScan":"enable","httpDetection":"disable","malwareDetection":"disable","networkEventsStreaming":"disable","nodeProfileService":"disable","nodeScan":"enable","vulnerabilityScan":"enable"},
+          "capabilityWarnings":["capabilities.nodeProfileService=enable but the backend is not configured (.Values.server is empty / submit is disabled). This capability requires the synchronizer, which is only enabled when connected to a backend, so nodeProfileServiceEnabled renders as FALSE in the node-agent configmap and node profiles will NOT be generated. To use it, set .Values.server (requires account and accessKey, or an existing credentials.cloudSecret).","capabilities.networkEventsStreaming=enable but the backend is not configured (.Values.server is empty / submit is disabled). This capability requires submitting data to a backend, so networkStreamingEnabled renders as FALSE in the node-agent configmap and network events will NOT be streamed. To use it, set .Values.server (requires account and accessKey, or an existing credentials.cloudSecret).","capabilities.httpDetection=enable but capabilities.runtimeDetection is not enabled. HTTP detection runs on top of runtime detection, so httpDetectionEnabled renders as FALSE in the node-agent configmap. To use it, set capabilities.runtimeDetection=enable."],
+          "components":{"autoUpdater":{"enabled":false},"cloudSecret":{"create":true,"name":"cloud-secret"},"customCaCertificates":{"name":"custom-ca-certificates"},"kubescape":{"enabled":true},"kubescapeScheduler":{"enabled":true},"kubevuln":{"enabled":true},"kubevulnScheduler":{"enabled":true},"nodeAgent":{"enabled":true},"operator":{"enabled":true},"prometheusExporter":{"enabled":false},"sbomScanner":{"enabled":false},"serviceDiscovery":{"enabled":false},"storage":{"enabled":true},"synchronizer":{"enabled":false}},
+          "configurations":{"excludeJsonPaths":null,"otelUrl":null,"persistence":"enable","priorityClass":{"daemonset":100000100,"enabled":true},"prometheusAnnotations":"disable"} ,
+          "serviceScanConfig" :{"enabled":false,"interval":"1h"}
+        }
+    kind: ConfigMap
+    metadata:
+      annotations: null
+      labels:
+        app: ks-capabilities
+        app.kubernetes.io/component: ks-capabilities
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: ks-capabilities
+      namespace: kubescape
+  5: |
+    apiVersion: v1
+    data:
+      matchingRules.json: |
+        {"match":[{"apiGroups":["apps"],"apiVersions":["v1"],"resources":["deployments"]}],"namespaces":["default"]}
+    kind: ConfigMap
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: cs-matching-rules
+      namespace: kubescape
+  6: |
+    apiVersion: scheduling.k8s.io/v1
+    description: This priority class is for node-agent daemonset pods
+    globalDefault: false
+    kind: PriorityClass
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape-critical
+        app.kubernetes.io/component: kubescape-critical
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape-critical
+    value: 1.000001e+08
+  7: |
+    apiVersion: v1
+    data:
+      request-body.json: '{"commands":[{"CommandName":"kubescapeScan","args":{"scanV1":{}}}]}'
+    kind: ConfigMap
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape-scheduler
+        app.kubernetes.io/component: kubescape-scheduler
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubescape-scheduler
+      namespace: kubescape
+  8: |
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape-scheduler
+        app.kubernetes.io/component: kubescape-scheduler
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        armo.tier: kubescape-scan
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubescape-scheduler
+      namespace: kubescape
+    spec:
+      failedJobsHistoryLimit: 1
+      jobTemplate:
+        spec:
+          template:
+            metadata:
+              annotations: null
+              labels:
+                app: kubescape-scheduler
+                app.kubernetes.io/component: kubescape-scheduler
+                app.kubernetes.io/instance: RELEASE-NAME
+                app.kubernetes.io/managed-by: Helm
+                app.kubernetes.io/name: kubescape-operator
+                app.kubernetes.io/part-of: kubescape
+                app.kubernetes.io/version: 1.40.4
+                armo.tier: kubescape-scan
+                helm.sh/chart: kubescape-operator-1.40.4
+                kubescape.io/ignore: "true"
+                kubescape.io/tier: core
+                tier: ks-control-plane
+            spec:
+              affinity: null
+              automountServiceAccountToken: false
+              containers:
+                - args:
+                    - -method=post
+                    - -scheme=http
+                    - -host=operator:4002
+                    - -path=v1/triggerAction
+                    - -headers=Content-Type:application/json
+                    - -path-body=/home/ks/request-body.json
+                  image: quay.io/kubescape/http-request:v0.2.23
+                  imagePullPolicy: IfNotPresent
+                  name: kubescape-scheduler
+                  resources:
+                    limits:
+                      cpu: 10m
+                      memory: 20Mi
+                    requests:
+                      cpu: 1m
+                      memory: 10Mi
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+                    readOnlyRootFilesystem: true
+                    runAsGroup: 100
+                    runAsNonRoot: true
+                    runAsUser: 100
+                  volumeMounts:
+                    - mountPath: /home/ks/request-body.json
+                      name: kubescape-scheduler
+                      readOnly: true
+                      subPath: request-body.json
+              nodeSelector:
+                kubernetes.io/os: linux
+              restartPolicy: Never
+              securityContext:
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: kubescape
+              tolerations: null
+              volumes:
+                - configMap:
+                    name: kubescape-scheduler
+                  name: kubescape-scheduler
+      schedule: 1 6 * * *
+      successfulJobsHistoryLimit: 3
+  9: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+          - pods/proxy
+          - namespaces
+          - nodes
+          - configmaps
+          - services
+          - serviceaccounts
+          - endpoints
+          - persistentvolumeclaims
+          - persistentvolumes
+          - limitranges
+          - replicationcontrollers
+          - podtemplates
+          - resourcequotas
+          - events
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - admissionregistration.k8s.io
+        resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - apiregistration.k8s.io
+        resources:
+          - apiservices
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - apps
+        resources:
+          - deployments
+          - statefulsets
+          - daemonsets
+          - replicasets
+          - controllerrevisions
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - autoscaling
+        resources:
+          - horizontalpodautoscalers
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - batch
+        resources:
+          - jobs
+          - cronjobs
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - coordination.k8s.io
+        resources:
+          - leases
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - events.k8s.io
+        resources:
+          - events
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - hostdata.kubescape.cloud
+        resources:
+          - APIServerInfo
+          - ControlPlaneInfo
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - networkpolicies
+          - Ingress
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - cilium.io
+        resources:
+          - ciliumnetworkpolicies
+          - ciliumclusterwidenetworkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - projectcalico.org
+        resources:
+          - networkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - networking.istio.io
+        resources:
+          - gateways
+          - virtualservices
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - security.istio.io
+        resources:
+          - authorizationpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - policy
+        resources:
+          - poddisruptionbudgets
+          - podsecuritypolicies
+          - PodSecurityPolicy
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - rbac.authorization.k8s.io
+        resources:
+          - clusterroles
+          - clusterrolebindings
+          - roles
+          - rolebindings
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - storage.k8s.io
+        resources:
+          - csistoragecapacities
+          - storageclasses
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - extensions
+        resources:
+          - Ingress
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - gateway.networking.k8s.io
+        resources:
+          - httproutes
+          - gateways
+          - gatewayclasses
+          - tcproutes
+          - tlsroutes
+          - udproutes
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+        verbs:
+          - update
+      - apiGroups:
+          - spdx.softwarecomposition.kubescape.io
+        resources:
+          - workloadconfigurationscans
+          - workloadconfigurationscansummaries
+        verbs:
+          - create
+          - get
+          - update
+          - patch
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - servicesscanresults
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - hostdata.kubescape.cloud
+        resources:
+          - osreleasefiles
+          - kernelversions
+          - linuxsecurityhardeningstatuses
+          - openportslists
+          - linuxkernelvariables
+          - kubeletinfos
+          - kubeproxyinfos
+          - controlplaneinfos
+          - cloudproviderinfos
+          - cniinfos
+        verbs:
+          - get
+          - list
+          - watch
+  10: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: kubescape
+    subjects:
+      - kind: ServiceAccount
+        name: kubescape
+        namespace: kubescape
+  11: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubescape
+      namespace: kubescape
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: kubescape
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: kubescape-operator
+      strategy:
+        rollingUpdate:
+          maxSurge: 0%
+          maxUnavailable: 100%
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
+            checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
+          labels:
+            app: kubescape
+            app.kubernetes.io/component: kubescape
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: kubescape-operator
+            app.kubernetes.io/part-of: kubescape
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
+            kubescape.io/ignore: "true"
+            kubescape.io/tier: core
+            tier: ks-control-plane
+        spec:
+          affinity: null
+          automountServiceAccountToken: true
+          containers:
+            - command:
+                - ksserver
+              env:
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      divisor: "1"
+                      resource: limits.memory
+                - name: KS_LOGGER_LEVEL
+                  value: info
+                - name: KS_LOGGER_NAME
+                  value: zap
+                - name: KS_DOWNLOAD_ARTIFACTS
+                  value: "true"
+                - name: KS_DEFAULT_CONFIGMAP_NAME
+                  value: kubescape-config
+                - name: KS_DEFAULT_CONFIGMAP_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: KS_CONTEXT
+                  value: cluster
+                - name: KS_DEFAULT_CLOUD_CONFIGMAP_NAME
+                  value: ks-cloud-config
+                - name: KS_ENABLE_HOST_SCANNER
+                  value: "true"
+                - name: KS_SKIP_UPDATE_CHECK
+                  value: "false"
+                - name: KS_HOST_SCAN_YAML
+                  value: /home/nonroot/.kubescape/host-scanner.yaml
+                - name: LARGE_CLUSTER_SIZE
+                  value: "1500"
+                - name: KS_EXCLUDE_NAMESPACES
+                  value: kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public
+              image: quay.io/kubescape/kubescape:v4.0.13
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /livez
+                  port: 8080
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              name: kubescape
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8080
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              resources:
+                limits:
+                  cpu: 600m
+                  memory: 1Gi
+                requests:
+                  cpu: 250m
+                  memory: 400Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              volumeMounts:
+                - mountPath: /etc/credentials
+                  name: cloud-secret
+                  readOnly: true
+                - mountPath: /home/nonroot/.kubescape
+                  name: kubescape-volume
+                  subPath: config.json
+                - mountPath: /home/nonroot/.kubescape/host-scanner.yaml
+                  name: host-scanner-definition
+                  subPath: host-scanner-yaml
+                - mountPath: /home/nonroot/results
+                  name: results
+                - mountPath: /home/nonroot/failed
+                  name: failed
+                - mountPath: /etc/config/clusterData.json
+                  name: ks-cloud-config
+                  readOnly: true
+                  subPath: clusterData.json
+          nodeSelector:
+            kubernetes.io/os: linux
+          securityContext:
+            fsGroup: 65532
+            runAsGroup: 65532
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: kubescape
+          tolerations: null
+          volumes:
+            - name: cloud-secret
+              secret:
+                secretName: cloud-secret
+            - configMap:
+                items:
+                  - key: clusterData
+                    path: clusterData.json
+                name: ks-cloud-config
+              name: ks-cloud-config
+            - configMap:
+                name: host-scanner-definition
+              name: host-scanner-definition
+            - emptyDir: {}
+              name: kubescape-volume
+            - emptyDir: {}
+              name: results
+            - emptyDir: {}
+              name: failed
+  12: |
+    apiVersion: v1
+    data:
+      host-scanner-yaml: ""
+    kind: ConfigMap
+    metadata:
+      annotations: null
+      labels:
+        app: ks-cloud-config
+        app.kubernetes.io/component: ks-cloud-config
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: host-scanner-definition
+      namespace: kubescape
+  13: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape
+      namespace: kubescape
+    rules:
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+        verbs:
+          - create
+          - get
+          - update
+          - watch
+          - list
+          - patch
+          - delete
+  14: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape
+      namespace: kubescape
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: kubescape
+    subjects:
+      - kind: ServiceAccount
+        name: kubescape
+        namespace: kubescape
+  15: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape
+      namespace: kubescape
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
+  16: |
+    apiVersion: v1
+    automountServiceAccountToken: false
+    kind: ServiceAccount
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape
+        app.kubernetes.io/component: kubescape
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape
+      namespace: kubescape
+  17: |
+    apiVersion: v1
+    data:
+      request-body.json: '{"commands":[{"commandName":"scan","designators":[{"designatorType":"Attributes","attributes":{}}]}]}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: kubevuln-scheduler
+        app.kubernetes.io/component: kubevuln-scheduler
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubevuln-scheduler
+      namespace: kubescape
+  18: |
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      annotations: null
+      labels:
+        app: kubevuln-scheduler
+        app.kubernetes.io/component: kubevuln-scheduler
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        armo.tier: vuln-scan
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubevuln-scheduler
+      namespace: kubescape
+    spec:
+      failedJobsHistoryLimit: 1
+      jobTemplate:
+        spec:
+          template:
+            metadata:
+              annotations: null
+              labels:
+                app: kubevuln-scheduler
+                app.kubernetes.io/component: kubevuln-scheduler
+                app.kubernetes.io/instance: RELEASE-NAME
+                app.kubernetes.io/managed-by: Helm
+                app.kubernetes.io/name: kubescape-operator
+                app.kubernetes.io/part-of: kubescape
+                app.kubernetes.io/version: 1.40.4
+                armo.tier: vuln-scan
+                helm.sh/chart: kubescape-operator-1.40.4
+                kubescape.io/ignore: "true"
+                kubescape.io/tier: core
+                tier: ks-control-plane
+            spec:
+              affinity: null
+              automountServiceAccountToken: false
+              containers:
+                - args:
+                    - -method=post
+                    - -scheme=http
+                    - -host=operator:4002
+                    - -path=v1/triggerAction
+                    - -headers=Content-Type:application/json
+                    - -path-body=/home/ks/request-body.json
+                  image: quay.io/kubescape/http-request:v0.2.23
+                  imagePullPolicy: IfNotPresent
+                  name: kubevuln-scheduler
+                  resources:
+                    limits:
+                      cpu: 10m
+                      memory: 20Mi
+                    requests:
+                      cpu: 1m
+                      memory: 10Mi
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                        - ALL
+                    readOnlyRootFilesystem: true
+                    runAsGroup: 100
+                    runAsNonRoot: true
+                    runAsUser: 100
+                  volumeMounts:
+                    - mountPath: /home/ks/request-body.json
+                      name: kubevuln-scheduler
+                      readOnly: true
+                      subPath: request-body.json
+              nodeSelector:
+                kubernetes.io/os: linux
+              restartPolicy: Never
+              securityContext:
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: kubevuln
+              tolerations: null
+              volumes:
+                - configMap:
+                    name: kubevuln-scheduler
+                  name: kubevuln-scheduler
+      schedule: 1 6 * * *
+      successfulJobsHistoryLimit: 3
+  19: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations: null
+      labels:
+        app: kubevuln
+        app.kubernetes.io/component: kubevuln
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubevuln
+    rules:
+      - apiGroups:
+          - spdx.softwarecomposition.kubescape.io
+        resources:
+          - vulnerabilitymanifests
+          - vulnerabilitymanifestsummaries
+          - openvulnerabilityexchangecontainers
+          - sbomsyfts
+          - sbomsyftfiltereds
+        verbs:
+          - create
+          - get
+          - update
+          - watch
+          - list
+          - patch
+      - apiGroups:
+          - spdx.softwarecomposition.kubescape.io
+        resources:
+          - containerprofiles
+        verbs:
+          - get
+          - watch
+          - list
+  20: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: kubevuln
+        app.kubernetes.io/component: kubevuln
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubevuln
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: kubevuln
+    subjects:
+      - kind: ServiceAccount
+        name: kubevuln
+        namespace: kubescape
+  21: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations: null
+      labels:
+        app: kubevuln
+        app.kubernetes.io/component: kubevuln
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubevuln
+      namespace: kubescape
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: kubevuln
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: kubescape-operator
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          annotations:
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
+            checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
+          labels:
+            app: kubevuln
+            app.kubernetes.io/component: kubevuln
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: kubescape-operator
+            app.kubernetes.io/part-of: kubescape
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
+            kubescape.io/ignore: "true"
+            kubescape.io/tier: core
+            tier: ks-control-plane
+        spec:
+          affinity: null
+          automountServiceAccountToken: true
+          containers:
+            - args:
+                - -alsologtostderr
+                - -v=4
+                - 2>&1
+              env:
+                - name: GOMEMLIMIT
+                  value: 4000MiB
+                - name: KS_LOGGER_LEVEL
+                  value: info
+                - name: KS_LOGGER_NAME
+                  value: zap
+                - name: PRINT_POST_JSON
+                  value: ""
+                - name: CA_MAX_VULN_SCAN_ROUTINES
+                  value: "1"
+              image: quay.io/kubescape/kubevuln:v0.3.430
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /v1/liveness
+                  port: 8080
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              name: kubevuln
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /v1/readiness
+                  port: 8080
+              resources:
+                limits:
+                  cpu: 1500m
+                  ephemeral-storage: 10Gi
+                  memory: 5000Mi
+                requests:
+                  cpu: 300m
+                  ephemeral-storage: 5Gi
+                  memory: 1000Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              volumeMounts:
+                - mountPath: /etc/credentials
+                  name: cloud-secret
+                  readOnly: true
+                - mountPath: /tmp
+                  name: tmp-dir
+                - mountPath: /home/nonroot/anchore-resources/db
+                  name: grype-db-cache
+                - mountPath: /etc/config/clusterData.json
+                  name: ks-cloud-config
+                  readOnly: true
+                  subPath: clusterData.json
+                - mountPath: /home/nonroot/.cache/grype
+                  name: grype-db
+          nodeSelector:
+            kubernetes.io/os: linux
+          securityContext:
+            fsGroup: 65532
+            runAsGroup: 65532
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: kubevuln
+          tolerations: null
+          volumes:
+            - name: cloud-secret
+              secret:
+                secretName: cloud-secret
+            - emptyDir: {}
+              name: tmp-dir
+            - emptyDir: {}
+              name: grype-db-cache
+            - configMap:
+                items:
+                  - key: clusterData
+                    path: clusterData.json
+                name: ks-cloud-config
+              name: ks-cloud-config
+            - emptyDir: {}
+              name: grype-db
+  22: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app: kubevuln
+        app.kubernetes.io/component: kubevuln
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubevuln
+      namespace: kubescape
+    spec:
+      ports:
+        - port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app.kubernetes.io/component: kubevuln
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
+  23: |
+    apiVersion: v1
+    automountServiceAccountToken: false
+    kind: ServiceAccount
+    metadata:
+      annotations: null
+      labels:
+        app: kubevuln
+        app.kubernetes.io/component: kubevuln
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubevuln
+      namespace: kubescape
+  24: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: cloudproviderinfos.hostdata.kubescape.cloud
+    spec:
+      group: hostdata.kubescape.cloud
+      names:
+        kind: CloudProviderInfo
+        listKind: CloudProviderInfoList
+        plural: cloudproviderinfos
+        singular: cloudproviderinfo
+      scope: Cluster
+      versions:
+        - additionalPrinterColumns:
+            - jsonPath: .spec.nodeName
+              name: Node
+              type: string
+            - jsonPath: .status.lastSensed
+              name: Last Sensed
+              type: string
+          name: v1beta1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          served: true
+          storage: true
+  25: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: cniinfos.hostdata.kubescape.cloud
+    spec:
+      group: hostdata.kubescape.cloud
+      names:
+        kind: CNIInfo
+        listKind: CNIInfoList
+        plural: cniinfos
+        singular: cniinfo
+      scope: Cluster
+      versions:
+        - additionalPrinterColumns:
+            - jsonPath: .spec.nodeName
+              name: Node
+              type: string
+            - jsonPath: .status.lastSensed
+              name: Last Sensed
+              type: string
+          name: v1beta1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          served: true
+          storage: true
+  26: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: controlplaneinfos.hostdata.kubescape.cloud
+    spec:
+      group: hostdata.kubescape.cloud
+      names:
+        kind: ControlPlaneInfo
+        listKind: ControlPlaneInfoList
+        plural: controlplaneinfos
+        singular: controlplaneinfo
+      scope: Cluster
+      versions:
+        - additionalPrinterColumns:
+            - jsonPath: .spec.nodeName
+              name: Node
+              type: string
+            - jsonPath: .status.lastSensed
+              name: Last Sensed
+              type: string
+          name: v1beta1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          served: true
+          storage: true
+  27: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kernelversions.hostdata.kubescape.cloud
+    spec:
+      group: hostdata.kubescape.cloud
+      names:
+        kind: KernelVersion
+        listKind: KernelVersionList
+        plural: kernelversions
+        singular: kernelversion
+      scope: Cluster
+      versions:
+        - additionalPrinterColumns:
+            - jsonPath: .spec.nodeName
+              name: Node
+              type: string
+            - jsonPath: .status.lastSensed
+              name: Last Sensed
+              type: string
+          name: v1beta1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          served: true
+          storage: true
+  28: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubeletinfos.hostdata.kubescape.cloud
+    spec:
+      group: hostdata.kubescape.cloud
+      names:
+        kind: KubeletInfo
+        listKind: KubeletInfoList
+        plural: kubeletinfos
+        singular: kubeletinfo
+      scope: Cluster
+      versions:
+        - additionalPrinterColumns:
+            - jsonPath: .spec.nodeName
+              name: Node
+              type: string
+            - jsonPath: .status.lastSensed
+              name: Last Sensed
+              type: string
+          name: v1beta1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          served: true
+          storage: true
+  29: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: kubeproxyinfos.hostdata.kubescape.cloud
+    spec:
+      group: hostdata.kubescape.cloud
+      names:
+        kind: KubeProxyInfo
+        listKind: KubeProxyInfoList
+        plural: kubeproxyinfos
+        singular: kubeproxyinfo
+      scope: Cluster
+      versions:
+        - additionalPrinterColumns:
+            - jsonPath: .spec.nodeName
+              name: Node
+              type: string
+            - jsonPath: .status.lastSensed
+              name: Last Sensed
+              type: string
+          name: v1beta1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          served: true
+          storage: true
+  30: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: linuxkernelvariables.hostdata.kubescape.cloud
+    spec:
+      group: hostdata.kubescape.cloud
+      names:
+        kind: LinuxKernelVariables
+        listKind: LinuxKernelVariablesList
+        plural: linuxkernelvariables
+        singular: linuxkernelvariable
+      scope: Cluster
+      versions:
+        - additionalPrinterColumns:
+            - jsonPath: .spec.nodeName
+              name: Node
+              type: string
+            - jsonPath: .status.lastSensed
+              name: Last Sensed
+              type: string
+          name: v1beta1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          served: true
+          storage: true
+  31: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: linuxsecurityhardeningstatuses.hostdata.kubescape.cloud
+    spec:
+      group: hostdata.kubescape.cloud
+      names:
+        kind: LinuxSecurityHardeningStatus
+        listKind: LinuxSecurityHardeningStatusList
+        plural: linuxsecurityhardeningstatuses
+        singular: linuxsecurityhardeningstatus
+      scope: Cluster
+      versions:
+        - additionalPrinterColumns:
+            - jsonPath: .spec.nodeName
+              name: Node
+              type: string
+            - jsonPath: .status.lastSensed
+              name: Last Sensed
+              type: string
+          name: v1beta1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          served: true
+          storage: true
+  32: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: openportslists.hostdata.kubescape.cloud
+    spec:
+      group: hostdata.kubescape.cloud
+      names:
+        kind: OpenPortsList
+        listKind: OpenPortsListList
+        plural: openportslists
+        singular: openportslist
+      scope: Cluster
+      versions:
+        - additionalPrinterColumns:
+            - jsonPath: .spec.nodeName
+              name: Node
+              type: string
+            - jsonPath: .status.lastSensed
+              name: Last Sensed
+              type: string
+          name: v1beta1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                status:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          served: true
+          storage: true
+  33: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: v0.11.1
+      name: osreleasefiles.hostdata.kubescape.cloud
+    spec:
+      group: hostdata.kubescape.cloud
+      names:
+        kind: OsReleaseFile
+        listKind: OsReleaseFileList
+        plural: osreleasefiles
+        singular: osreleasefile
+      scope: Cluster
+      versions:
+        - additionalPrinterColumns:
+            - jsonPath: .spec.nodeName
+              name: Node
+              type: string
+            - jsonPath: .status.lastSensed
+              name: Last Sensed
+              type: string
+            - jsonPath: .metadata.creationTimestamp
+              name: Age
+              type: date
+          name: v1beta1
+          schema:
+            openAPIV3Schema:
+              description: OsReleaseFile contains the OS release information from a node
+              properties:
+                apiVersion:
+                  description: APIVersion defines the versioned schema of this representation of an object.
+                  type: string
+                kind:
+                  description: Kind is a string value representing the REST resource this object represents.
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  description: OsReleaseFileSpec contains the actual OS release file content
+                  properties:
+                    content:
+                      description: Content is the raw content of the OS release file
+                      type: string
+                    nodeName:
+                      description: NodeName is the name of the node this data came from
+                      type: string
+                  type: object
+                status:
+                  description: OsReleaseFileStatus contains status information about the sensing
+                  properties:
+                    error:
+                      description: Error contains any error message from the last sensing attempt
+                      type: string
+                    lastSensed:
+                      description: LastSensed is the timestamp when this data was last collected
+                      format: date-time
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+  34: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations: null
+      labels:
+        app: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: node-agent
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+          - nodes/proxy
+          - services
+          - endpoints
+          - namespaces
+          - configmaps
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - batch
+        resources:
+          - jobs
+          - cronjobs
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - apps
+        resources:
+          - deployments
+          - daemonsets
+          - statefulsets
+          - replicasets
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - seccompprofiles
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - spdx.softwarecomposition.kubescape.io
+        resources:
+          - containerprofiles
+          - sbomsyfts
+        verbs:
+          - create
+          - get
+          - update
+          - watch
+          - list
+          - patch
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - runtimerulealertbindings
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - operatorcommands
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - operatorcommands/status
+        verbs:
+          - get
+          - watch
+          - list
+          - update
+          - patch
+      - apiGroups:
+          - events.k8s.io
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+          - get
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - rules
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - hostdata.kubescape.cloud
+        resources:
+          - osreleasefiles
+          - kernelversions
+          - linuxsecurityhardeningstatuses
+          - openportslists
+          - linuxkernelvariables
+          - kubeletinfos
+          - kubeproxyinfos
+          - controlplaneinfos
+          - cloudproviderinfos
+          - cniinfos
+        verbs:
+          - create
+          - get
+          - update
+          - patch
+          - list
+          - watch
+  35: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: node-agent
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: node-agent
+    subjects:
+      - kind: ServiceAccount
+        name: node-agent
+        namespace: kubescape
+  36: |
+    apiVersion: v1
+    data:
+      config.json: |
+        {
+            "applicationProfileServiceEnabled": true,
+            "prometheusExporterEnabled": false,
+            "runtimeDetectionEnabled": false,
+            "httpDetectionEnabled": false,
+            "networkServiceEnabled": true,
+            "malwareDetectionEnabled": false,
+            "hostSensorEnabled": true,
+            "hostSensorInterval": "5m",
+            "nodeProfileServiceEnabled": false,
+            "networkStreamingEnabled": false,
+            "maxImageSize": 5.36870912e+09,
+            "maxSBOMSize": 2.097152e+07,
+            "maxTsProfileSize": 1e+06,
+            "sbomGenerationEnabled": true,
+            "enableEmbeddedSBOMs": false,
+            "seccompServiceEnabled": true,
+            "seccompProfileBackend": "crd",
+            "initialDelay": "2m",
+            "updateDataPeriod": "10m",
+            "nodeProfileInterval": "10m",
+            "networkStreamingInterval": "2m",
+            "maxSniffingTimePerContainer": "24h",
+            "excludeNamespaces": "kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public",
+            "excludeLabels":null,
+            "exporters": {
+              "alertManagerExporterUrls":[],
+              "stdoutExporter":true,
+              "syslogExporterURL": ""
+            },
+            "excludeJsonPaths":null,
+            "ruleCooldown": {
+                "ruleCooldownDuration": "1h",
+                "ruleCooldownAfterCount": 1,
+                "ruleCooldownOnProfileFailure": true,
+                "ruleCooldownMaxSize": 20000
+            },
+            "alertDeduplication": {
+                "bypass": false
+            },
+            "dCapSys": false,
+            "dDns": false,
+            "dExec": false,
+            "dExit": false,
+            "dFork": false,
+            "dHardlink": false,
+            "dHttp": false,
+            "dIouring": false,
+            "dNetwork": false,
+            "dOpen": false,
+            "dPtrace": false,
+            "dRandomx": false,
+            "dSeccomp": false,
+            "dSsh": false,
+            "dSymlink": false,
+            "dKmod": false,
+            "dUnshare": false,
+            "dBpf": false,
+            "dTop": false
+        }
+    kind: ConfigMap
+    metadata:
+      annotations: null
+      labels:
+        app: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: node-agent
+      namespace: kubescape
+  37: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      annotations: null
+      labels:
+        app: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: node-agent
+      namespace: kubescape
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: node-agent
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: kubescape-operator
+      template:
+        metadata:
+          annotations:
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
+            checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
+            checksum/node-agent-config: 1610f2ace8c6c7ce2ec544611db6c1bb415b18beab5a0644b1cca0b75d434bef
+            container.apparmor.security.beta.kubernetes.io/node-agent: unconfined
+          labels:
+            app: node-agent
+            app.kubernetes.io/component: node-agent
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: kubescape-operator
+            app.kubernetes.io/part-of: kubescape
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
+            kubescape.io/ignore: "true"
+            kubescape.io/tier: core
+            tier: ks-control-plane
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                          - linux
+          automountServiceAccountToken: true
+          containers:
+            - env:
+                - name: GOMEMLIMIT
+                  value: 1120MiB
+                - name: HOST_ROOT
+                  value: /host
+                - name: KS_LOGGER_LEVEL
+                  value: info
+                - name: KS_LOGGER_NAME
+                  value: zap
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: NAMESPACE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: KUBELET_ROOT
+                  value: /var/lib/kubelet
+                - name: AGENT_VERSION
+                  value: v0.3.219
+                - name: NodeName
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              image: quay.io/kubescape/node-agent:v0.3.219
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /livez
+                  port: 7888
+                periodSeconds: 3
+              name: node-agent
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 7888
+                periodSeconds: 3
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 1400Mi
+                requests:
+                  cpu: 100m
+                  memory: 180Mi
+              securityContext:
+                capabilities:
+                  add:
+                    - SYS_ADMIN
+                    - SYS_PTRACE
+                    - NET_ADMIN
+                    - SYSLOG
+                    - SYS_RESOURCE
+                    - IPC_LOCK
+                    - NET_RAW
+                privileged: false
+                runAsUser: 0
+                seLinuxOptions:
+                  type: spc_t
+              startupProbe:
+                failureThreshold: 30
+                httpGet:
+                  path: /readyz
+                  port: 7888
+                periodSeconds: 10
+                timeoutSeconds: 1
+              volumeMounts:
+                - mountPath: /host
+                  name: host
+                  readOnly: true
+                - mountPath: /var/lib/kubelet
+                  name: kubeletdir
+                - mountPath: /run
+                  name: run
+                - mountPath: /var
+                  name: var
+                  readOnly: true
+                - mountPath: /lib/modules
+                  name: modules
+                  readOnly: true
+                - mountPath: /sys/kernel/debug
+                  name: debugfs
+                - mountPath: /sys/fs/cgroup
+                  name: cgroup
+                  readOnly: true
+                - mountPath: /sys/fs/bpf
+                  name: bpffs
+                - mountPath: /data
+                  name: data
+                - mountPath: /profiles
+                  name: profiles
+                - mountPath: /boot
+                  name: boot
+                  readOnly: true
+                - mountPath: /etc/credentials
+                  name: cloud-secret
+                  readOnly: true
+                - mountPath: /etc/config/clusterData.json
+                  name: ks-cloud-config
+                  readOnly: true
+                  subPath: clusterData.json
+                - mountPath: /etc/config/config.json
+                  name: config
+                  readOnly: true
+                  subPath: config.json
+          hostPID: true
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: kubescape-critical
+          securityContext: null
+          serviceAccountName: node-agent
+          tolerations: null
+          volumes:
+            - hostPath:
+                path: /
+              name: host
+            - hostPath:
+                path: /var/lib/kubelet
+              name: kubeletdir
+            - hostPath:
+                path: /run
+              name: run
+            - hostPath:
+                path: /var
+              name: var
+            - hostPath:
+                path: /sys/fs/cgroup
+              name: cgroup
+            - hostPath:
+                path: /lib/modules
+              name: modules
+            - hostPath:
+                path: /sys/fs/bpf
+              name: bpffs
+            - hostPath:
+                path: /sys/kernel/debug
+              name: debugfs
+            - hostPath:
+                path: /boot
+              name: boot
+            - emptyDir: null
+              name: data
+            - emptyDir: null
+              name: profiles
+            - hostPath:
+                path: /
+                type: Directory
+              name: host-filesystem
+            - name: cloud-secret
+              secret:
+                secretName: cloud-secret
+            - configMap:
+                items:
+                  - key: clusterData
+                    path: clusterData.json
+                name: ks-cloud-config
+              name: ks-cloud-config
+            - configMap:
+                items:
+                  - key: config.json
+                    path: config.json
+                name: node-agent
+              name: config
+  38: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: node-agent
+      namespace: kubescape
+    spec:
+      ports:
+        - name: prometheus
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
+  39: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations: null
+      labels:
+        app: node-agent
+        app.kubernetes.io/component: node-agent
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: node-agent
+      namespace: kubescape
+  40: |
+    apiVersion: v1
+    data:
+      tls.crt: bW9jay1jYS1jZXJ0
+      tls.key: bW9jay1jYS1rZXk=
+    kind: Secret
+    metadata:
+      annotations:
+        helm.sh/resource-policy: keep
+      labels:
+        app: operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape-admission-webhook-ca
+      namespace: kubescape
+    type: kubernetes.io/tls
+  41: |
+    apiVersion: v1
+    data:
+      ca.crt: bW9jay1jYS1jZXJ0
+      tls.crt: bW9jay1jZXJ0LWNlcnQ=
+      tls.key: bW9jay1jZXJ0LWtleQ==
+    kind: Secret
+    metadata:
+      annotations: null
+      labels:
+        app: kubescape-admission-webhook
+        app.kubernetes.io/component: kubescape-admission-webhook
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape-admission-webhook-tls
+      namespace: kubescape
+    type: kubernetes.io/tls
+  42: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app: operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape-admission-webhook
+      namespace: kubescape
+    spec:
+      ports:
+        - port: 443
+          targetPort: 8443
+      selector:
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
+  43: |
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      annotations: null
+      labels:
+        app: operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape-admission-webhook
+    webhooks:
+      - admissionReviewVersions:
+          - v1
+        clientConfig:
+          caBundle: bW9jay1jYS1jZXJ0
+          service:
+            name: kubescape-admission-webhook
+            namespace: kubescape
+            path: /validate
+            port: 443
+        failurePolicy: Ignore
+        name: validation.kubescape.admission
+        rules:
+          - apiGroups:
+              - '*'
+            apiVersions:
+              - v1
+            operations:
+              - CREATE
+              - UPDATE
+              - DELETE
+              - CONNECT
+            resources:
+              - pods
+              - pods/exec
+              - pods/portforward
+              - pods/attach
+              - clusterrolebindings
+              - rolebindings
+            scope: '*'
+          - apiGroups:
+              - networking.k8s.io
+            apiVersions:
+              - v1
+            operations:
+              - CREATE
+            resources:
+              - networkpolicies
+            scope: '*'
+        sideEffects: None
+  44: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations: null
+      labels:
+        app: operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: operator
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - pods
+          - nodes
+          - namespaces
+          - configmaps
+          - services
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - events
+        verbs:
+          - create
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - batch
+        resources:
+          - jobs
+          - cronjobs
+        verbs:
+          - get
+          - watch
+          - list
+          - create
+          - update
+          - delete
+          - patch
+      - apiGroups:
+          - apps
+        resources:
+          - deployments
+          - daemonsets
+          - statefulsets
+          - replicasets
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - spdx.softwarecomposition.kubescape.io
+        resources:
+          - vulnerabilitymanifests
+          - vulnerabilitymanifestsummaries
+          - workloadconfigurationscans
+          - workloadconfigurationscansummaries
+          - openvulnerabilityexchangecontainers
+          - containerprofiles
+          - sbomsyfts
+        verbs:
+          - get
+          - watch
+          - list
+          - delete
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - runtimerulealertbindings
+          - rules
+        verbs:
+          - list
+          - watch
+          - get
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - servicesscanresults
+        verbs:
+          - get
+          - watch
+          - list
+          - create
+          - update
+          - delete
+          - patch
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - operatorcommands
+        verbs:
+          - get
+          - watch
+          - list
+          - create
+          - update
+          - patch
+      - apiGroups:
+          - kubescape.io
+        resources:
+          - operatorcommands/status
+        verbs:
+          - get
+          - watch
+          - list
+          - update
+          - patch
+  45: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: operator
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: operator
+    subjects:
+      - kind: ServiceAccount
+        name: operator
+        namespace: kubescape
+  46: |
+    apiVersion: v1
+    data:
+      config.json: |
+        {
+          "excludeNamespaces": "kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public",
+          "namespace": "kubescape",
+          "triggersecurityframework": true,
+          "podScanGuardTime": "1h",
+          "excludeJsonPaths":null,
+          "nodeAgentAutoscaler": {
+            "enabled": false,
+            "nodeGroupLabel": "node.kubernetes.io/instance-type",
+            "resourcePercentages": {
+              "requestCPU": 2,
+              "requestMemory": 2,
+              "limitCPU": 5,
+              "limitMemory": 5
+            },
+            "minResources": {
+              "cpu": "100m",
+              "memory": "600Mi"
+            },
+            "maxResources": {
+              "cpu": "2000m",
+              "memory": "4Gi"
+            },
+            "reconcileInterval": "5m",
+            "templatePath": "/etc/templates/daemonset-template.yaml",
+            "operatorDeploymentName": "operator",
+            "goMemLimitPercentage": 0.8,
+            "seLinuxType": "spc_t",
+            "bottlerocketAutoDetect": true
+          }
+        }
+    kind: ConfigMap
+    metadata:
+      annotations: null
+      labels:
+        app: operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: operator
+      namespace: kubescape
+  47: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations: null
+      labels:
+        app: operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: operator
+      namespace: kubescape
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: operator
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: kubescape-operator
+      strategy:
+        rollingUpdate:
+          maxSurge: 0%
+          maxUnavailable: 100%
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            checksum/capabilities-config: 2cc69c7830063c5c2a6efd8707ee55d5b4dd07b7f9700b4f55ffe30aec98e6e9
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
+            checksum/cloud-secret: 3248919273cee6d6f750f97ea378fc79fff1f03b131f21d584a00258bf475a80
+            checksum/matching-rules-config: c81857b415602f6b161db3199a16461c5acd8ba44ec7572189441f4f294a3614
+            checksum/operator-config: e74c02473b1c10be5264e717bd386897d8eb697ba99fba89fcb4cfd6edecda16
+          labels:
+            app: operator
+            app.kubernetes.io/component: operator
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: kubescape-operator
+            app.kubernetes.io/part-of: kubescape
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
+            kubescape.io/ignore: "true"
+            kubescape.io/tier: core
+            tier: ks-control-plane
+        spec:
+          affinity: null
+          automountServiceAccountToken: true
+          containers:
+            - env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                - name: HELM_RELEASE
+                  value: kubescape-operator-1.40.4
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      divisor: "1"
+                      resource: limits.memory
+                - name: KS_LOGGER_LEVEL
+                  value: info
+                - name: KS_LOGGER_NAME
+                  value: zap
+              image: quay.io/kubescape/operator:v0.2.169
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /v1/liveness
+                  port: readiness-port
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              name: operator
+              ports:
+                - containerPort: 4002
+                  name: trigger-port
+                  protocol: TCP
+                - containerPort: 8000
+                  name: readiness-port
+                  protocol: TCP
+                - containerPort: 8443
+                  name: admission-port
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /v1/readiness
+                  port: readiness-port
+                initialDelaySeconds: 10
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: 300m
+                  memory: 300Mi
+                requests:
+                  cpu: 50m
+                  memory: 100Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              volumeMounts:
+                - mountPath: /etc/credentials
+                  name: cloud-secret
+                  readOnly: true
+                - mountPath: /tmp
+                  name: tmp-dir
+                - mountPath: /etc/config/clusterData.json
+                  name: ks-cloud-config
+                  readOnly: true
+                  subPath: clusterData.json
+                - mountPath: /etc/config/capabilities.json
+                  name: ks-capabilities
+                  readOnly: true
+                  subPath: capabilities.json
+                - mountPath: /etc/config/matchingRules.json
+                  name: cs-matching-rules
+                  readOnly: true
+                  subPath: matchingRules.json
+                - mountPath: /etc/config/config.json
+                  name: config
+                  readOnly: true
+                  subPath: config.json
+                - mountPath: /etc/certs
+                  name: tls-certs
+                  readOnly: true
+          nodeSelector:
+            kubernetes.io/os: linux
+          securityContext:
+            fsGroup: 65532
+            runAsGroup: 65532
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: operator
+          tolerations: null
+          volumes:
+            - name: cloud-secret
+              secret:
+                secretName: cloud-secret
+            - name: tls-certs
+              secret:
+                secretName: kubescape-admission-webhook-tls
+            - emptyDir: {}
+              name: tmp-dir
+            - configMap:
+                items:
+                  - key: clusterData
+                    path: clusterData.json
+                name: ks-cloud-config
+              name: ks-cloud-config
+            - configMap:
+                items:
+                  - key: capabilities
+                    path: capabilities.json
+                name: ks-capabilities
+              name: ks-capabilities
+            - configMap:
+                items:
+                  - key: config.json
+                    path: config.json
+                name: operator
+              name: config
+            - configMap:
+                items:
+                  - key: matchingRules.json
+                    path: matchingRules.json
+                name: cs-matching-rules
+              name: cs-matching-rules
+  48: |
+    apiVersion: v1
+    data:
+      cronjobTemplate: |-
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: kubescape-scheduler
+          namespace: kubescape
+          labels:
+            app: kubescape-scheduler
+            tier: ks-control-plane
+            kubescape.io/tier: "core"
+            armo.tier: "kubescape-scan"
+        spec:
+          schedule: "0 8 * * *"
+          successfulJobsHistoryLimit: 3
+          failedJobsHistoryLimit: 1
+          jobTemplate:
+            spec:
+              template:
+                metadata:
+                  labels:
+                    armo.tier: "kubescape-scan"
+                    kubescape.io/tier: "core"
+                spec:
+                  securityContext:
+                    seccompProfile:
+                      type: RuntimeDefault
+                  containers:
+                  - name: kubescape-scheduler
+                    image: "quay.io/kubescape/http-request:v0.2.23"
+                    imagePullPolicy: IfNotPresent
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      runAsNonRoot: true
+                      runAsUser: 100
+                    resources:
+                      limits:
+                        cpu: 10m
+                        memory: 20Mi
+                      requests:
+                        cpu: 1m
+                        memory: 10Mi
+                    args:
+                      - -method=post
+                      - -scheme=http
+                      - -host=operator:4002
+                      - -path=v1/triggerAction
+                      - -headers=Content-Type:application/json
+                      - -path-body=/home/ks/request-body.json
+                    volumeMounts:
+                      - name: "request-body-volume"
+                        mountPath: /home/ks/request-body.json
+                        subPath: request-body.json
+                        readOnly: true
+                  restartPolicy: Never
+                  serviceAccountName: kubescape
+                  automountServiceAccountToken: false
+                  nodeSelector:
+                    kubernetes.io/os: linux
+                  affinity:
+                  tolerations:
+                  volumes:
+                    - name: "request-body-volume" # placeholder
+                      configMap:
+                        name: kubescape-scheduler
+    kind: ConfigMap
+    metadata:
+      annotations: null
+      labels:
+        app: ks-cloud-config
+        app.kubernetes.io/component: ks-cloud-config
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubescape-cronjob-template
+      namespace: kubescape
+  49: |
+    apiVersion: v1
+    data:
+      cronjobTemplate: |-
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: kubevuln-scheduler
+          namespace: kubescape
+          labels:
+            app: kubevuln-scheduler
+            tier: ks-control-plane
+            kubescape.io/tier: "core"
+            armo.tier: "vuln-scan"
+        spec:
+          schedule: "0 0 * * *"
+          successfulJobsHistoryLimit: 3
+          failedJobsHistoryLimit: 1
+          jobTemplate:
+            spec:
+              template:
+                metadata:
+                  labels:
+                    armo.tier: "vuln-scan"
+                    kubescape.io/tier: "core"
+                spec:
+                  securityContext:
+                    seccompProfile:
+                      type: RuntimeDefault
+                  containers:
+                  - name: kubevuln-scheduler
+                    image: "quay.io/kubescape/http-request:v0.2.23"
+                    imagePullPolicy: IfNotPresent
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      runAsNonRoot: true
+                      runAsUser: 100
+                    resources:
+                      limits:
+                        cpu: 10m
+                        memory: 20Mi
+                      requests:
+                        cpu: 1m
+                        memory: 10Mi
+                    args:
+                      - -method=post
+                      - -scheme=http
+                      - -host=operator:4002
+                      - -path=v1/triggerAction
+                      - -headers=Content-Type:application/json
+                      - -path-body=/home/ks/request-body.json
+                    volumeMounts:
+                      - name: "request-body-volume"
+                        mountPath: /home/ks/request-body.json
+                        subPath: request-body.json
+                        readOnly: true
+                  restartPolicy: Never
+                  serviceAccountName: kubevuln
+                  automountServiceAccountToken: false
+                  nodeSelector:
+                    kubernetes.io/os: linux
+                  affinity:
+                  tolerations:
+                  volumes:
+                    - name: "request-body-volume" # placeholder
+                      configMap:
+                        name: kubevuln-scheduler
+    kind: ConfigMap
+    metadata:
+      annotations: null
+      labels:
+        app: ks-cloud-config
+        app.kubernetes.io/component: ks-cloud-config
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: kubevuln-cronjob-template
+      namespace: kubescape
+  50: |
+    apiVersion: v1
+    data:
+      cronjobTemplate: |-
+        apiVersion: batch/v1
+        kind: CronJob
+        metadata:
+          name: registry-scheduler
+          namespace: kubescape
+          labels:
+            app: registry-scheduler
+            kubescape.io/tier: "core"
+            tier: ks-control-plane
+            armo.tier: "registry-scan"
+        spec:
+          schedule: "0 0 * * *"
+          successfulJobsHistoryLimit: 3
+          failedJobsHistoryLimit: 1
+          jobTemplate:
+            spec:
+              template:
+                metadata:
+                  labels:
+                    armo.tier: "registry-scan"
+                    kubescape.io/tier: "core"
+                spec:
+                  securityContext:
+                    seccompProfile:
+                      type: RuntimeDefault
+                  containers:
+                  - name: registry-scheduler
+                    image: "quay.io/kubescape/http-request:v0.2.23"
+                    imagePullPolicy: IfNotPresent
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      runAsNonRoot: true
+                      runAsUser: 100
+                    resources:
+                      limits:
+                        cpu: 10m
+                        memory: 20Mi
+                      requests:
+                        cpu: 1m
+                        memory: 10Mi
+                    args:
+                      - -method=post
+                      - -scheme=http
+                      - -host=operator:4002
+                      - -path=v1/triggerAction
+                      - -headers=Content-Type:application/json
+                      - -path-body=/home/ks/request-body.json
+                    volumeMounts:
+                      - name: "request-body-volume"
+                        mountPath: /home/ks/request-body.json
+                        subPath: request-body.json
+                        readOnly: true
+                  restartPolicy: Never
+                  serviceAccountName: kubevuln
+                  automountServiceAccountToken: false
+                  nodeSelector:
+                    kubernetes.io/os: linux
+                  affinity:
+                  tolerations:
+                  volumes:
+                    - name: "request-body-volume" # placeholder
+                      configMap:
+                        name: registry-scheduler
+    kind: ConfigMap
+    metadata:
+      annotations: null
+      labels:
+        app: ks-cloud-config
+        app.kubernetes.io/component: ks-cloud-config
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: registry-scan-cronjob-template
+      namespace: kubescape
+  51: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      annotations: null
+      labels:
+        app: operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: operator
+      namespace: kubescape
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - secrets
+        verbs:
+          - create
+          - get
+          - update
+          - watch
+          - list
+          - patch
+          - delete
+      - apiGroups:
+          - batch
+        resources:
+          - cronjobs
+        verbs:
+          - create
+          - get
+          - update
+          - watch
+          - list
+          - patch
+          - delete
+  52: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: operator
+      namespace: kubescape
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: operator
+    subjects:
+      - kind: ServiceAccount
+        name: operator
+        namespace: kubescape
+  53: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app: operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: operator
+      namespace: kubescape
+    spec:
+      ports:
+        - port: 4002
+          protocol: TCP
+          targetPort: 4002
+      selector:
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
+  54: |
+    apiVersion: v1
+    automountServiceAccountToken: false
+    kind: ServiceAccount
+    metadata:
+      annotations: null
+      labels:
+        app: operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: operator
+      namespace: kubescape
+  55: |
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: v1beta1.spdx.softwarecomposition.kubescape.io
+    spec:
+      caBundle: bW9jay1jYS1jZXJ0
+      group: spdx.softwarecomposition.kubescape.io
+      groupPriorityMinimum: 1000
+      service:
+        name: storage
+        namespace: kubescape
+      version: v1beta1
+      versionPriority: 15
+  56: |
+    apiVersion: v1
+    data:
+      tls.crt: bW9jay1jYS1jZXJ0
+      tls.key: bW9jay1jYS1rZXk=
+    kind: Secret
+    metadata:
+      annotations:
+        helm.sh/resource-policy: keep
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage-tls-ca
+      namespace: kubescape
+    type: kubernetes.io/tls
+  57: |
+    apiVersion: v1
+    data:
+      ca.crt: bW9jay1jYS1jZXJ0
+      tls.crt: bW9jay1jZXJ0LWNlcnQ=
+      tls.key: bW9jay1jZXJ0LWtleQ==
+    kind: Secret
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage-tls
+      namespace: kubescape
+    type: kubernetes.io/tls
+  58: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+          - pods
+          - services
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - admissionregistration.k8s.io
+        resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - batch
+        resources:
+          - cronjobs
+          - jobs
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - flowcontrol.apiserver.k8s.io
+        resources:
+          - prioritylevelconfigurations
+          - flowschemas
+        verbs:
+          - get
+          - watch
+          - list
+  59: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage:system:auth-delegator
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:auth-delegator
+    subjects:
+      - kind: ServiceAccount
+        name: storage
+        namespace: kubescape
+  60: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: storage
+    subjects:
+      - kind: ServiceAccount
+        name: storage
+        namespace: kubescape
+  61: |
+    apiVersion: v1
+    data:
+      config.json: |
+        {
+          "cleanupInterval": "6h",
+          "disableVirtualCRDs": false,
+          "disableSeccompProfileEndpoint": true,
+          "excludeJsonPaths": null,
+          "defaultQueueLength": 100,
+          "defaultWorkerCount": 2,
+          "defaultMaxObjectSize": 400000,
+          "maxContainerProfileSize": 50000,
+          "queueManagerEnabled": true,
+          "kindQueues": {"applicationprofiles":{"maxObjectSize":20000000,"queueLength":50,"workerCount":2},"containerprofiles":{"maxObjectSize":2500000,"queueLength":50,"workerCount":2},"networkneighborhoods":{"maxObjectSize":10000000,"queueLength":50,"workerCount":2},"openvulnerabilityexchangecontainers":{"maxObjectSize":500000,"queueLength":50,"workerCount":1},"sbomsyftfiltereds":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1},"sbomsyfts":{"maxObjectSize":100000000,"queueLength":50,"workerCount":1},"vulnerabilitymanifests":{"maxObjectSize":50000000,"queueLength":50,"workerCount":1}},
+          "singleWriterEnabled": true,
+          "poolTimeout": "15s",
+          "sqliteBusyTimeout": "60s",
+          "tlsClientCaFile": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+          "tlsServerCertFile": "/etc/storage-ca-certificates/tls.crt",
+          "tlsServerKeyFile": "/etc/storage-ca-certificates/tls.key",
+          "serverBindPort": "8443"
+        }
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: storage
+      namespace: kubescape
+  62: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        kubescape.io/tier: core
+        tier: ks-control-plane
+      name: storage
+      namespace: kubescape
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: storage
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: kubescape-operator
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          annotations:
+            checksum/cloud-config: bff087e836e8f4a8e379d53fa4e58e9afd944697957647a6bf2e69ba65b2f905
+            checksum/storage-config: e2c0f297c19b287eec31ca85c07b6b1b3c37238423a5e301e3b9e0e3bc558ff0
+          labels:
+            app: storage
+            app.kubernetes.io/component: storage
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: kubescape-operator
+            app.kubernetes.io/part-of: kubescape
+            app.kubernetes.io/version: 1.40.4
+            helm.sh/chart: kubescape-operator-1.40.4
+            kubescape.io/ignore: "true"
+            kubescape.io/tier: core
+            tier: ks-control-plane
+        spec:
+          affinity: null
+          containers:
+            - env:
+                - name: GOMEMLIMIT
+                  value: 1400MiB
+                - name: KS_LOGGER_LEVEL
+                  value: info
+                - name: KS_LOGGER_NAME
+                  value: zap
+              image: quay.io/kubescape/storage:v0.0.331
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /livez
+                  port: 8443
+                  scheme: HTTPS
+              name: apiserver
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8443
+                  scheme: HTTPS
+              resources:
+                limits:
+                  cpu: 1500m
+                  memory: 2000Mi
+                requests:
+                  cpu: 100m
+                  memory: 400Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+              volumeMounts:
+                - mountPath: /data
+                  name: data
+                - mountPath: /etc/config/clusterData.json
+                  name: ks-cloud-config
+                  readOnly: true
+                  subPath: clusterData.json
+                - mountPath: /etc/config/config.json
+                  name: config
+                  readOnly: true
+                  subPath: config.json
+                - mountPath: /etc/storage-ca-certificates
+                  name: ca-certificates
+                  readOnly: true
+          nodeSelector:
+            kubernetes.io/os: linux
+          securityContext:
+            fsGroup: 65532
+            runAsGroup: 65532
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: storage
+          tolerations: null
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: kubescape-storage
+            - configMap:
+                items:
+                  - key: clusterData
+                    path: clusterData.json
+                name: ks-cloud-config
+              name: ks-cloud-config
+            - configMap:
+                items:
+                  - key: config.json
+                    path: config.json
+                name: storage
+              name: config
+            - name: ca-certificates
+              secret:
+                secretName: storage-tls
+  63: |
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: kubescape-storage
+      namespace: kubescape
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+  64: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage-auth-reader
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+      - kind: ServiceAccount
+        name: storage
+        namespace: kubescape
+  65: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: seccompprofile
+        app.kubernetes.io/component: seccompprofile
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: seccompprofiles.kubescape.io
+    spec:
+      group: kubescape.io
+      names:
+        kind: SeccompProfile
+        listKind: SeccompProfileList
+        plural: seccompprofiles
+        shortNames:
+          - scp
+        singular: seccompprofile
+      scope: Namespaced
+      versions:
+        - additionalPrinterColumns:
+            - jsonPath: .metadata.creationTimestamp
+              name: Age
+              type: date
+          name: v1
+          schema:
+            openAPIV3Schema:
+              properties:
+                apiVersion:
+                  type: string
+                kind:
+                  type: string
+                metadata:
+                  type: object
+                spec:
+                  properties:
+                    containers:
+                      items:
+                        properties:
+                          name:
+                            description: Name of the container
+                            type: string
+                          path:
+                            description: Path to the seccomp profile
+                            type: string
+                          spec:
+                            properties:
+                              architectures:
+                                description: The architecture used for system calls
+                                items:
+                                  type: string
+                                type: array
+                              baseProfileName:
+                                description: Name of base profile to union into this profile
+                                type: string
+                              defaultAction:
+                                description: The default action for seccomp
+                                type: string
+                              disabled:
+                                description: Whether the profile is disabled
+                                type: boolean
+                              flags:
+                                description: List of flags to use with seccomp(2)
+                                items:
+                                  type: string
+                                type: array
+                              listenerMetadata:
+                                description: Opaque data to pass to the seccomp agent
+                                type: string
+                              listenerPath:
+                                description: Path of UNIX domain socket to contact a seccomp agent
+                                type: string
+                              syscalls:
+                                items:
+                                  properties:
+                                    action:
+                                      description: The action for seccomp rules
+                                      type: string
+                                    args:
+                                      items:
+                                        properties:
+                                          index:
+                                            description: The index for syscall arguments
+                                            format: int64
+                                            type: integer
+                                          op:
+                                            description: The operator for syscall arguments
+                                            type: string
+                                          value:
+                                            description: The value for syscall arguments
+                                            format: int64
+                                            type: integer
+                                          valueTwo:
+                                            description: The second value for syscall arguments
+                                            format: int64
+                                            type: integer
+                                        type: object
+                                      type: array
+                                    errnoRet:
+                                      description: The errno return code to use
+                                      format: int64
+                                      type: integer
+                                    names:
+                                      description: The names of the syscalls
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                    ephemeralContainers:
+                      items:
+                        properties:
+                          name:
+                            description: Name of the ephemeral container
+                            type: string
+                          path:
+                            description: Path to the seccomp profile
+                            type: string
+                          spec:
+                            properties:
+                              architectures:
+                                description: The architecture used for system calls
+                                items:
+                                  type: string
+                                type: array
+                              baseProfileName:
+                                description: Name of base profile to union into this profile
+                                type: string
+                              defaultAction:
+                                description: The default action for seccomp
+                                type: string
+                              disabled:
+                                description: Whether the profile is disabled
+                                type: boolean
+                              flags:
+                                description: List of flags to use with seccomp(2)
+                                items:
+                                  type: string
+                                type: array
+                              listenerMetadata:
+                                description: Opaque data to pass to the seccomp agent
+                                type: string
+                              listenerPath:
+                                description: Path of UNIX domain socket to contact a seccomp agent
+                                type: string
+                              syscalls:
+                                items:
+                                  properties:
+                                    action:
+                                      description: The action for seccomp rules
+                                      type: string
+                                    args:
+                                      items:
+                                        properties:
+                                          index:
+                                            description: The index for syscall arguments
+                                            format: int64
+                                            type: integer
+                                          op:
+                                            description: The operator for syscall arguments
+                                            type: string
+                                          value:
+                                            description: The value for syscall arguments
+                                            format: int64
+                                            type: integer
+                                          valueTwo:
+                                            description: The second value for syscall arguments
+                                            format: int64
+                                            type: integer
+                                        type: object
+                                      type: array
+                                    errnoRet:
+                                      description: The errno return code to use
+                                      format: int64
+                                      type: integer
+                                    names:
+                                      description: The names of the syscalls
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                    initContainers:
+                      items:
+                        properties:
+                          name:
+                            description: Name of the init container
+                            type: string
+                          path:
+                            description: Path to the seccomp profile
+                            type: string
+                          spec:
+                            properties:
+                              architectures:
+                                description: The architecture used for system calls
+                                items:
+                                  type: string
+                                type: array
+                              baseProfileName:
+                                description: Name of base profile to union into this profile
+                                type: string
+                              defaultAction:
+                                description: The default action for seccomp
+                                type: string
+                              disabled:
+                                description: Whether the profile is disabled
+                                type: boolean
+                              flags:
+                                description: List of flags to use with seccomp(2)
+                                items:
+                                  type: string
+                                type: array
+                              listenerMetadata:
+                                description: Opaque data to pass to the seccomp agent
+                                type: string
+                              listenerPath:
+                                description: Path of UNIX domain socket to contact a seccomp agent
+                                type: string
+                              syscalls:
+                                items:
+                                  properties:
+                                    action:
+                                      description: The action for seccomp rules
+                                      type: string
+                                    args:
+                                      items:
+                                        properties:
+                                          index:
+                                            description: The index for syscall arguments
+                                            format: int64
+                                            type: integer
+                                          op:
+                                            description: The operator for syscall arguments
+                                            type: string
+                                          value:
+                                            description: The value for syscall arguments
+                                            format: int64
+                                            type: integer
+                                          valueTwo:
+                                            description: The second value for syscall arguments
+                                            format: int64
+                                            type: integer
+                                        type: object
+                                      type: array
+                                    errnoRet:
+                                      description: The errno return code to use
+                                      format: int64
+                                      type: integer
+                                    names:
+                                      description: The names of the syscalls
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      type: array
+                  type: object
+                status:
+                  properties:
+                    containers:
+                      additionalProperties:
+                        properties:
+                          activeWorkloads:
+                            description: Active workloads using this profile
+                            items:
+                              type: string
+                            type: array
+                          conditions:
+                            items:
+                              properties:
+                                lastTransitionTime:
+                                  description: Last time this condition transitioned
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Message about this condition's last transition
+                                  type: string
+                                reason:
+                                  description: Reason for this condition's last transition
+                                  type: string
+                                status:
+                                  description: Status of this condition (True, False, Unknown)
+                                  type: string
+                                type:
+                                  description: Type of this condition
+                                  type: string
+                              type: object
+                            type: array
+                          localhostProfile:
+                            description: Path for securityContext.seccompProfile.localhostProfile
+                            type: string
+                          path:
+                            description: Path to the seccomp profile
+                            type: string
+                          status:
+                            description: Profile state
+                            type: string
+                        type: object
+                      type: object
+                  type: object
+              type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+  66: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage
+      namespace: kubescape
+    spec:
+      ports:
+        - name: https
+          port: 443
+          protocol: TCP
+          targetPort: 8443
+      selector:
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: kubescape-operator
+      type: ClusterIP
+  67: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations: null
+      labels:
+        app: storage
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kubescape-operator
+        app.kubernetes.io/part-of: kubescape
+        app.kubernetes.io/version: 1.40.4
+        helm.sh/chart: kubescape-operator-1.40.4
+        kubescape.io/ignore: "true"
+        tier: ks-control-plane
+      name: storage
       namespace: kubescape
 with image pull secret generated:
   1: |

--- a/charts/kubescape-operator/tests/snapshot_test.yaml
+++ b/charts/kubescape-operator/tests/snapshot_test.yaml
@@ -1071,3 +1071,16 @@ tests:
             apiGroups: ["networking.k8s.io"]
             resources: ["networkpolicies"]
             verbs: ["create", "delete", "get", "list"]
+  - it: storage profile size caps and GOMEMLIMIT headroom
+    capabilities:
+      apiVersions:
+        - batch/v1
+    set:
+      unittest: true
+      storage.resources.limits.memory: 2000Mi
+      storage.gomemlimitPercentage: 0.7
+      nodeAgent.config.maxTsProfileSize: 1000000
+      storage.maxContainerProfileSize: 50000
+    asserts:
+      - matchSnapshot: {}
+    

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -589,6 +589,11 @@ storage:
   defaultQueueLength: 100
   defaultWorkerCount: 2
   defaultMaxObjectSize: 400000 # in bytes, this is the maximum size of an object that can be stored in the storage service
+  maxContainerProfileSize: 40000 # item count, matches storage viper default
+  # GOMEMLIMIT as a fraction of resources.limits.memory. 0.8 = 80%.
+  # Lower values give the runtime more headroom; raise toward 1.0 only if
+  # GC is not aggressive enough.
+  gomemlimitPercentage: 0.8
   kindQueues:
     # -- set the queues for the different kinds, the default is to use the default queue length and worker count
     applicationprofiles:
@@ -636,6 +641,7 @@ nodeAgent:
 
   config:
     maxLearningPeriod: 24h # duration string
+    maxTsProfileSize: 2097152 # bytes, matches node-agent viper default (2 MiB)
     learningPeriod: 2m # duration string
     updatePeriod: 10m # duration string
     nodeProfileInterval: 10m # duration string


### PR DESCRIPTION
## What

Exposes the two untunable ContainerProfile size caps through the chart and gives storage's Go runtime GC headroom:

- `nodeAgent.config.maxTsProfileSize` (bytes, default 2097152 = node-agent viper default) → rendered into node-agent `config.json`
- `storage.maxContainerProfileSize` (item count, default 40000 = storage viper default) → rendered into storage `config.json`
- `storage.gomemlimitPercentage` (default 0.8) → storage GOMEMLIMIT now computed via the existing `kubescape-operator.gomemlimit` helper instead of raw `limits.memory` (1:1 mapping gives the GC zero headroom, the OOM-crashloop shape from the linked customer incident)

## Why

A customer (ISO Gruppe, Rancher/RKE2) hit `request entity too large` on ContainerProfiles. The caps live in three different units (heap bytes / wire bytes / item count) with ~19% nominal headroom, and only `maxObjectSize` was chart-exposed, so operators could not unblock without a new container image. Raising the caps safely also requires GOMEMLIMIT headroom, hence part 2. Details: #885, kubescape/node-agent#865 (Go-side fix shipped in node-agent#866, chart side remained open), kubescape/storage#350.

## Note on issue key names

The issue asks for `maxApplicationProfileSize` / `maxNetworkNeighborhoodSize`, but current storage code (`pkg/config/config.go`) defines `maxContainerProfileSize` (viper default 40000) and has no neighborhood-size key, so this PR exposes the real keys. Happy to adjust if maintainers prefer upstream key additions first.

## Testing

- `helmunittest/helm-unittest` docker image (same as CI): 108/108 tests, 1060/1060 snapshots green
- New snapshot case `storage profile size caps and GOMEMLIMIT headroom` with non-default values (2000Mi limit x 0.7 → renders `GOMEMLIMIT: 1400MiB`, caps render as 1e+06 / 50000), proving end-to-end wiring rather than defaults

Closes #885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable limits for node-agent time-series profiles and storage container profiles.
  - Added a storage memory-headroom percentage setting for controlling memory usage.

- **Bug Fixes**
  - Storage now applies its memory limit setting only when a memory limit is configured, helping prevent invalid or unintended memory configuration.

- **Documentation**
  - Added default values and configuration entries for the new profile-size and memory-headroom settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->