### PR TITLE
fix(storage): bump storage image to v0.0.333

### DIFF
--- a/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubescape-operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -5629,7 +5629,7 @@ all capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -10213,7 +10213,7 @@ autoscaler mode with sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -14515,7 +14515,7 @@ autoscaler mode without sbom sidecar:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -15971,7 +15971,7 @@ cert strategy initContainer, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -16386,7 +16386,7 @@ cert strategy initContainer, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -17040,7 +17040,7 @@ cert strategy initContainer, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -17720,7 +17720,7 @@ cert strategy initContainer, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -18109,7 +18109,7 @@ cert strategy template, admission disabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -18468,7 +18468,7 @@ cert strategy template, admission disabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -18926,7 +18926,7 @@ cert strategy template, admission enabled, mtls disabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -19424,7 +19424,7 @@ cert strategy template, admission enabled, mtls enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -24039,7 +24039,7 @@ default capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -28653,7 +28653,7 @@ disable otel:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -33922,7 +33922,7 @@ extra.backendStorageEnabled passthrough allows scanning capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -38389,7 +38389,7 @@ minimal capabilities:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -44764,7 +44764,7 @@ multiple node agents:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -49539,7 +49539,7 @@ priority class scheduling:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -53880,7 +53880,7 @@ relevancy only:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -60003,7 +60003,7 @@ skipPersistence enabled:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -64771,7 +64771,7 @@ storage profile size caps and GOMEMLIMIT headroom:
                   value: info
                 - name: KS_LOGGER_NAME
                   value: zap
-              image: quay.io/kubescape/storage:v0.0.331
+              image: quay.io/kubescape/storage:v0.0.333
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/kubescape-operator/values.yaml
+++ b/charts/kubescape-operator/values.yaml
@@ -565,7 +565,7 @@ storage:
   image:
     # -- source code: https://github.com/kubescape/storage
     repository: quay.io/kubescape/storage
-    tag: v0.0.331
+    tag: v0.0.333
     pullPolicy: IfNotPresent
 
   nodeSelector:


### PR DESCRIPTION
## Overview

Bumps the storage image tag from `v0.0.331` to [`v0.0.333`](https://github.com/kubescape/storage/releases/tag/v0.0.333).

## Additional Information

Storage release `v0.0.333` resolves single-writer contention under concurrent load on containerprofiles by routing commit jobs across sharded worker goroutines.

Regenerated snapshot tests using `helm unittest -u charts/kubescape-operator`.

## How to Test

Run helm unit tests:
```bash
helm unittest charts/kubescape-operator
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the storage service image to version `v0.0.333`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->