### PR TITLE
feat(kubescape,operator,prometheus-exporter,synchronizer): give GOMEMLIMIT GC headroom

### DIFF
--- a/charts/kubescape-operator/templates/kubescape/deployment.yaml
+++ b/charts/kubescape-operator/templates/kubescape/deployment.yaml
@@ -88,11 +88,10 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 3
         env:
+        {{- if .Values.kubescape.resources.limits.memory }}
         - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.memory
-              divisor: '1'
+          value: {{ include "kubescape-operator.gomemlimit" (dict "memory" .Values.kubescape.resources.limits.memory "percentage" .Values.kubescape.gomemlimitPercentage) | quote }}
+        {{- end }}
         - name: KS_LOGGER_LEVEL
           value: "{{ .Values.logger.level }}"
         - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/templates/operator/deployment.yaml
+++ b/charts/kubescape-operator/templates/operator/deployment.yaml
@@ -175,11 +175,10 @@ spec:
                   fieldPath: spec.nodeName
             - name: HELM_RELEASE
               value: kubescape-operator-{{ .Chart.Version | replace "+" "_" }}
+            {{- if .Values.operator.resources.limits.memory }}
             - name: GOMEMLIMIT
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.memory
-                  divisor: '1'
+              value: {{ include "kubescape-operator.gomemlimit" (dict "memory" .Values.operator.resources.limits.memory "percentage" .Values.operator.gomemlimitPercentage) | quote }}
+            {{- end }}
             - name: KS_LOGGER_LEVEL
               value: "{{ .Values.logger.level }}"
             - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
+++ b/charts/kubescape-operator/templates/prometheus-exporter/deployment.yaml
@@ -69,11 +69,10 @@ spec:
           resources:
 {{ toYaml .Values.prometheusExporter.resources | indent 12 }}
           env:
+            {{- if .Values.prometheusExporter.resources.limits.memory }}
             - name: GOMEMLIMIT
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.memory
-                  divisor: '1'
+              value: {{ include "kubescape-operator.gomemlimit" (dict "memory" .Values.prometheusExporter.resources.limits.memory "percentage" .Values.prometheusExporter.gomemlimitPercentage) | quote }}
+            {{- end }}
             - name: KS_LOGGER_LEVEL
               value: "{{ .Values.logger.level }}"
             - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/templates/synchronizer/deployment.yaml
+++ b/charts/kubescape-operator/templates/synchronizer/deployment.yaml
@@ -75,11 +75,10 @@ spec:
           env:
             - name: HELM_RELEASE
               value: kubescape-operator-{{ .Chart.Version | replace "+" "_" }}
+            {{- if .Values.synchronizer.resources.limits.memory }}
             - name: GOMEMLIMIT
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.memory
-                  divisor: '1'
+              value: {{ include "kubescape-operator.gomemlimit" (dict "memory" .Values.synchronizer.resources.limits.memory "percentage" .Values.synchronizer.gomemlimitPercentage) | quote }}
+            {{- end }}
             - name: KS_LOGGER_LEVEL
               value: "{{ .Values.logger.level }}"
             - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -62124,10 +62124,7 @@ storage profile size caps and GOMEMLIMIT headroom:
                 - ksserver
               env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 819MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -64007,10 +64004,7 @@ storage profile size caps and GOMEMLIMIT headroom:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1220,10 +1220,7 @@ all capabilities:
                 - ksserver
               env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 819MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -4445,10 +4442,7 @@ all capabilities:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -5182,10 +5176,7 @@ all capabilities:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 80MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -6832,10 +6823,7 @@ all capabilities:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 400MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -7756,10 +7744,7 @@ autoscaler mode with sbom sidecar:
                 - ksserver
               env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 819MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -9443,10 +9428,7 @@ autoscaler mode with sbom sidecar:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -11255,10 +11237,7 @@ autoscaler mode with sbom sidecar:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 400MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -12067,10 +12046,7 @@ autoscaler mode without sbom sidecar:
                 - ksserver
               env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 819MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -13754,10 +13730,7 @@ autoscaler mode without sbom sidecar:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -15566,10 +15539,7 @@ autoscaler mode without sbom sidecar:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 400MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -15816,10 +15786,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -16132,10 +16099,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -16812,10 +16776,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -17393,10 +17354,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -17966,10 +17924,7 @@ cert strategy template, admission disabled, mtls disabled:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -18282,10 +18237,7 @@ cert strategy template, admission disabled, mtls enabled:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -18780,10 +18732,7 @@ cert strategy template, admission enabled, mtls disabled:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -19235,10 +19184,7 @@ cert strategy template, admission enabled, mtls enabled:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -20389,10 +20335,7 @@ default capabilities:
                 - ksserver
               env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 819MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -23217,10 +23160,7 @@ default capabilities:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -25175,10 +25115,7 @@ default capabilities:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 400MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -26061,10 +25998,7 @@ disable otel:
                 - ksserver
               env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 819MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -27952,10 +27886,7 @@ disable otel:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -29746,10 +29677,7 @@ disable otel:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 400MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -30560,10 +30488,7 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
                 - ksserver
               env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 819MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -33230,10 +33155,7 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -35006,10 +34928,7 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 400MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -35824,10 +35743,7 @@ minimal capabilities:
                 - ksserver
               env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 819MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -37706,10 +37622,7 @@ minimal capabilities:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -40187,10 +40100,7 @@ multiple node agents:
                 - ksserver
               env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 819MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -43667,10 +43577,7 @@ multiple node agents:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -44404,10 +44311,7 @@ multiple node agents:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 80MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -46054,10 +45958,7 @@ multiple node agents:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 400MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -46979,10 +46880,7 @@ priority class scheduling:
                 - ksserver
               env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 819MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -48873,10 +48771,7 @@ priority class scheduling:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -50669,10 +50564,7 @@ priority class scheduling:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 400MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -51481,10 +51373,7 @@ relevancy only:
                 - ksserver
               env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 819MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -53233,10 +53122,7 @@ relevancy only:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -55705,10 +55591,7 @@ skipPersistence enabled:
                 - ksserver
               env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 819MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -58933,10 +58816,7 @@ skipPersistence enabled:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 240MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -59670,10 +59550,7 @@ skipPersistence enabled:
           containers:
             - env:
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 80MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME
@@ -61320,10 +61197,7 @@ skipPersistence enabled:
                 - name: HELM_RELEASE
                   value: kubescape-operator-1.40.4
                 - name: GOMEMLIMIT
-                  valueFrom:
-                    resourceFieldRef:
-                      divisor: "1"
-                      resource: limits.memory
+                  value: 400MiB
                 - name: KS_LOGGER_LEVEL
                   value: info
                 - name: KS_LOGGER_NAME

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -317,8 +317,8 @@ imageScanning:
 # kubescape scanner - https://github.com/kubescape/kubescape
 kubescape:
   # GOMEMLIMIT as a fraction of resources.limits.memory. 0.8 = 80%.
-  # Lower values give the runtime more headroom; raise toward 1.0 only if
-  # GC is not aggressive enough.
+  # Lower values give the runtime more headroom. Raise toward 1.0 only
+  # if GC is too aggressive; lower it if GC is not aggressive enough.
   gomemlimitPercentage: 0.8
   name: kubescape
 
@@ -382,8 +382,8 @@ kubescape:
 # Operator will trigger kubescape and kubevuln scanning
 operator:
   # GOMEMLIMIT as a fraction of resources.limits.memory. 0.8 = 80%.
-  # Lower values give the runtime more headroom; raise toward 1.0 only if
-  # GC is not aggressive enough.
+  # Lower values give the runtime more headroom. Raise toward 1.0 only
+  # if GC is too aggressive; lower it if GC is not aggressive enough.
   gomemlimitPercentage: 0.8
   # operator Deployment name
   name: operator
@@ -927,8 +927,8 @@ nodeAgent:
 
 synchronizer:
   # GOMEMLIMIT as a fraction of resources.limits.memory. 0.8 = 80%.
-  # Lower values give the runtime more headroom; raise toward 1.0 only if
-  # GC is not aggressive enough.
+  # Lower values give the runtime more headroom. Raise toward 1.0 only
+  # if GC is too aggressive; lower it if GC is not aggressive enough.
   gomemlimitPercentage: 0.8
   name: synchronizer
   image:
@@ -1013,8 +1013,8 @@ grypeOfflineDB:
 # Prometheus exporter
 prometheusExporter:
   # GOMEMLIMIT as a fraction of resources.limits.memory. 0.8 = 80%.
-  # Lower values give the runtime more headroom; raise toward 1.0 only if
-  # GC is not aggressive enough.
+  # Lower values give the runtime more headroom. Raise toward 1.0 only
+  # if GC is too aggressive; lower it if GC is not aggressive enough.
   gomemlimitPercentage: 0.8
   name: "prometheus-exporter"
   image:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -316,6 +316,10 @@ imageScanning:
 
 # kubescape scanner - https://github.com/kubescape/kubescape
 kubescape:
+  # GOMEMLIMIT as a fraction of resources.limits.memory. 0.8 = 80%.
+  # Lower values give the runtime more headroom; raise toward 1.0 only if
+  # GC is not aggressive enough.
+  gomemlimitPercentage: 0.8
   name: kubescape
 
   image:
@@ -377,6 +381,10 @@ kubescape:
 
 # Operator will trigger kubescape and kubevuln scanning
 operator:
+  # GOMEMLIMIT as a fraction of resources.limits.memory. 0.8 = 80%.
+  # Lower values give the runtime more headroom; raise toward 1.0 only if
+  # GC is not aggressive enough.
+  gomemlimitPercentage: 0.8
   # operator Deployment name
   name: operator
 
@@ -918,6 +926,10 @@ nodeAgent:
 # +++++++++++++++++++++++++++++ Synchronizer ++++++++++++++++++++++++++++++++++++++++++++++++
 
 synchronizer:
+  # GOMEMLIMIT as a fraction of resources.limits.memory. 0.8 = 80%.
+  # Lower values give the runtime more headroom; raise toward 1.0 only if
+  # GC is not aggressive enough.
+  gomemlimitPercentage: 0.8
   name: synchronizer
   image:
     # -- source code: https://github.com/kubescape/synchronizer
@@ -1000,6 +1012,10 @@ grypeOfflineDB:
 
 # Prometheus exporter
 prometheusExporter:
+  # GOMEMLIMIT as a fraction of resources.limits.memory. 0.8 = 80%.
+  # Lower values give the runtime more headroom; raise toward 1.0 only if
+  # GC is not aggressive enough.
+  gomemlimitPercentage: 0.8
   name: "prometheus-exporter"
   image:
     repository: quay.io/kubescape/prometheus-exporter


### PR DESCRIPTION
## What

Gives the Go runtime GC headroom in the four remaining components that pin `GOMEMLIMIT` to `limits.memory` exactly (100%): `kubescape`, `operator`, `prometheus-exporter`, `synchronizer`.

Follows the pattern already used by `kubevuln`, `node-agent` and `storage` (#916): `GOMEMLIMIT` is computed via the existing `kubescape-operator.gomemlimit` helper as `gomemlimitPercentage * resources.limits.memory`, default `0.8`, overridable per component in `values.yaml`.

## Why

With `GOMEMLIMIT == limits.memory`, the GC's "collect aggressively" line and the kernel's OOM line are the same line. On an allocation spike, live heap crosses the limit before the GC reacts and the kernel wins, the OOM-crashloop shape seen in the ISO Gruppe incident (#885). 80% gives the GC 20% runway.

This finishes the consistency cleanup requested in #885: 6 of the chart's Go components already give headroom (kubevuln, node-agent, storage via #916), these 4 did not.

## Behavior

| Component | limits.memory (default) | GOMEMLIMIT after |
|---|---|---|
| kubescape | 1Gi | 819MiB |
| operator | 300Mi | 240MiB |
| synchronizer | 500Mi | 400MiB |
| prometheus-exporter | 100Mi | 80MiB |

- No memory limit set in values: unchanged, no env var rendered (guard preserved)
- Override: set `X.gomemlimitPercentage` in values
- Helm values are authoritative, same as the three components already on this helper. If a namespace applies LimitRange defaults, mirror them in values for GOMEMLIMIT to track them.

## Test Plan

- [x] `helm unittest charts/kubescape-operator/` green (13 suites, 107 tests, 993 snapshots)
- [x] Snapshots regenerated with `-u`; diff shows only the four deployments' GOMEMLIMIT env blocks changed
- [x] Default render verified via `helm template`: kubescape 819MiB, operator 240MiB, synchronizer 400MiB, prometheus-exporter 80MiB (0.8 × limits.memory)
- [x] DCO signed

Part of #885. Part 1: #916


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable Go memory limit percentages for Kubescape, the operator, synchronizer, storage, and Prometheus exporter components.
  - The default setting uses 80% of each configured memory limit.
  - Go memory limits are applied only when a component’s memory limit is configured.
  - Memory settings are calculated consistently across supported chart components.
  - Restored storage profile size settings and added a node agent profile size setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->