### PR TITLE
chore: drop legacy capabilities.backend-storage support

### DIFF
--- a/charts/kubescape-operator/Chart.yaml
+++ b/charts/kubescape-operator/Chart.yaml
@@ -15,14 +15,14 @@ kubeVersion: ">=1.28.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.40.4
+version: 1.40.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-appVersion: 1.40.4
+appVersion: 1.40.5
 
 maintainers:
 - name: Ben Hirschberg

--- a/charts/kubescape-operator/templates/_common.tpl
+++ b/charts/kubescape-operator/templates/_common.tpl
@@ -30,8 +30,6 @@ storageCertgenScripts: {{ include (printf "%s/storage/certgen/configmap.yaml" $.
     {{- fail (printf "nodeAgent.config.extra.backendStorageEnabled must be a bool (true or false), got %s %v" (kindOf $val) $val) -}}
   {{- end -}}
   {{- $backendStorage = $val -}}
-{{- else if eq (index .Values.capabilities "backend-storage" | default "") "enable" -}}
-  {{- $backendStorage = true -}}
 {{- end -}}
 continuousScan: {{ and (eq .Values.capabilities.continuousScan "enable") (not $submit) }}
 createCloudSecret: {{ $createCloudSecret }}

--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,7 +1,7 @@
 all capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.4.
+      Thank you for installing kubescape-operator version 1.40.5.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -35,8 +35,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -55,8 +55,8 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
-                helm.sh/chart: kubescape-operator-1.40.4
+                app.kubernetes.io/version: 1.40.5
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -117,8 +117,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -161,8 +161,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -186,8 +186,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -212,8 +212,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -233,8 +233,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -281,8 +281,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -311,8 +311,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -332,8 +332,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -355,8 +355,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -376,8 +376,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -394,9 +394,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -416,9 +416,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -476,8 +476,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -507,9 +507,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
+            app.kubernetes.io/version: 1.40.5
             bar: baz
-            helm.sh/chart: kubescape-operator-1.40.4
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -568,8 +568,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -603,8 +603,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -628,8 +628,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -653,8 +653,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -681,8 +681,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -701,8 +701,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -720,9 +720,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -742,9 +742,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -811,8 +811,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -863,8 +863,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1149,8 +1149,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1174,8 +1174,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1207,8 +1207,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -1390,8 +1390,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1409,8 +1409,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1486,8 +1486,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1517,8 +1517,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1543,8 +1543,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -1569,8 +1569,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1599,8 +1599,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -1617,8 +1617,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -1650,8 +1650,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1669,9 +1669,9 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1691,9 +1691,9 @@ all capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -1760,8 +1760,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -1812,8 +1812,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1886,8 +1886,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -1911,8 +1911,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -1941,8 +1941,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -2071,8 +2071,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2128,8 +2128,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -2152,8 +2152,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -2178,8 +2178,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2207,8 +2207,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -2594,8 +2594,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-gke-allowlist
@@ -2614,8 +2614,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2761,8 +2761,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -2849,8 +2849,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2868,8 +2868,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -2896,9 +2896,9 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
+            app.kubernetes.io/version: 1.40.5
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.4
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -3121,8 +3121,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -3172,8 +3172,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -3894,8 +3894,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -3953,8 +3953,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -3979,8 +3979,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -4007,8 +4007,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -4029,8 +4029,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -4052,8 +4052,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -4071,8 +4071,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -4098,8 +4098,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -4155,8 +4155,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4314,8 +4314,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4373,8 +4373,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4392,8 +4392,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4428,8 +4428,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -4443,7 +4443,7 @@ all capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -4660,8 +4660,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4748,8 +4748,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4767,8 +4767,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4932,8 +4932,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -4951,8 +4951,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -4995,8 +4995,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5021,8 +5021,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -5047,8 +5047,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5076,8 +5076,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -5093,8 +5093,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5121,8 +5121,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5146,8 +5146,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5172,8 +5172,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -5257,8 +5257,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5315,8 +5315,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5343,8 +5343,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5361,8 +5361,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -5397,8 +5397,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -5416,8 +5416,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -5442,8 +5442,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5508,8 +5508,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -5533,8 +5533,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5575,8 +5575,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5594,8 +5594,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -5623,8 +5623,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -5716,8 +5716,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -5775,8 +5775,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -5799,8 +5799,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -5825,8 +5825,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -5850,8 +5850,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -6174,8 +6174,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -6203,8 +6203,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -6221,8 +6221,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6458,8 +6458,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -6767,8 +6767,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6786,8 +6786,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -6817,8 +6817,8 @@ all capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -6830,7 +6830,7 @@ all capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -6935,8 +6935,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7002,8 +7002,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7045,8 +7045,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7070,8 +7070,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -7095,8 +7095,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7123,8 +7123,8 @@ all capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -7132,7 +7132,7 @@ all capabilities:
 autoscaler mode with sbom sidecar:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.4.
+      Thank you for installing kubescape-operator version 1.40.5.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -7168,8 +7168,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -7215,8 +7215,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -7245,8 +7245,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7267,8 +7267,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7288,8 +7288,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -7308,8 +7308,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7327,9 +7327,9 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7349,9 +7349,9 @@ autoscaler mode with sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -7416,8 +7416,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7686,8 +7686,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7711,8 +7711,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7743,8 +7743,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -7882,8 +7882,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -7901,8 +7901,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7932,8 +7932,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7958,8 +7958,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -7988,8 +7988,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -8007,8 +8007,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8026,9 +8026,9 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8048,9 +8048,9 @@ autoscaler mode with sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -8115,8 +8115,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8156,8 +8156,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8181,8 +8181,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8210,8 +8210,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -8320,8 +8320,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8349,8 +8349,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -8736,8 +8736,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8883,8 +8883,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -8971,8 +8971,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -8990,8 +8990,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -9018,8 +9018,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -9027,7 +9027,7 @@ autoscaler mode with sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 7b65380acf10117daf2388c2ea4ae90974ad08e1918d145231398a4eeac7b3e0\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.219\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.5\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.5\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 7b65380acf10117daf2388c2ea4ae90974ad08e1918d145231398a4eeac7b3e0\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.5\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.5\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - emptyDir:\n          medium: Memory\n          sizeLimit: 10Mi\n        name: sbom-comm\n      - emptyDir: {}\n        name: sbom-scanner-tmp\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: sbom-scanner\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        command: \n          - /usr/bin/sbom-scanner\n        securityContext:\n          runAsUser: 0\n          readOnlyRootFilesystem: true\n          capabilities:\n            drop: [\"ALL\"]\n        resources:\n          limits:\n            cpu: 1000m\n            memory: 4Gi\n          requests:\n            cpu: 50m\n            memory: 256Mi\n        env:\n          - name: GOMEMLIMIT\n            value: \"3276MiB\"\n          - name: SOCKET_PATH\n            value: \"/sbom-comm/scanner.sock\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: CLUSTER_NAME\n            value: \"kind-kind\"\n        volumeMounts:\n          - mountPath: /sbom-comm\n            name: sbom-comm\n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /tmp\n            name: sbom-scanner-tmp\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: SBOM_SCANNER_SOCKET\n            value: \"/sbom-comm/scanner.sock\"\n          - name: SCANNER_MEMORY_LIMIT\n            value: \"4Gi\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.219\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: sbom-comm\n            mountPath: /sbom-comm\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -9038,8 +9038,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9061,8 +9061,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -9084,8 +9084,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -9103,8 +9103,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -9130,8 +9130,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -9187,8 +9187,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9313,8 +9313,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9372,8 +9372,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9391,8 +9391,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9426,8 +9426,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -9441,7 +9441,7 @@ autoscaler mode with sbom sidecar:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -9642,8 +9642,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9727,8 +9727,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9812,8 +9812,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -9831,8 +9831,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9887,8 +9887,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9913,8 +9913,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9942,8 +9942,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -9960,8 +9960,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -9990,8 +9990,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -10013,8 +10013,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -10032,8 +10032,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10098,8 +10098,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -10123,8 +10123,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10168,8 +10168,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10187,8 +10187,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -10216,8 +10216,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -10312,8 +10312,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -10336,8 +10336,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -10361,8 +10361,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -10685,8 +10685,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10714,8 +10714,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -10732,8 +10732,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -10900,8 +10900,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11191,8 +11191,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11210,8 +11210,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11240,8 +11240,8 @@ autoscaler mode with sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -11253,7 +11253,7 @@ autoscaler mode with sbom sidecar:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -11338,8 +11338,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11381,8 +11381,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11406,8 +11406,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11434,8 +11434,8 @@ autoscaler mode with sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -11443,7 +11443,7 @@ autoscaler mode with sbom sidecar:
 autoscaler mode without sbom sidecar:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.4.
+      Thank you for installing kubescape-operator version 1.40.5.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -11479,8 +11479,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -11526,8 +11526,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -11556,8 +11556,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11578,8 +11578,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11599,8 +11599,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -11619,8 +11619,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11638,9 +11638,9 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -11660,9 +11660,9 @@ autoscaler mode without sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -11727,8 +11727,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -11997,8 +11997,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12022,8 +12022,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12054,8 +12054,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -12193,8 +12193,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12212,8 +12212,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12243,8 +12243,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12269,8 +12269,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12299,8 +12299,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -12318,8 +12318,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12337,9 +12337,9 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12359,9 +12359,9 @@ autoscaler mode without sbom sidecar:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -12426,8 +12426,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12467,8 +12467,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12492,8 +12492,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -12521,8 +12521,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -12631,8 +12631,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -12660,8 +12660,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -13047,8 +13047,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13194,8 +13194,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13282,8 +13282,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13301,8 +13301,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13329,8 +13329,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -13338,7 +13338,7 @@ autoscaler mode without sbom sidecar:
   39: |
     apiVersion: v1
     data:
-      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.4\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.4\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 7b65380acf10117daf2388c2ea4ae90974ad08e1918d145231398a4eeac7b3e0\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.4\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.4\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.219\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
+      daemonset-template.yaml: "apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: \"{{ .Name }}\"\n  namespace: kubescape\n  annotations:\n    \n  labels:\n    helm.sh/chart: kubescape-operator-1.40.5\n    app.kubernetes.io/name: kubescape-operator\n    app.kubernetes.io/instance: RELEASE-NAME\n    app.kubernetes.io/component: node-agent\n    app.kubernetes.io/version: \"1.40.5\"\n    app.kubernetes.io/managed-by: Helm\n    app.kubernetes.io/part-of: kubescape\n    app: node-agent\n    tier: ks-control-plane\n    kubescape.io/ignore: \"true\"\n    kubescape.io/tier: \"core\"\n    kubescape.io/managed-by: operator-autoscaler\n    kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\nspec:\n  selector:\n    matchLabels:\n      app.kubernetes.io/name: kubescape-operator\n      app.kubernetes.io/instance: RELEASE-NAME\n      app.kubernetes.io/component: node-agent\n      kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n  template:\n    metadata:\n      annotations:\n        \n        checksum/node-agent-config: 7b65380acf10117daf2388c2ea4ae90974ad08e1918d145231398a4eeac7b3e0\n        checksum/cloud-secret: 435193bc039d949c849ba4b141adeb4836e4d0fdcc4bf0b9588d0e36de86c424\n        checksum/cloud-config: 36cdbef2f6574028638c1fd9ce116f3aa533d846bd9af394c84fce27c04e1b0a\n        container.apparmor.security.beta.kubernetes.io/node-agent: unconfined\n      labels:\n        helm.sh/chart: kubescape-operator-1.40.5\n        app.kubernetes.io/name: kubescape-operator\n        app.kubernetes.io/instance: RELEASE-NAME\n        app.kubernetes.io/component: node-agent\n        app.kubernetes.io/version: \"1.40.5\"\n        app.kubernetes.io/managed-by: Helm\n        app.kubernetes.io/part-of: kubescape\n        app: node-agent\n        tier: ks-control-plane\n        kubescape.io/ignore: \"true\"\n        kubescape.io/tier: \"core\"\n        kubescape.io/node-group: \"{{ .NodeGroupLabel }}\"\n    spec:\n      securityContext:\n      priorityClassName: kubescape-critical\n      serviceAccountName: node-agent\n      automountServiceAccountToken: true\n      hostPID: true\n      volumes:\n      \n      - hostPath:\n          path: /\n        name: host\n      - hostPath:\n          path: /var/lib/kubelet\n        name: kubeletdir\n      - hostPath:\n          path: /run\n        name: run\n      - hostPath:\n          path: /var\n        name: var\n      - hostPath:\n          path: /sys/fs/cgroup\n        name: cgroup\n      - hostPath:\n          path: /lib/modules\n        name: modules\n      - hostPath:\n          path: /sys/fs/bpf\n        name: bpffs\n      - hostPath:\n          path: /sys/kernel/debug\n        name: debugfs\n      - hostPath:\n          path: /boot\n        name: boot\n      - emptyDir: null\n        name: data\n      - emptyDir: null\n        name: profiles\n      - hostPath:\n          path: /\n          type: Directory\n        name: host-filesystem\n      - name: cloud-secret\n        secret:\n          secretName: cloud-secret\n      - name: ks-cloud-config\n        configMap:\n          name: ks-cloud-config\n          items:\n            - key: \"clusterData\"\n              path: \"clusterData.json\"\n      - name: config\n        configMap:\n          name: node-agent\n          items:\n            - key: \"config.json\"\n              path: \"config.json\"\n      containers:\n      \n      - name: node-agent\n        image: \"quay.io/kubescape/node-agent:v0.3.219\"\n        imagePullPolicy: IfNotPresent\n        livenessProbe:\n          httpGet:\n            path: /livez\n            port: 7888\n          periodSeconds: 3\n        readinessProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 3\n        startupProbe:\n          httpGet:\n            path: /readyz\n            port: 7888\n          periodSeconds: 10\n          failureThreshold: 30\n          timeoutSeconds: 1\n        resources:\n          \n          requests:\n            cpu: \"{{ .Resources.Requests.CPU }}\"\n            memory: \"{{ .Resources.Requests.Memory }}\"\n          limits:\n            cpu: \"{{ .Resources.Limits.CPU }}\"\n            memory: \"{{ .Resources.Limits.Memory }}\"\n        env:\n          \n          - name: GOMEMLIMIT\n            value: \"{{ .GoMemLimit }}\"\n          - name: HOST_ROOT\n            value: \"/host\"\n          - name: KS_LOGGER_LEVEL\n            value: \"info\"\n          - name: KS_LOGGER_NAME\n            value: \"zap\"\n          - name: NODE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n          - name: POD_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.name\n          - name: NAMESPACE_NAME\n            valueFrom:\n              fieldRef:\n                fieldPath: metadata.namespace\n          - name: KUBELET_ROOT\n            value: \"/var/lib/kubelet\"\n          - name: AGENT_VERSION\n            value: \"v0.3.219\"\n          - name: API_URL\n            value: \"https://api.armosec.io\"\n          - name: NodeName\n            valueFrom:\n              fieldRef:\n                fieldPath: spec.nodeName\n        securityContext:\n          runAsUser: 0\n          privileged: false\n          capabilities:\n            add:\n              - SYS_ADMIN\n              - SYS_PTRACE\n              - NET_ADMIN\n              - SYSLOG\n              - SYS_RESOURCE\n              - IPC_LOCK\n              - NET_RAW\n          seLinuxOptions:\n            type: \"{{ .SELinuxType }}\"\n        volumeMounts:\n          \n          - mountPath: /host\n            name: host\n            readOnly: true\n          - mountPath: /var/lib/kubelet\n            name: kubeletdir\n          - mountPath: /run\n            name: run\n          - mountPath: /var\n            name: var\n            readOnly: true\n          - mountPath: /lib/modules\n            name: modules\n            readOnly: true\n          - mountPath: /sys/kernel/debug\n            name: debugfs\n          - mountPath: /sys/fs/cgroup\n            name: cgroup\n            readOnly: true\n          - mountPath: /sys/fs/bpf\n            name: bpffs\n          - mountPath: /data\n            name: data\n          - mountPath: /profiles\n            name: profiles\n          - mountPath: /boot\n            name: boot\n            readOnly: true\n          - name: cloud-secret\n            mountPath: /etc/credentials\n            readOnly: true\n          - name: ks-cloud-config\n            mountPath: /etc/config/clusterData.json\n            readOnly: true\n            subPath: \"clusterData.json\"\n          - name: config\n            mountPath: /etc/config/config.json\n            readOnly: true\n            subPath: \"config.json\"\n      nodeSelector:\n        kubernetes.io/os: linux\n      {{- if not .IsDefaultGroup }}\n        {{ .NodeGroupLabelKey }}: \"{{ .NodeGroupLabel }}\"\n      {{- end }}\n      affinity:\n      {{- if .IsDefaultGroup }}\n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: {{ .NodeGroupLabelKey }}\n                operator: DoesNotExist\n      {{- else }}\n      \n        nodeAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n            nodeSelectorTerms:\n            - matchExpressions:\n              - key: kubernetes.io/os\n                operator: In\n                values:\n                - linux\n      {{- end }}\n      tolerations:\n"
     kind: ConfigMap
     metadata:
       annotations: null
@@ -13349,8 +13349,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13372,8 +13372,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -13395,8 +13395,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -13414,8 +13414,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -13441,8 +13441,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -13498,8 +13498,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13624,8 +13624,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -13683,8 +13683,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13702,8 +13702,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -13737,8 +13737,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -13752,7 +13752,7 @@ autoscaler mode without sbom sidecar:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -13953,8 +13953,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14038,8 +14038,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14123,8 +14123,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14142,8 +14142,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14198,8 +14198,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14224,8 +14224,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14253,8 +14253,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -14271,8 +14271,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -14301,8 +14301,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -14324,8 +14324,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -14343,8 +14343,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14409,8 +14409,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -14434,8 +14434,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -14479,8 +14479,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14498,8 +14498,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -14527,8 +14527,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -14623,8 +14623,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -14647,8 +14647,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -14672,8 +14672,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -14996,8 +14996,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -15025,8 +15025,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -15043,8 +15043,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15211,8 +15211,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15502,8 +15502,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15521,8 +15521,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15551,8 +15551,8 @@ autoscaler mode without sbom sidecar:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15564,7 +15564,7 @@ autoscaler mode without sbom sidecar:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -15649,8 +15649,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15692,8 +15692,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15717,8 +15717,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15745,8 +15745,8 @@ autoscaler mode without sbom sidecar:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -15764,8 +15764,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15799,8 +15799,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -15814,7 +15814,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -15934,8 +15934,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -15960,8 +15960,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -15989,8 +15989,8 @@ cert strategy initContainer, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16080,8 +16080,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16115,8 +16115,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16130,7 +16130,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -16250,8 +16250,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -16275,8 +16275,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -16300,8 +16300,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -16325,8 +16325,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -16351,8 +16351,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -16377,8 +16377,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16407,8 +16407,8 @@ cert strategy initContainer, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16574,8 +16574,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -16599,8 +16599,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -16624,8 +16624,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -16650,8 +16650,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -16676,8 +16676,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -16703,8 +16703,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -16759,8 +16759,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -16795,8 +16795,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -16810,7 +16810,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -17009,8 +17009,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -17035,8 +17035,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17064,8 +17064,8 @@ cert strategy initContainer, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17155,8 +17155,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -17180,8 +17180,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-kubescape
@@ -17205,8 +17205,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -17231,8 +17231,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -17257,8 +17257,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -17284,8 +17284,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -17340,8 +17340,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17376,8 +17376,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17391,7 +17391,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -17590,8 +17590,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -17615,8 +17615,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -17640,8 +17640,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen-kubescape
@@ -17665,8 +17665,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -17691,8 +17691,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-certgen
@@ -17717,8 +17717,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17747,8 +17747,8 @@ cert strategy initContainer, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17914,8 +17914,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -17949,8 +17949,8 @@ cert strategy template, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -17964,7 +17964,7 @@ cert strategy template, admission disabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -18084,8 +18084,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -18110,8 +18110,8 @@ cert strategy template, admission disabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18139,8 +18139,8 @@ cert strategy template, admission disabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18230,8 +18230,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18265,8 +18265,8 @@ cert strategy template, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18280,7 +18280,7 @@ cert strategy template, admission disabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -18400,8 +18400,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -18430,8 +18430,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -18453,8 +18453,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -18472,8 +18472,8 @@ cert strategy template, admission disabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18501,8 +18501,8 @@ cert strategy template, admission disabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18602,8 +18602,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -18625,8 +18625,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -18644,8 +18644,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -18671,8 +18671,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -18728,8 +18728,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18763,8 +18763,8 @@ cert strategy template, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -18778,7 +18778,7 @@ cert strategy template, admission enabled, mtls disabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -18907,8 +18907,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -18933,8 +18933,8 @@ cert strategy template, admission enabled, mtls disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -18962,8 +18962,8 @@ cert strategy template, admission enabled, mtls disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19057,8 +19057,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -19080,8 +19080,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -19099,8 +19099,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -19126,8 +19126,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -19183,8 +19183,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19218,8 +19218,8 @@ cert strategy template, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19233,7 +19233,7 @@ cert strategy template, admission enabled, mtls enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -19362,8 +19362,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -19392,8 +19392,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -19415,8 +19415,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -19434,8 +19434,8 @@ cert strategy template, admission enabled, mtls enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19463,8 +19463,8 @@ cert strategy template, admission enabled, mtls enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19550,7 +19550,7 @@ cert strategy template, admission enabled, mtls enabled:
 default capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.4.
+      Thank you for installing kubescape-operator version 1.40.5.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -19586,8 +19586,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -19634,8 +19634,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -19664,8 +19664,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19686,8 +19686,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19707,8 +19707,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -19725,8 +19725,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19755,8 +19755,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -19812,8 +19812,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -19847,8 +19847,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -19875,8 +19875,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -19895,8 +19895,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19914,9 +19914,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -19936,9 +19936,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -20002,8 +20002,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -20048,8 +20048,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20318,8 +20318,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20343,8 +20343,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20376,8 +20376,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -20530,8 +20530,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20549,8 +20549,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20615,8 +20615,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20646,8 +20646,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20672,8 +20672,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20702,8 +20702,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -20720,8 +20720,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -20753,8 +20753,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20772,9 +20772,9 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -20794,9 +20794,9 @@ default capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -20860,8 +20860,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -20906,8 +20906,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -20947,8 +20947,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -20972,8 +20972,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21002,8 +21002,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -21127,8 +21127,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -21178,8 +21178,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -21207,8 +21207,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -21594,8 +21594,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -21741,8 +21741,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -21829,8 +21829,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21848,8 +21848,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -21876,8 +21876,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -22092,8 +22092,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -22149,8 +22149,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -22871,8 +22871,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -22914,8 +22914,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -22942,8 +22942,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -22960,8 +22960,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -23086,8 +23086,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -23145,8 +23145,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23164,8 +23164,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23200,8 +23200,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -23215,7 +23215,7 @@ default capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -23416,8 +23416,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23501,8 +23501,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23520,8 +23520,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -23668,8 +23668,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -23687,8 +23687,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -23731,8 +23731,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -23757,8 +23757,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -23786,8 +23786,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -23809,8 +23809,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -23828,8 +23828,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -23858,8 +23858,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -23881,8 +23881,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -23900,8 +23900,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -23966,8 +23966,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -23991,8 +23991,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -24036,8 +24036,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24055,8 +24055,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -24084,8 +24084,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -24180,8 +24180,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -24231,8 +24231,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -24255,8 +24255,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -24280,8 +24280,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -24604,8 +24604,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -24633,8 +24633,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -24651,8 +24651,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -24819,8 +24819,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -25110,8 +25110,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25129,8 +25129,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25160,8 +25160,8 @@ default capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -25173,7 +25173,7 @@ default capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -25274,8 +25274,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -25330,8 +25330,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -25373,8 +25373,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -25398,8 +25398,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -25426,8 +25426,8 @@ default capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -25435,7 +25435,7 @@ default capabilities:
 disable otel:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.4.
+      Thank you for installing kubescape-operator version 1.40.5.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -25473,8 +25473,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -25520,8 +25520,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -25550,8 +25550,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25572,8 +25572,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25593,8 +25593,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -25613,8 +25613,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25632,9 +25632,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -25654,9 +25654,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -25721,8 +25721,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -25991,8 +25991,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -26016,8 +26016,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26048,8 +26048,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -26187,8 +26187,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26206,8 +26206,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -26237,8 +26237,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -26263,8 +26263,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -26293,8 +26293,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -26312,8 +26312,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26331,9 +26331,9 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26353,9 +26353,9 @@ disable otel:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -26420,8 +26420,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -26461,8 +26461,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -26486,8 +26486,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -26515,8 +26515,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -26625,8 +26625,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -26654,8 +26654,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -27041,8 +27041,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -27188,8 +27188,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -27276,8 +27276,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27295,8 +27295,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27322,8 +27322,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -27520,8 +27520,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -27548,8 +27548,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -27570,8 +27570,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -27593,8 +27593,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -27612,8 +27612,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -27639,8 +27639,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -27696,8 +27696,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27822,8 +27822,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -27881,8 +27881,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27900,8 +27900,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -27935,8 +27935,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -27950,7 +27950,7 @@ disable otel:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -28145,8 +28145,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28230,8 +28230,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28315,8 +28315,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28334,8 +28334,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -28378,8 +28378,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -28404,8 +28404,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -28433,8 +28433,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -28451,8 +28451,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -28481,8 +28481,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -28504,8 +28504,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -28523,8 +28523,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28589,8 +28589,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -28614,8 +28614,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -28659,8 +28659,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28678,8 +28678,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -28707,8 +28707,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -28803,8 +28803,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -28827,8 +28827,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -28852,8 +28852,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -29176,8 +29176,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -29205,8 +29205,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -29223,8 +29223,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29391,8 +29391,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29682,8 +29682,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29701,8 +29701,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -29731,8 +29731,8 @@ disable otel:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -29744,7 +29744,7 @@ disable otel:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -29829,8 +29829,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29872,8 +29872,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29897,8 +29897,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29925,8 +29925,8 @@ disable otel:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -29934,7 +29934,7 @@ disable otel:
 extra.backendStorageEnabled passthrough allows scanning capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.4.
+      Thank you for installing kubescape-operator version 1.40.5.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -29972,8 +29972,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -30019,8 +30019,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -30049,8 +30049,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30071,8 +30071,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30092,8 +30092,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -30112,8 +30112,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30131,9 +30131,9 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30153,9 +30153,9 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -30220,8 +30220,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30490,8 +30490,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30515,8 +30515,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30547,8 +30547,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -30686,8 +30686,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30705,8 +30705,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30736,8 +30736,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30762,8 +30762,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30792,8 +30792,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -30811,8 +30811,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30830,9 +30830,9 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -30852,9 +30852,9 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -30919,8 +30919,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30960,8 +30960,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -30985,8 +30985,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31014,8 +31014,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -31124,8 +31124,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -31153,8 +31153,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -31540,8 +31540,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31687,8 +31687,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -31778,8 +31778,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31797,8 +31797,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -31824,8 +31824,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -32022,8 +32022,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -32076,8 +32076,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -32798,8 +32798,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -32826,8 +32826,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -32848,8 +32848,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -32871,8 +32871,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -32890,8 +32890,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -32917,8 +32917,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -32974,8 +32974,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -33100,8 +33100,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -33159,8 +33159,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33178,8 +33178,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33213,8 +33213,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -33228,7 +33228,7 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -33423,8 +33423,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33508,8 +33508,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33593,8 +33593,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33612,8 +33612,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -33656,8 +33656,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -33682,8 +33682,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -33711,8 +33711,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -33729,8 +33729,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -33759,8 +33759,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -33782,8 +33782,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -33801,8 +33801,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -33867,8 +33867,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -33892,8 +33892,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -33937,8 +33937,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33956,8 +33956,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -33985,8 +33985,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -34081,8 +34081,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -34105,8 +34105,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -34130,8 +34130,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -34454,8 +34454,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -34483,8 +34483,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -34501,8 +34501,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -34657,8 +34657,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -34942,8 +34942,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34961,8 +34961,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -34991,8 +34991,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -35004,7 +35004,7 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -35089,8 +35089,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -35132,8 +35132,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -35157,8 +35157,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -35185,8 +35185,8 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -35194,7 +35194,7 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
 minimal capabilities:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.4.
+      Thank you for installing kubescape-operator version 1.40.5.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -35236,8 +35236,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -35283,8 +35283,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -35313,8 +35313,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35335,8 +35335,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35356,8 +35356,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -35376,8 +35376,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35395,9 +35395,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35417,9 +35417,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -35484,8 +35484,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -35754,8 +35754,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -35779,8 +35779,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35811,8 +35811,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -35946,8 +35946,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -35965,8 +35965,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -35996,8 +35996,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -36022,8 +36022,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -36052,8 +36052,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -36071,8 +36071,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36090,9 +36090,9 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36112,9 +36112,9 @@ minimal capabilities:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -36179,8 +36179,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -36220,8 +36220,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -36245,8 +36245,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -36274,8 +36274,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -36382,8 +36382,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -36411,8 +36411,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -36798,8 +36798,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -36945,8 +36945,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -37031,8 +37031,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37050,8 +37050,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37077,8 +37077,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -37276,8 +37276,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -37304,8 +37304,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -37326,8 +37326,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -37349,8 +37349,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -37368,8 +37368,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -37395,8 +37395,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -37452,8 +37452,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37578,8 +37578,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -37635,8 +37635,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37654,8 +37654,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37689,8 +37689,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -37704,7 +37704,7 @@ minimal capabilities:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -37899,8 +37899,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -37984,8 +37984,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38069,8 +38069,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38088,8 +38088,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -38132,8 +38132,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -38158,8 +38158,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -38187,8 +38187,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -38205,8 +38205,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -38235,8 +38235,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -38258,8 +38258,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -38277,8 +38277,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -38343,8 +38343,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -38368,8 +38368,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -38413,8 +38413,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38432,8 +38432,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -38461,8 +38461,8 @@ minimal capabilities:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -38557,8 +38557,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -38581,8 +38581,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -38606,8 +38606,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -38930,8 +38930,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -38959,8 +38959,8 @@ minimal capabilities:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -38968,7 +38968,7 @@ minimal capabilities:
 multiple node agents:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.4.
+      Thank you for installing kubescape-operator version 1.40.5.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -39002,8 +39002,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -39022,8 +39022,8 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
-                helm.sh/chart: kubescape-operator-1.40.4
+                app.kubernetes.io/version: 1.40.5
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -39084,8 +39084,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -39128,8 +39128,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -39153,8 +39153,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -39179,8 +39179,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -39200,8 +39200,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -39248,8 +39248,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -39278,8 +39278,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39299,8 +39299,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -39322,8 +39322,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39343,8 +39343,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -39361,9 +39361,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39383,9 +39383,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -39443,8 +39443,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39474,9 +39474,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
+            app.kubernetes.io/version: 1.40.5
             bar: baz
-            helm.sh/chart: kubescape-operator-1.40.4
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -39535,8 +39535,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -39570,8 +39570,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -39595,8 +39595,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -39620,8 +39620,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -39648,8 +39648,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -39668,8 +39668,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39687,9 +39687,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -39709,9 +39709,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -39778,8 +39778,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -39830,8 +39830,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40116,8 +40116,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40141,8 +40141,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40174,8 +40174,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -40357,8 +40357,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40376,8 +40376,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40453,8 +40453,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40484,8 +40484,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40510,8 +40510,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -40536,8 +40536,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40566,8 +40566,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -40584,8 +40584,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -40617,8 +40617,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40636,9 +40636,9 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40658,9 +40658,9 @@ multiple node agents:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -40727,8 +40727,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -40779,8 +40779,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -40853,8 +40853,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -40878,8 +40878,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -40908,8 +40908,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -41038,8 +41038,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -41095,8 +41095,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -41119,8 +41119,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -41145,8 +41145,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -41174,8 +41174,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -41561,8 +41561,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-gke-allowlist
@@ -41581,8 +41581,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -41728,8 +41728,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -41816,8 +41816,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -41835,8 +41835,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -41863,9 +41863,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
+            app.kubernetes.io/version: 1.40.5
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.4
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -42089,8 +42089,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -42117,9 +42117,9 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
+            app.kubernetes.io/version: 1.40.5
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.4
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -42343,8 +42343,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -42394,8 +42394,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -43116,8 +43116,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -43175,8 +43175,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -43201,8 +43201,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -43229,8 +43229,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -43251,8 +43251,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -43274,8 +43274,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -43293,8 +43293,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -43320,8 +43320,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -43377,8 +43377,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -43536,8 +43536,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -43595,8 +43595,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43614,8 +43614,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43650,8 +43650,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -43665,7 +43665,7 @@ multiple node agents:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -43882,8 +43882,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43970,8 +43970,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -43989,8 +43989,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -44154,8 +44154,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44173,8 +44173,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -44217,8 +44217,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -44243,8 +44243,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -44269,8 +44269,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -44298,8 +44298,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -44315,8 +44315,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44343,8 +44343,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44368,8 +44368,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44394,8 +44394,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -44479,8 +44479,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44537,8 +44537,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44565,8 +44565,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44583,8 +44583,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -44619,8 +44619,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -44638,8 +44638,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -44664,8 +44664,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -44730,8 +44730,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -44755,8 +44755,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -44797,8 +44797,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44816,8 +44816,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -44845,8 +44845,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -44938,8 +44938,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -44997,8 +44997,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -45021,8 +45021,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -45047,8 +45047,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -45072,8 +45072,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -45396,8 +45396,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -45425,8 +45425,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -45443,8 +45443,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -45680,8 +45680,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -45989,8 +45989,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46008,8 +46008,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46039,8 +46039,8 @@ multiple node agents:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -46052,7 +46052,7 @@ multiple node agents:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -46157,8 +46157,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -46224,8 +46224,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -46267,8 +46267,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -46292,8 +46292,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -46317,8 +46317,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -46345,8 +46345,8 @@ multiple node agents:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -46354,7 +46354,7 @@ multiple node agents:
 priority class scheduling:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.4.
+      Thank you for installing kubescape-operator version 1.40.5.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -46390,8 +46390,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -46437,8 +46437,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -46467,8 +46467,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46489,8 +46489,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46510,8 +46510,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -46530,8 +46530,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46549,9 +46549,9 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46571,9 +46571,9 @@ priority class scheduling:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -46639,8 +46639,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -46909,8 +46909,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -46934,8 +46934,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -46966,8 +46966,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -47106,8 +47106,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47125,8 +47125,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -47156,8 +47156,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -47182,8 +47182,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -47212,8 +47212,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -47231,8 +47231,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47250,9 +47250,9 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47272,9 +47272,9 @@ priority class scheduling:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -47340,8 +47340,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -47381,8 +47381,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -47406,8 +47406,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -47435,8 +47435,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -47546,8 +47546,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -47575,8 +47575,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -47962,8 +47962,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -48109,8 +48109,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -48197,8 +48197,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48216,8 +48216,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48243,8 +48243,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -48441,8 +48441,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -48469,8 +48469,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -48491,8 +48491,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -48514,8 +48514,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -48533,8 +48533,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -48560,8 +48560,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -48617,8 +48617,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -48743,8 +48743,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -48802,8 +48802,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48821,8 +48821,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -48856,8 +48856,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -48871,7 +48871,7 @@ priority class scheduling:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -49067,8 +49067,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49152,8 +49152,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49237,8 +49237,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49256,8 +49256,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -49300,8 +49300,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -49326,8 +49326,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -49355,8 +49355,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -49373,8 +49373,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -49403,8 +49403,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -49426,8 +49426,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -49445,8 +49445,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -49511,8 +49511,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -49536,8 +49536,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -49581,8 +49581,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49600,8 +49600,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -49629,8 +49629,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -49726,8 +49726,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -49750,8 +49750,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -49775,8 +49775,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -50099,8 +50099,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -50128,8 +50128,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -50146,8 +50146,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50314,8 +50314,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50605,8 +50605,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50624,8 +50624,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50654,8 +50654,8 @@ priority class scheduling:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -50667,7 +50667,7 @@ priority class scheduling:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -50753,8 +50753,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50796,8 +50796,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50821,8 +50821,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50849,8 +50849,8 @@ priority class scheduling:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -50858,7 +50858,7 @@ priority class scheduling:
 relevancy only:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.4.
+      Thank you for installing kubescape-operator version 1.40.5.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -50893,8 +50893,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -50940,8 +50940,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -50970,8 +50970,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -50992,8 +50992,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51013,8 +51013,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -51033,8 +51033,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51052,9 +51052,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51074,9 +51074,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -51141,8 +51141,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -51411,8 +51411,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -51436,8 +51436,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51468,8 +51468,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -51603,8 +51603,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51622,8 +51622,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -51653,8 +51653,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -51679,8 +51679,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -51709,8 +51709,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -51728,8 +51728,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51747,9 +51747,9 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51769,9 +51769,9 @@ relevancy only:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -51836,8 +51836,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -51877,8 +51877,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -51902,8 +51902,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -51931,8 +51931,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -52039,8 +52039,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -52068,8 +52068,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -52455,8 +52455,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -52602,8 +52602,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -52688,8 +52688,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52707,8 +52707,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -52734,8 +52734,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -52933,8 +52933,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -52961,8 +52961,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -52979,8 +52979,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -53105,8 +53105,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -53162,8 +53162,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53181,8 +53181,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53216,8 +53216,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -53231,7 +53231,7 @@ relevancy only:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -53417,8 +53417,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53502,8 +53502,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53587,8 +53587,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53606,8 +53606,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -53650,8 +53650,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -53676,8 +53676,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -53705,8 +53705,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -53723,8 +53723,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -53753,8 +53753,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -53776,8 +53776,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -53795,8 +53795,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -53861,8 +53861,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -53886,8 +53886,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -53931,8 +53931,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53950,8 +53950,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -53979,8 +53979,8 @@ relevancy only:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -54075,8 +54075,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -54099,8 +54099,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -54124,8 +54124,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -54448,8 +54448,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -54477,8 +54477,8 @@ relevancy only:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -54486,7 +54486,7 @@ relevancy only:
 skipPersistence enabled:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.4.
+      Thank you for installing kubescape-operator version 1.40.5.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -54520,8 +54520,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -54540,8 +54540,8 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
-                helm.sh/chart: kubescape-operator-1.40.4
+                app.kubernetes.io/version: 1.40.5
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 tier: ks-control-plane
             spec:
@@ -54602,8 +54602,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -54646,8 +54646,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -54671,8 +54671,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -54697,8 +54697,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: helm-release-upgrader
@@ -54718,8 +54718,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -54766,8 +54766,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -54796,8 +54796,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54817,8 +54817,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -54840,8 +54840,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54861,8 +54861,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -54879,9 +54879,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54901,9 +54901,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -54961,8 +54961,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -54992,9 +54992,9 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
+            app.kubernetes.io/version: 1.40.5
             bar: baz
-            helm.sh/chart: kubescape-operator-1.40.4
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -55053,8 +55053,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -55088,8 +55088,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -55113,8 +55113,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -55138,8 +55138,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -55166,8 +55166,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: grype-offline-db
@@ -55186,8 +55186,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55205,9 +55205,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55227,9 +55227,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -55296,8 +55296,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scheduler
@@ -55348,8 +55348,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -55634,8 +55634,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -55659,8 +55659,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55692,8 +55692,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -55875,8 +55875,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -55894,8 +55894,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -55971,8 +55971,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -56002,8 +56002,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -56028,8 +56028,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-scc
@@ -56054,8 +56054,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -56084,8 +56084,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -56102,8 +56102,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-monitor
@@ -56138,8 +56138,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -56157,9 +56157,9 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -56179,9 +56179,9 @@ skipPersistence enabled:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -56248,8 +56248,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scheduler
@@ -56300,8 +56300,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -56374,8 +56374,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -56399,8 +56399,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -56429,8 +56429,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -56559,8 +56559,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -56616,8 +56616,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-kubevuln
@@ -56640,8 +56640,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln-scc
@@ -56666,8 +56666,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -56695,8 +56695,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -57082,8 +57082,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-gke-allowlist
@@ -57102,8 +57102,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -57249,8 +57249,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -57337,8 +57337,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57356,8 +57356,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -57384,9 +57384,9 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
+            app.kubernetes.io/version: 1.40.5
             cloud.google.com/matching-allowlist: armo-kubescape-node-agent-1.27
-            helm.sh/chart: kubescape-operator-1.40.4
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             otel: enabled
@@ -57609,8 +57609,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: all-rules-all-pods
@@ -57660,8 +57660,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: default-rules
@@ -58382,8 +58382,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -58441,8 +58441,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent-scc
@@ -58467,8 +58467,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -58495,8 +58495,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -58517,8 +58517,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -58540,8 +58540,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -58559,8 +58559,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -58586,8 +58586,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -58643,8 +58643,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58802,8 +58802,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -58861,8 +58861,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58880,8 +58880,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -58916,8 +58916,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -58931,7 +58931,7 @@ skipPersistence enabled:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -59148,8 +59148,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -59236,8 +59236,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -59255,8 +59255,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -59420,8 +59420,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -59439,8 +59439,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -59483,8 +59483,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -59509,8 +59509,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator-scc
@@ -59535,8 +59535,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -59564,8 +59564,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -59581,8 +59581,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59609,8 +59609,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59634,8 +59634,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59660,8 +59660,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             tier: ks-control-plane
         spec:
@@ -59745,8 +59745,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59803,8 +59803,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59831,8 +59831,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59849,8 +59849,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: prometheus-exporter
@@ -59885,8 +59885,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-proxy-certificate
@@ -59904,8 +59904,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -59930,8 +59930,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -59996,8 +59996,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -60021,8 +60021,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -60063,8 +60063,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -60082,8 +60082,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -60111,8 +60111,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -60204,8 +60204,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -60263,8 +60263,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -60287,8 +60287,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -60313,8 +60313,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-scc
@@ -60338,8 +60338,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -60662,8 +60662,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -60691,8 +60691,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -60709,8 +60709,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -60946,8 +60946,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61255,8 +61255,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -61274,8 +61274,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -61305,8 +61305,8 @@ skipPersistence enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -61318,7 +61318,7 @@ skipPersistence enabled:
                 - /usr/bin/client
               env:
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -61423,8 +61423,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61490,8 +61490,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61533,8 +61533,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61558,8 +61558,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer-scc
@@ -61583,8 +61583,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61611,8 +61611,8 @@ skipPersistence enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: synchronizer
@@ -61620,7 +61620,7 @@ skipPersistence enabled:
 storage profile size caps and GOMEMLIMIT headroom:
   1: |+
     raw: |+
-      Thank you for installing kubescape-operator version 1.40.4.
+      Thank you for installing kubescape-operator version 1.40.5.
       View your cluster's configuration scanning schedule:
       > kubectl -n kubescape get cj kubescape-scheduler -o=jsonpath='{.metadata.name}{"\t"}{.spec.schedule}{"\n"}'
 
@@ -61662,8 +61662,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: credentials
         tier: ks-control-plane
@@ -61709,8 +61709,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/infra: config
         kubescape.io/tier: core
@@ -61739,8 +61739,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -61761,8 +61761,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -61782,8 +61782,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-critical
@@ -61802,8 +61802,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -61821,9 +61821,9 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: kubescape-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -61843,9 +61843,9 @@ storage profile size caps and GOMEMLIMIT headroom:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: kubescape-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -61910,8 +61910,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -62180,8 +62180,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -62205,8 +62205,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -62237,8 +62237,8 @@ storage profile size caps and GOMEMLIMIT headroom:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -62374,8 +62374,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -62393,8 +62393,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -62424,8 +62424,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -62450,8 +62450,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -62480,8 +62480,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape
@@ -62499,8 +62499,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -62518,9 +62518,9 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
+        app.kubernetes.io/version: 1.40.5
         armo.tier: vuln-scan
-        helm.sh/chart: kubescape-operator-1.40.4
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -62540,9 +62540,9 @@ storage profile size caps and GOMEMLIMIT headroom:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: kubescape-operator
                 app.kubernetes.io/part-of: kubescape
-                app.kubernetes.io/version: 1.40.4
+                app.kubernetes.io/version: 1.40.5
                 armo.tier: vuln-scan
-                helm.sh/chart: kubescape-operator-1.40.4
+                helm.sh/chart: kubescape-operator-1.40.5
                 kubescape.io/ignore: "true"
                 kubescape.io/tier: core
                 tier: ks-control-plane
@@ -62607,8 +62607,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -62648,8 +62648,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -62673,8 +62673,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -62702,8 +62702,8 @@ storage profile size caps and GOMEMLIMIT headroom:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -62810,8 +62810,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -62839,8 +62839,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubevuln
@@ -63226,8 +63226,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -63373,8 +63373,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -63460,8 +63460,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -63479,8 +63479,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -63506,8 +63506,8 @@ storage profile size caps and GOMEMLIMIT headroom:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -63702,8 +63702,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -63730,8 +63730,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: node-agent
@@ -63752,8 +63752,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-ca
@@ -63775,8 +63775,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook-tls
@@ -63794,8 +63794,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -63821,8 +63821,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-admission-webhook
@@ -63878,8 +63878,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -64004,8 +64004,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -64062,8 +64062,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -64081,8 +64081,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -64116,8 +64116,8 @@ storage profile size caps and GOMEMLIMIT headroom:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -64131,7 +64131,7 @@ storage profile size caps and GOMEMLIMIT headroom:
                     fieldRef:
                       fieldPath: spec.nodeName
                 - name: HELM_RELEASE
-                  value: kubescape-operator-1.40.4
+                  value: kubescape-operator-1.40.5
                 - name: GOMEMLIMIT
                   valueFrom:
                     resourceFieldRef:
@@ -64326,8 +64326,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -64411,8 +64411,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -64496,8 +64496,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -64515,8 +64515,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -64559,8 +64559,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -64585,8 +64585,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -64614,8 +64614,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: operator
@@ -64632,8 +64632,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: v1beta1.spdx.softwarecomposition.kubescape.io
@@ -64662,8 +64662,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls-ca
@@ -64685,8 +64685,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-tls
@@ -64704,8 +64704,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -64770,8 +64770,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage:system:auth-delegator
@@ -64795,8 +64795,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -64840,8 +64840,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -64859,8 +64859,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         kubescape.io/tier: core
         tier: ks-control-plane
@@ -64888,8 +64888,8 @@ storage profile size caps and GOMEMLIMIT headroom:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kubescape-operator
             app.kubernetes.io/part-of: kubescape
-            app.kubernetes.io/version: 1.40.4
-            helm.sh/chart: kubescape-operator-1.40.4
+            app.kubernetes.io/version: 1.40.5
+            helm.sh/chart: kubescape-operator-1.40.5
             kubescape.io/ignore: "true"
             kubescape.io/tier: core
             tier: ks-control-plane
@@ -64984,8 +64984,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-storage
@@ -65008,8 +65008,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage-auth-reader
@@ -65033,8 +65033,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: seccompprofiles.kubescape.io
@@ -65357,8 +65357,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -65386,8 +65386,8 @@ storage profile size caps and GOMEMLIMIT headroom:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: storage
@@ -65415,8 +65415,8 @@ with multiple private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets
@@ -65453,8 +65453,8 @@ with single private registry credentials:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubescape-operator
         app.kubernetes.io/part-of: kubescape
-        app.kubernetes.io/version: 1.40.4
-        helm.sh/chart: kubescape-operator-1.40.4
+        app.kubernetes.io/version: 1.40.5
+        helm.sh/chart: kubescape-operator-1.40.5
         kubescape.io/ignore: "true"
         tier: ks-control-plane
       name: kubescape-registry-scan-secrets

--- a/charts/kubescape-operator/tests/malware_capability_gate_test.yaml
+++ b/charts/kubescape-operator/tests/malware_capability_gate_test.yaml
@@ -76,25 +76,6 @@ tests:
           path: data["capabilities"]
           pattern: 'capabilities.malwareDetection=enable but capabilities.runtimeDetection is not enabled'
 
-  - it: legacy capabilities.backend-storage enables backendStorageEnabled in config.json
-    template: node-agent/configmap.yaml
-    documentIndex: 0
-    capabilities:
-      apiVersions:
-        - batch/v1
-    set:
-      unittest: true
-      clusterName: kind-kind
-      capabilities:
-        backend-storage: enable
-        runtimeDetection: enable
-      alertCRD:
-        scopeClustered: true
-    asserts:
-      - matchRegex:
-          path: data["config.json"]
-          pattern: '"backendStorageEnabled": true'
-
   - it: fails when deprecated nodeAgent.config.hostMalwareSensor is enabled
     capabilities:
       apiVersions:
@@ -139,29 +120,6 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
-
-  - it: extra.backendStorageEnabled false overrides capabilities.backend-storage enable
-    template: node-agent/configmap.yaml
-    documentIndex: 0
-    capabilities:
-      apiVersions:
-        - batch/v1
-    set:
-      unittest: true
-      clusterName: kind-kind
-      capabilities:
-        backend-storage: enable
-        runtimeDetection: enable
-      alertCRD:
-        scopeClustered: true
-      nodeAgent:
-        config:
-          extra:
-            backendStorageEnabled: false
-    asserts:
-      - notMatchRegex:
-          path: data["config.json"]
-          pattern: '"backendStorageEnabled"'
 
   - it: fails when extra.backendStorageEnabled is a string
     capabilities:


### PR DESCRIPTION
## Overview
Drops the legacy fallback to `capabilities.backend-storage: enable` in `_common.tpl`.

Following the refactoring in #884 where `nodeAgent.config.extra.backendStorageEnabled` was introduced, this PR cleans up the upstream chart by:
1. Removing the fallback `else if eq (index .Values.capabilities "backend-storage" | default "") "enable"` in the `configurations` template.
2. Cleaning up obsolete legacy unit tests in `malware_capability_gate_test.yaml`.
3. Bumping the chart version and appVersion to 1.40.5.

## How to Test
Run helm unit tests:
```bash
helm unittest charts/kubescape-operator
```

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes