### PR TITLE
docs: fix reversed GC tuning guidance in kubevuln, storage, nodeAgent comments

### DIFF
--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -451,8 +451,8 @@ kubevuln:
   name: kubevuln
 
   # GOMEMLIMIT as a fraction of resources.limits.memory. 0.8 = 80%.
-  # Lower values give the runtime more headroom; raise toward 1.0 only if
-  # GC is not aggressive enough.
+  # Lower values give the runtime more headroom. Raise toward 1.0 only
+  # if GC is too aggressive; lower it if GC is not aggressive enough.
   gomemlimitPercentage: 0.8
 
   image:
@@ -591,8 +591,8 @@ storage:
   defaultMaxObjectSize: 400000 # in bytes, this is the maximum size of an object that can be stored in the storage service
   maxContainerProfileSize: 40000 # item count, matches storage viper default
   # GOMEMLIMIT as a fraction of resources.limits.memory. 0.8 = 80%.
-  # Lower values give the runtime more headroom; raise toward 1.0 only if
-  # GC is not aggressive enough.
+  # Lower values give the runtime more headroom. Raise toward 1.0 only
+  # if GC is too aggressive; lower it if GC is not aggressive enough.
   gomemlimitPercentage: 0.8
   kindQueues:
     # -- set the queues for the different kinds, the default is to use the default queue length and worker count
@@ -630,8 +630,8 @@ storage:
 nodeAgent:
   name: node-agent
   # GOMEMLIMIT as a fraction of resources.limits.memory. 0.8 = 80%.
-  # Lower values give the runtime more headroom; raise toward 1.0 only if
-  # GC is not aggressive enough.
+  # Lower values give the runtime more headroom. Raise toward 1.0 only
+  # if GC is too aggressive; lower it if GC is not aggressive enough.
   gomemlimitPercentage: 0.8
   image:
     # -- source code: https://github.com/kubescape/node-agent


### PR DESCRIPTION
Small follow-up to #917 while fixing the GC comment there I noticed kubevuln, storage and nodeAgent still have the old reversed wording ("raise toward 1.0 if GC is not aggressive enough", it's the other way around). Storage came in with #916 so it's outside that PR's diff, hence a separate PR.

Comment only, nothing renders differently.
